### PR TITLE
Take module version from node headers.

### DIFF
--- a/crates/neon-sys/src/module.rs
+++ b/crates/neon-sys/src/module.rs
@@ -6,4 +6,7 @@ extern "system" {
     #[link_name = "NeonSys_Module_ExecKernel"]
     pub fn exec_kernel(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), exports: Local, scope: *mut c_void);
 
+    #[link_name = "NeonSys_Module_GetVersion"]
+    pub fn get_version() -> i32;
+
 }

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -250,6 +250,10 @@ extern "C" void NeonSys_Module_ExecKernel(void *kernel, NeonSys_ModuleScopeCallb
   callback(kernel, exports, scope);
 }
 
+extern "C" uint32_t NeonSys_Module_GetVersion() {
+  return NODE_MODULE_VERSION;
+}
+
 extern "C" void NeonSys_Class_ConstructBaseCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   Nan::HandleScope scope;
   v8::Local<v8::External> wrapper = v8::Local<v8::External>::Cast(info.Data());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,9 @@ macro_rules! register_module {
 
                 unsafe {
                     // Set the ABI version, which is passed in by `neon build` as an env var.
-                    __NODE_MODULE.version = env!("NEON_NODE_ABI").parse().unwrap();
+                    __NODE_MODULE.version = option_env!("NEON_NODE_ABI")
+                        .map(|s| s.parse().unwrap())
+                        .unwrap_or_else(|| $crate::macro_internal::sys::module::get_version());
 
                     node_module_register(&mut __NODE_MODULE);
                 }


### PR DESCRIPTION
If module abi version isn't specified in env, take it from the included node headers.
