### PR TITLE
Get neon building on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ homepage = "http://neon.rustbridge.io"
 repository = "https://github.com/rustbridge/neon"
 license = "MIT/Apache-2.0"
 exclude = ["neon.jpg"]
+build = "build.rs"
+
+# This name is arbitrary, but allows us to re-export the location of node.lib
+# to dependent packages so they can link on Windows.
+links = "neon-sys"
 
 [dependencies]
 cslice = { version = "=0.1.1", path = "crates/cslice" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+environment:
+  nodejs_version: "6"
+
+install:
+  # Install node
+  - ps: Install-Product node $env:nodejs_version
+
+  # Install Rust
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe -y
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cd tests
+  - npm test
+
+cache:
+  - target
+  - C:\Users\appveyor\.cargo\registry

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,16 @@
 os: Visual Studio 2015
 
 environment:
-  nodejs_version: "6"
+  NODEJS_VERSION: "6"
 
 platform:
   - x86
   - x64
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
+  - node -e "console.log(process.arch, process.versions)"
+
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe -y
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 os: Visual Studio 2015
 
-platform: x64
+platform:
+  - x64
+  - x86
 
 environment:
   NODEJS_VERSION: "6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+os: Visual Studio 2015
+
 environment:
   nodejs_version: "6"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 environment:
   nodejs_version: "6"
 
-install:
-  # Install node
-  - ps: Install-Product node $env:nodejs_version
+platform:
+  - x86
+  - x64
 
-  # Install Rust
+install:
+  - ps: Install-Product node $env:nodejs_version
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe -y
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,24 @@
 os: Visual Studio 2015
 
+platform: x64
+
 environment:
   NODEJS_VERSION: "6"
+  matrix:
+    - NODE_ARCHITECTURE: x64
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
 
-platform:
-  - x86
-  - x64
+    - NODE_ARCHITECTURE: x86
+      RUST_TOOLCHAIN: stable-i686-pc-windows-msvc
 
 install:
-  - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
+  - ps: Install-Product node $env:NODEJS_VERSION $env:NODE_ARCHITECTURE
   - node -e "console.log(process.arch, process.versions)"
 
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
-  - rustup-init.exe -y
+  - rustup-init.exe -y --default-toolchain %RUST_TOOLCHAIN%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustup show
   - rustc -V
   - cargo -V
 

--- a/build.rs
+++ b/build.rs
@@ -3,5 +3,6 @@ use std::env;
 fn main() {
     if cfg!(windows) {
         println!("cargo:node_root_dir={}", env::var("DEP_NEON_NODE_ROOT_DIR").unwrap());
+        println!("cargo:node_lib_file={}", env::var("DEP_NEON_NODE_LIB_FILE").unwrap());
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use std::env;
+
+fn main() {
+    if cfg!(windows) {
+        println!("cargo:node_root_dir={}", env::var("DEP_NEON_NODE_ROOT_DIR").unwrap());
+    }
+}

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -17,3 +17,4 @@ cslice = { version = "=0.1.1", path = "../cslice" }
 
 [build-dependencies]
 gcc = "0.3"
+regex = "0.1"

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -17,4 +17,3 @@ cslice = { version = "=0.1.1", path = "../cslice" }
 
 [build-dependencies]
 gcc = "0.3"
-regex = "0.1"

--- a/crates/neon-sys/binding.gyp
+++ b/crates/neon-sys/binding.gyp
@@ -1,7 +1,19 @@
 {
-  "targets": [{
-    "target_name": "neon",
-    "sources": [ "src/neon.cc" ],
-    "include_dirs": [ "<!(node -e \"require('nan')\")" ]
-  }]
+    "targets": [{
+        "target_name": "neon",
+        "sources": [ "src/neon.cc" ],
+        "include_dirs": [ "<!(node -e \"require('nan')\")" ],
+        'configurations': {
+            'Release': {
+                'msvs_settings': {
+                    'VCCLCompilerTool': {
+                        'WholeProgramOptimization': 'false'
+                    },
+                    'VCLinkerTool': {
+                        'LinkTimeCodeGeneration': 0
+                    }
+                }
+            }
+        }
+    }]
 }

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -48,6 +48,13 @@ fn build_object_file() {
             .expect("Couldn't find node_root_dir in node-gyp output.");
         let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find("'").unwrap() + node_root_dir_start_index;
         println!("cargo:node_root_dir={}", &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index]);
+        let node_lib_file_flag_pattern = "'-Dnode_lib_file=";
+        let node_lib_file_start_index = node_gyp_output
+            .find(node_lib_file_flag_pattern)
+            .map(|i| i + node_lib_file_flag_pattern.len())
+            .expect("Couldn't find node_lib_file in node-gyp output.");
+        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find(".lib").unwrap() + node_lib_file_start_index;
+        println!("cargo:node_lib_file={}", &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index]);
     }
 
     // Run `node-gyp build` (appending -d in debug mode).

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -1,53 +1,9 @@
 extern crate gcc;
+extern crate regex;
 
 use std::process::Command;
 use std::env;
-
-fn debug() -> bool {
-    match env::var("DEBUG") {
-        Ok(s) => s == "true",
-        Err(_) => false
-    }
-}
-
-fn mode() -> &'static str {
-    if debug() { "Debug" } else { "Release" }
-}
-
-#[cfg(unix)]
-fn object_path(libname: &str) -> String {
-    format!("build/{}/obj.target/{}/src/{}.o", mode(), libname, libname)
-}
-
-#[cfg(windows)]
-fn object_path(libname: &str) -> String {
-    format!("build\\{}\\obj\\{}\\{}.obj", mode(), libname, libname)
-}
-
-#[cfg(unix)]
-const NPM_COMMAND : &'static str = "npm";
-
-#[cfg(windows)]
-const NPM_COMMAND : &'static str = "npm.cmd";
-
-fn build_object_file() {
-    // Ensure that all package.json dependencies and dev dependencies are installed.
-    Command::new(NPM_COMMAND).args(&["install", "--silent"]).status().ok()
-        .expect(r#"failed to run "npm install" for neon-sys"#);
-
-    // Run the package.json `configure` script, which invokes `node-gyp configure` from the local node_modules.
-    Command::new(NPM_COMMAND).args(&["run", "--silent"]).arg(if debug() { "configure-debug" } else { "configure-release" }).status().ok().unwrap();
-
-    // Run the package.json `build` script, which invokes `node-gyp build` from the local node_modules.
-    Command::new(NPM_COMMAND).args(&["run", "--silent"]).arg(if debug() { "build-debug" } else { "build-release" }).status().ok().unwrap();
-}
-
-fn link_library() {
-    // Link the built object file into a static library.
-    gcc::Config::new()
-        .object(object_path("neon"))
-        .compile("libneon.a");
-}
+use regex::Regex;
 
 fn main() {
     // 1. Build the object file from source using node-gyp.
@@ -55,4 +11,55 @@ fn main() {
 
     // 2. Link the library from the object file using gcc.
     link_library();
+}
+
+fn build_object_file() {
+    let npm_command = if cfg!(unix) { "npm" } else { "npm.cmd" };
+    let node_gyp_command = if cfg!(unix) { "node-gyp" } else { "node-gyp.cmd" };
+
+    // Ensure that all package.json dependencies and dev dependencies are installed.
+    Command::new(npm_command).args(&["install", "--silent"]).status().ok().expect("Failed to run \"npm install\" for neon-sys!");
+
+    // Run `node-gyp configure` (appending -d in debug mode).
+    let configure_args = if debug() { vec!["configure", "-d"] } else { vec!["configure"] };
+    let output = Command::new(node_gyp_command)
+        .args(&configure_args)
+        .output()
+        .expect("Failed to run \"node-gyp configure\" for neon-sys!");
+
+    if cfg!(windows) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let node_root_dir = Regex::new(r"'-Dnode_root_dir=(.+)'").unwrap()
+            .captures(&stderr)
+            .and_then(|captures| captures.at(1))
+            .expect("Couldn't find node_root_dir in node-gyp output.");
+        println!("cargo:node_root_dir={}", node_root_dir);
+    }
+
+    // Run `node-gyp build` (appending -d in debug mode).
+    let build_args = if debug() { vec!["build", "-d"] } else { vec!["build"] };
+    Command::new(node_gyp_command)
+        .args(&build_args)
+        .status()
+        .ok()
+        .expect("Failed to run \"node-gyp build\" for neon-sys!");
+}
+
+// Link the built object file into a static library.
+fn link_library() {
+    let configuration = if debug() { "Debug" } else { "Release" };
+    let object_path = if cfg!(unix) {
+        format!("build/{}/obj.target/neon/src/neon.o", configuration)
+    } else {
+        format!("build\\{}\\obj\\neon\\neon.obj", configuration)
+    };
+
+    gcc::Config::new().object(object_path).compile("libneon.a");
+}
+
+fn debug() -> bool {
+    match env::var("DEBUG") {
+        Ok(s) => s == "true",
+        Err(_) => false
+    }
 }

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -32,14 +32,14 @@ const NPM_COMMAND : &'static str = "npm.cmd";
 
 fn build_object_file() {
     // Ensure that all package.json dependencies and dev dependencies are installed.
-    Command::new(NPM_COMMAND).arg("install").status().ok()
+    Command::new(NPM_COMMAND).args(&["install", "--silent"]).status().ok()
         .expect(r#"failed to run "npm install" for neon-sys"#);
 
     // Run the package.json `configure` script, which invokes `node-gyp configure` from the local node_modules.
-    Command::new(NPM_COMMAND).arg("run").arg(if debug() { "configure-debug" } else { "configure-release" }).status().ok().unwrap();
+    Command::new(NPM_COMMAND).args(&["run", "--silent"]).arg(if debug() { "configure-debug" } else { "configure-release" }).status().ok().unwrap();
 
     // Run the package.json `build` script, which invokes `node-gyp build` from the local node_modules.
-    Command::new(NPM_COMMAND).arg("run").arg(if debug() { "build-debug" } else { "build-release" }).status().ok().unwrap();
+    Command::new(NPM_COMMAND).args(&["run", "--silent"]).arg(if debug() { "build-debug" } else { "build-release" }).status().ok().unwrap();
 }
 
 fn link_library() {

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -14,7 +14,7 @@ fn mode() -> &'static str {
     if debug() { "Debug" } else { "Release" }
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn object_path(libname: &str) -> String {
     format!("build/{}/obj.target/{}/src/{}.o", mode(), libname, libname)
 }
@@ -24,16 +24,22 @@ fn object_path(libname: &str) -> String {
     format!("build\\{}\\obj\\{}\\{}.obj", mode(), libname, libname)
 }
 
+#[cfg(unix)]
+const NPM_COMMAND : &'static str = "npm";
+
+#[cfg(windows)]
+const NPM_COMMAND : &'static str = "npm.cmd";
+
 fn build_object_file() {
     // Ensure that all package.json dependencies and dev dependencies are installed.
-    Command::new("npm").arg("install").status().ok()
+    Command::new(NPM_COMMAND).arg("install").status().ok()
         .expect(r#"failed to run "npm install" for neon-sys"#);
 
     // Run the package.json `configure` script, which invokes `node-gyp configure` from the local node_modules.
-    Command::new("npm").arg("run").arg(if debug() { "configure-debug" } else { "configure-release" }).status().ok().unwrap();
+    Command::new(NPM_COMMAND).arg("run").arg(if debug() { "configure-debug" } else { "configure-release" }).status().ok().unwrap();
 
     // Run the package.json `build` script, which invokes `node-gyp build` from the local node_modules.
-    Command::new("npm").arg("run").arg(if debug() { "build-debug" } else { "build-release" }).status().ok().unwrap();
+    Command::new(NPM_COMMAND).arg("run").arg(if debug() { "build-debug" } else { "build-release" }).status().ok().unwrap();
 }
 
 fn link_library() {

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -1,7 +1,7 @@
 extern crate gcc;
 extern crate regex;
 
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::env;
 use regex::Regex;
 
@@ -39,6 +39,7 @@ fn build_object_file() {
     // Run `node-gyp build` (appending -d in debug mode).
     let build_args = if debug() { vec!["build", "-d"] } else { vec!["build"] };
     Command::new(node_gyp_command)
+        .stderr(Stdio::null()) // Prevent cargo build from hanging on Windows.
         .args(&build_args)
         .status()
         .ok()

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -20,8 +20,18 @@ fn build_object_file() {
     // Ensure that all package.json dependencies and dev dependencies are installed.
     Command::new(npm_command).args(&["install", "--silent"]).status().ok().expect("Failed to run \"npm install\" for neon-sys!");
 
-    // Run `node-gyp configure` (appending -d in debug mode).
-    let configure_args = if debug() { vec!["configure", "-d", "--arch=ia32"] } else { vec!["configure", "--arch=ia32"] };
+    // Run `node-gyp configure` with correct debug and architecture flags
+    let mut configure_args = vec!["configure"];
+    if debug() {
+        configure_args.push("--debug")
+    }
+    let target = env::var("TARGET").unwrap();
+    if target.contains("i686") || target.contains("i586") {
+        configure_args.push("--arch=ia32");
+    } else if target.contains("x86_64") {
+        configure_args.push("--arch=x64");
+    }
+
     let output = Command::new(node_gyp_command)
         .args(&configure_args)
         .output()

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -21,7 +21,7 @@ fn build_object_file() {
     Command::new(npm_command).args(&["install", "--silent"]).status().ok().expect("Failed to run \"npm install\" for neon-sys!");
 
     // Run `node-gyp configure` (appending -d in debug mode).
-    let configure_args = if debug() { vec!["configure", "-d"] } else { vec!["configure"] };
+    let configure_args = if debug() { vec!["configure", "-d", "--arch=ia32"] } else { vec!["configure", "--arch=ia32"] };
     let output = Command::new(node_gyp_command)
         .args(&configure_args)
         .output()

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -14,8 +14,14 @@ fn mode() -> &'static str {
     if debug() { "Debug" } else { "Release" }
 }
 
+#[cfg(not(windows))]
 fn object_path(libname: &str) -> String {
     format!("build/{}/obj.target/{}/src/{}.o", mode(), libname, libname)
+}
+
+#[cfg(windows)]
+fn object_path(libname: &str) -> String {
+    format!("build\\{}\\obj\\{}\\{}.obj", mode(), libname, libname)
 }
 
 fn build_object_file() {

--- a/crates/neon-sys/package.json
+++ b/crates/neon-sys/package.json
@@ -1,14 +1,10 @@
 {
   "main": "index.js",
   "scripts": {
-    "configure-release": "node-gyp configure",
-    "build-release": "node-gyp build",
-    "configure-debug": "node-gyp configure -d",
-    "build-debug": "node-gyp build -d"
+    "preinstall": "echo 'Skipping node-gyp installation as part of npm install.'"
   },
   "devDependencies": {
-    "nan": "^2.3.2",
-    "node-gyp": "^3.3.1"
+    "nan": "^2.3.2"
   },
   "dependencies": {
     "bindings": "1.2.1"

--- a/crates/neon-sys/src/array.rs
+++ b/crates/neon-sys/src/array.rs
@@ -1,6 +1,6 @@
 use raw::{Local, Isolate};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Array_New"]
     pub fn new(out: &mut Local, isolate: *mut Isolate, length: u32);

--- a/crates/neon-sys/src/buffer.rs
+++ b/crates/neon-sys/src/buffer.rs
@@ -3,7 +3,7 @@ use cslice::CMutSlice;
 
 // Suppress a spurious rustc warning about the use of CMutSlice.
 #[allow(improper_ctypes)]
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Buffer_New"]
     pub fn new(out: &mut Local, size: u32) -> bool;

--- a/crates/neon-sys/src/call.rs
+++ b/crates/neon-sys/src/call.rs
@@ -1,6 +1,6 @@
 use raw::{FunctionCallbackInfo, Isolate, Local};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Call_SetReturn"]
     pub fn set_return(info: &FunctionCallbackInfo, value: Local);

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_void;
 use raw::{Isolate, Local};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Class_GetClassMap"]
     pub fn get_class_map(isolate: *mut Isolate) -> *mut c_void;

--- a/crates/neon-sys/src/convert.rs
+++ b/crates/neon-sys/src/convert.rs
@@ -1,6 +1,6 @@
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Convert_ToObject"]
     pub fn to_object(out: &mut Local, value: &Local) -> bool;

--- a/crates/neon-sys/src/error.rs
+++ b/crates/neon-sys/src/error.rs
@@ -1,6 +1,6 @@
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Error_Throw"]
     pub fn throw(val: Local);

--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_void;
 use raw::{FunctionCallbackInfo, Local};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Fun_New"]
     pub fn new(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;

--- a/crates/neon-sys/src/mem.rs
+++ b/crates/neon-sys/src/mem.rs
@@ -1,6 +1,6 @@
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Mem_SameHandle"]
     pub fn same_handle(h1: Local, h2: Local) -> bool;

--- a/crates/neon-sys/src/module.rs
+++ b/crates/neon-sys/src/module.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_void;
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Module_ExecKernel"]
     pub fn exec_kernel(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), exports: Local, scope: *mut c_void);

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -221,7 +221,7 @@ extern "C" void NeonSys_Scope_Enter(v8::HandleScope *scope, v8::Isolate *isolate
 }
 
 extern "C" void NeonSys_Scope_Exit(v8::HandleScope *scope) {
-  scope->~HandleScope();
+  scope->HandleScope::~HandleScope();
 }
 
 extern "C" size_t NeonSys_Scope_Sizeof() {

--- a/crates/neon-sys/src/object.rs
+++ b/crates/neon-sys/src/object.rs
@@ -1,6 +1,6 @@
 use raw::{Isolate, Local};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Object_New"]
     pub fn new(out: &mut Local);

--- a/crates/neon-sys/src/primitive.rs
+++ b/crates/neon-sys/src/primitive.rs
@@ -1,6 +1,6 @@
 use raw::{Local, Isolate};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Primitive_Undefined"]
     pub fn undefined(out: &mut Local);

--- a/crates/neon-sys/src/scope.rs
+++ b/crates/neon-sys/src/scope.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_void;
 use raw::{HandleScope, EscapableHandleScope, Local};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Scope_Escape"]
     pub fn escape(out: &mut Local, scope: *mut EscapableHandleScope, value: Local);

--- a/crates/neon-sys/src/string.rs
+++ b/crates/neon-sys/src/string.rs
@@ -1,6 +1,6 @@
 use raw::{Local, Isolate};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_String_New"]
     pub fn new(out: &mut Local, isolate: *mut Isolate, data: *const u8, len: i32) -> bool;

--- a/crates/neon-sys/src/tag.rs
+++ b/crates/neon-sys/src/tag.rs
@@ -16,7 +16,7 @@ pub enum Tag {
     Other
 }
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Tag_Of"]
     pub fn of(val: Local) -> Tag;

--- a/tests/native/Cargo.toml
+++ b/tests/native/Cargo.toml
@@ -3,6 +3,7 @@ name = "tests"
 version = "0.1.0"
 authors = ["The Neon Community"]
 license = "MIT/Apache-2.0"
+build = "build.rs"
 
 [lib]
 name = "tests"

--- a/tests/native/build.rs
+++ b/tests/native/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    if cfg!(windows) {
+        let debug = env::var("DEBUG").ok().map_or(false, |s| s == "true");
+        let configuration = if debug { "Debug" } else { "Release" };
+        let node_root_dir = env::var("DEP_NEON_SYS_NODE_ROOT_DIR").unwrap();
+        println!("cargo:rustc-link-lib=node");
+        println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
+    }
+}

--- a/tests/native/build.rs
+++ b/tests/native/build.rs
@@ -5,7 +5,8 @@ fn main() {
         let debug = env::var("DEBUG").ok().map_or(false, |s| s == "true");
         let configuration = if debug { "Debug" } else { "Release" };
         let node_root_dir = env::var("DEP_NEON_SYS_NODE_ROOT_DIR").unwrap();
-        println!("cargo:rustc-link-lib=node");
+        let node_lib_file = env::var("DEP_NEON_SYS_NODE_LIB_FILE").unwrap();
         println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
+        println!("cargo:rustc-link-lib={}", node_lib_file);
     }
 }


### PR DESCRIPTION
#### Summary of changes
- The explicit destructor call in `NeonSys_Scope_Exit` was causing a linker error with MSBuild 14.0.
  
  ```
  neon.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) private: static void   __cdecl v8::HandleScope::operator delete(void *,unsigned __int64)" (__imp_??3HandleScope@v8@@CAXPEAX_K@Z) [C:\Users\Max\neon\crates\neon-sys\build\neon.vcxproj]
  C:\Users\Max\neon\crates\neon-sys\build\Release\neon.node : fatal error LNK1120: 1 unresolved externals [C:\Users\Max\neon\crates\neon-sys\build\neon.vcxproj]
  ```
  
  It looks like when MSVC compiles these types of explicit destructor calls, it emits a call to `operator delete`, even when `delete` isn't being used in the source. This causes the above linker error because `v8::HandleScope::operator delete` is private. Switching to the static method syntax seems to work around this problem.
- The `extern "system"` calling convention specifier was preventing `neon-sys` from linking correctly in 32-bit windows builds. According to Rust's [foreign calling convention docs](https://doc.rust-lang.org/book/ffi.html#foreign-calling-conventions):
  
  > ... on win32 with a x86 architecture, this [`extern "system"`] means that the abi used would be `stdcall`.
  
  I believe that since the functions defined in `neon.cc` are marked as `extern "C"`, they can always be linked into rust via the `"C"` calling convention, regardless of target.
- In the neon-sys build script, we run `npm` as `npm.cmd`, and look for the `neon.obj` file in a different folder.
- On windows, native node modules that use `neon` need to link against `node.lib`, similarly to how [C++ modules built with `node-gyp` do so](https://github.com/nodejs/node-gyp/blob/master/addon.gypi#L95). To do this, `neon-sys` needs to capture the location of `node.lib` at build time, and modules that use neon must contain a build script that supplies this location to the linker.
  
  Since this `build.rs` file must be included in _every_ module that uses neon, we've added code to generate this file as part of `neon new`: https://github.com/rustbridge/neon-cli/pull/32.
- I've added an `appveyor.yml` that tests neon on both 64 and 32-bit architectures. As you can see on our fork, [the 64 bit build passes](https://ci.appveyor.com/project/Atom/neon/build/1.0.32/job/5vqtb4nolufwgesp). Unfortunately, [the 32 bit build fails](https://ci.appveyor.com/project/Atom/neon/build/1.0.32/job/124m9unvbqqaoain) because it is using the currently-published version of `neon-cli` which does not handle building 32-bit modules on a 64-bit system. Once https://github.com/rustbridge/neon-cli/pull/32 is merged and a new `neon-cli` is published, this build will pass.
