### PR TITLE
Fix neon on new node versions, and make it work on Electron as well

### DIFF
--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -6,6 +6,9 @@ extern "system" {
     #[link_name = "NeonSys_Fun_New"]
     pub fn new(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
 
+    #[link_name = "NeonSys_Fun_Template_New"]
+    pub fn new_template(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
+
     #[link_name = "NeonSys_Fun_ExecKernel"]
     pub fn exec_kernel(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), info: &FunctionCallbackInfo, scope: *mut c_void);
 

--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -6,7 +6,7 @@ extern "system" {
     #[link_name = "NeonSys_Fun_New"]
     pub fn new(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
 
-    #[link_name = "NeonSys_Fun_Template_New"]
+    #[link_name = "NeonSys_Fun_New_Template"]
     pub fn new_template(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
 
     #[link_name = "NeonSys_Fun_ExecKernel"]

--- a/crates/neon-sys/src/module.rs
+++ b/crates/neon-sys/src/module.rs
@@ -6,4 +6,7 @@ extern "system" {
     #[link_name = "NeonSys_Module_ExecKernel"]
     pub fn exec_kernel(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), exports: Local, scope: *mut c_void);
 
+    #[link_name = "NeonSys_Module_GetVersion"]
+    pub fn get_version() -> i32;
+
 }

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -377,7 +377,7 @@ extern "C" void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj) {
   return static_cast<neon::BaseClassInstanceMetadata *>(obj->GetAlignedPointerFromInternalField(0))->GetInternals();
 }
 
-extern "C" bool NeonSys_Fun_Template_New(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel) {
+extern "C" bool NeonSys_Fun_New_Template(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel) {
   v8::Local<v8::External> wrapper = v8::External::New(isolate, kernel);
   if (wrapper.IsEmpty()) {
     return false;

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -355,7 +355,7 @@ extern "C" void NeonSys_Class_ThrowThisError(v8::Isolate *isolate, void *metadat
   Nan::ThrowTypeError(metadata->GetThisError().ToJsString(isolate, "this is not an object of the expected type."));
 }
 
-extern "C" bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata_pointer, const char *name, uint32_t byte_length, v8::Local<v8::Function> method) {
+extern "C" bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata_pointer, const char *name, uint32_t byte_length, v8::Local<v8::FunctionTemplate> method) {
   neon::ClassMetadata *metadata = static_cast<neon::ClassMetadata *>(metadata_pointer);
   v8::Local<v8::FunctionTemplate> ft = metadata->GetTemplate(isolate);
   v8::Local<v8::ObjectTemplate> pt = ft->PrototypeTemplate();
@@ -377,6 +377,15 @@ extern "C" void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj) {
   return static_cast<neon::BaseClassInstanceMetadata *>(obj->GetAlignedPointerFromInternalField(0))->GetInternals();
 }
 
+extern "C" bool NeonSys_Fun_Template_New(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel) {
+  v8::Local<v8::External> wrapper = v8::External::New(isolate, kernel);
+  if (wrapper.IsEmpty()) {
+    return false;
+  }
+
+  v8::MaybeLocal<v8::FunctionTemplate> maybe_result = v8::FunctionTemplate::New(isolate, callback, wrapper);
+  return maybe_result.ToLocal(out);
+}
 
 extern "C" bool NeonSys_Fun_New(v8::Local<v8::Function> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel) {
   v8::Local<v8::External> wrapper = v8::External::New(isolate, kernel);

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -250,6 +250,10 @@ extern "C" void NeonSys_Module_ExecKernel(void *kernel, NeonSys_ModuleScopeCallb
   callback(kernel, exports, scope);
 }
 
+extern "C" uint32_t NeonSys_Module_GetVersion() {
+  return NODE_MODULE_VERSION;
+}
+
 extern "C" void NeonSys_Class_ConstructBaseCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   Nan::HandleScope scope;
   v8::Local<v8::External> wrapper = v8::Local<v8::External>::Cast(info.Data());

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -115,7 +115,7 @@ extern "C" {
   bool NeonSys_Class_HasInstance(void *metadata, v8::Local<v8::Value> v);
   bool NeonSys_Class_SetName(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length);
   void NeonSys_Class_ThrowThisError(v8::Isolate *isolate, void *metadata_pointer);
-  bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length, v8::Local<v8::Function> method);
+  bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length, v8::Local<v8::FunctionTemplate> method);
   void NeonSys_Class_MetadataToClass(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, void *metadata);
   void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj);
 

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -274,9 +274,9 @@ pub trait ClassInternal: Class {
             }
 
             for (name, method) in descriptor.methods {
-                let method: Handle<JsFunction> = try!(build(|out| {
+                let method: Handle<JsValue> = try!(build(|out| {
                     let (method_callback, method_kernel) = method.export();
-                    neon_sys::fun::new(out, isolate, method_callback, method_kernel)
+                    neon_sys::fun::new_template(out, isolate, method_callback, method_kernel)
                 }));
                 if !neon_sys::class::add_method(isolate, metadata_pointer, name.as_ptr(), name.len() as u32, method.to_raw()) {
                     return Err(Throw);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,9 @@ macro_rules! register_module {
 
                 unsafe {
                     // Set the ABI version, which is passed in by `neon build` as an env var.
-                    __NODE_MODULE.version = env!("NEON_NODE_ABI").parse().unwrap();
+                    __NODE_MODULE.version = option_env!("NEON_NODE_ABI")
+                        .map(|s| s.parse().unwrap())
+                        .unwrap_or_else(|| $crate::macro_internal::sys::module::get_version());
 
                     node_module_register(&mut __NODE_MODULE);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,8 @@ macro_rules! register_module {
                 }
 
                 unsafe {
-                    // Set the ABI version, which is passed in by `neon build` as an env var.
-                    __NODE_MODULE.version = option_env!("NEON_NODE_ABI")
-                        .map(|s| s.parse().unwrap())
-                        .unwrap_or_else(|| $crate::macro_internal::sys::module::get_version());
-
+                    // Set the ABI version based on the NODE_MODULE_VERSION constant provided by the current node headers.
+                    __NODE_MODULE.version = $crate::macro_internal::sys::module::get_version();
                     node_module_register(&mut __NODE_MODULE);
                 }
             }


### PR DESCRIPTION
This pull request changes neon so that it works on newer node versions. In addition, this pull request will enable using neon from Electron applications as well. ✨ It does so by:
1. Using the `NODE_MODULE_VERSION` constant assigned by node-gyp to set the ABI version during `register_module!`. Using an environment variable should be unnecessary, as node-gyp already takes care of all the work to figure out the modules version for the current node instance. 
2. Fixing rustbridge/neon#119, which was causing hard crashes on Node >= 6.3.0. In particular, using `Function` to add methods to a class prototype is now deprecated, and therefore we have changed neon to use `FunctionTemplate`s instead.

@dherman: what do you think? 💭
