### PR TITLE
Expose JS strings' UCS2 representation to rust

### DIFF
--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -177,6 +177,19 @@ extern "C" size_t NeonSys_String_Data(char *out, size_t len, v8::Local<v8::Value
   return Nan::DecodeWrite(out, len, str, Nan::UTF8);
 }
 
+extern "C" bool NeonSys_String_NewFromUCS2(v8::Local<v8::String> *out, v8::Isolate *isolate, const uint16_t *data, int32_t len) {
+  Nan::MaybeLocal<v8::String> maybe = v8::String::NewFromTwoByte(isolate, data, v8::NewStringType::kNormal, len);
+  return maybe.ToLocal(out);
+}
+
+extern "C" int32_t NeonSys_String_UCS2Length(v8::Local<v8::String> str) {
+  return str->Length();
+}
+
+extern "C" size_t NeonSys_String_UCS2Data(uint16_t *out, size_t len, v8::Local<v8::String> str) {
+  return str->Write(out, 0, -1);
+}
+
 extern "C" bool NeonSys_Convert_ToString(v8::Local<v8::String> *out, v8::Local<v8::Value> value) {
   Nan::MaybeLocal<v8::String> maybe = Nan::To<v8::String>(value);
   return maybe.ToLocal(out);

--- a/crates/neon-sys/src/string.rs
+++ b/crates/neon-sys/src/string.rs
@@ -11,4 +11,13 @@ extern "system" {
     #[link_name = "NeonSys_String_Data"]
     pub fn data(out: *mut u8, len: isize, str: Local) -> isize;
 
+    #[link_name = "NeonSys_String_NewFromUCS2"]
+    pub fn new_from_ucs2(out: &mut Local, isolate: *mut Isolate, data: *const u16, len: i32) -> bool;
+
+    #[link_name = "NeonSys_String_UCS2Length"]
+    pub fn ucs2_len(str: Local) -> isize;
+
+    #[link_name = "NeonSys_String_UCS2Data"]
+    pub fn ucs2_data(out: *mut u16, len: isize, str: Local) -> isize;
+
 }

--- a/tests/lib/strings.js
+++ b/tests/lib/strings.js
@@ -4,5 +4,6 @@ var assert = require('chai').assert;
 describe('JsString', function() {
   it('should return a JsString built in Rust', function () {
     assert.equal(addon.return_js_string(), "hello node");
+    assert.equal(addon.index_into_js_string("abc", 1), "b");
   });
 });

--- a/tests/native/src/js/strings.rs
+++ b/tests/native/src/js/strings.rs
@@ -1,6 +1,15 @@
 use neon::vm::{Call, JsResult};
-use neon::js::JsString;
+use neon::js::{JsString, JsNumber};
+use neon::mem::Handle;
 
 pub fn return_js_string(call: Call) -> JsResult<JsString> {
     Ok(JsString::new(call.scope, "hello node").unwrap())
+}
+
+pub fn index_into_js_string(call: Call) -> JsResult<JsString> {
+    let js_string = try!(try!(call.arguments.require(call.scope, 0)).check::<JsString>());
+    let js_index = try!(try!(call.arguments.require(call.scope, 1)).check::<JsNumber>());
+    let string = js_string.ucs2_value();
+    let index = js_index.value() as usize;
+    Ok(JsString::new_from_ucs2(call.scope, &string[index..index + 1]).unwrap())
 }

--- a/tests/native/src/lib.rs
+++ b/tests/native/src/lib.rs
@@ -10,7 +10,7 @@ mod js {
     pub mod classes;
 }
 
-use js::strings::return_js_string;
+use js::strings::*;
 use js::numbers::*;
 use js::arrays::*;
 use js::objects::*;
@@ -23,6 +23,7 @@ use neon::js::class::{Class, JsClass};
 
 register_module!(m, {
     try!(m.export("return_js_string", return_js_string));
+    try!(m.export("index_into_js_string", index_into_js_string));
 
     try!(m.export("return_js_number", return_js_number));
     try!(m.export("return_large_js_number", return_large_js_number));


### PR DESCRIPTION
Wow, this is an awesome library.

I'm working on a module that performs string manipulation in rust using string indices that are provided by javascript. I'd like to avoid transcoding the JS strings back and forth from UTF8 and converting UCS2 indices to UTF8 indices.

This adds the following methods on `JsString` class, analogous to the existing utf8-based methods:
- `new_from_ucs2(scope, data: &[u16])` (analogous to `new`)
- `ucs2_value() -> Vec<u16>` (analogous to `value`)
- `ucs2_size() -> isize` (analogous to `size`)

I added a test in a similar style to your existing tests.

I wasn't totally sure about the naming; V8 doesn't refer to strings internal encoding in any consistent way, so `ucs2` seemed like the most precise qualifier to use.
