### PR TITLE
Allow JS class instances to be created in Rust

### DIFF
--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -31,6 +31,9 @@ extern "system" {
     #[link_name = "NeonSys_Class_MetadataToClass"]
     pub fn metadata_to_class(out: &mut Local, isolate: *mut Isolate, metadata: *mut c_void);
 
+    #[link_name = "NeonSys_Class_MetadataToInstance"]
+    pub fn metadata_to_instance(out: &mut Local, isolate: *mut Isolate, metadata: *mut c_void, internals: *mut c_void);
+
     #[link_name = "NeonSys_Class_GetAllocateKernel"]
     pub fn get_allocate_kernel(obj: Local) -> *mut c_void;
 

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -369,6 +369,12 @@ extern "C" void NeonSys_Class_MetadataToClass(v8::Local<v8::FunctionTemplate> *o
   *out = static_cast<neon::ClassMetadata *>(metadata)->GetTemplate(isolate);
 }
 
+extern "C" void NeonSys_Class_MetadataToInstance(v8::Local<v8::Object> *out, v8::Isolate *isolate, void *metadata_pointer, void *internals) {
+  neon::BaseClassMetadata *metadata = static_cast<neon::BaseClassMetadata *>(metadata_pointer);
+  v8::Local<v8::Object> object = metadata->BuildInstance(isolate, internals);
+  *out = object;
+}
+
 extern "C" void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj) {
   return static_cast<neon::BaseClassInstanceMetadata *>(obj->GetAlignedPointerFromInternalField(0))->GetInternals();
 }

--- a/crates/neon-sys/src/neon_class_metadata.h
+++ b/crates/neon-sys/src/neon_class_metadata.h
@@ -202,6 +202,13 @@ public:
     }
   }
 
+  virtual v8::Local<v8::Object> BuildInstance(v8::Isolate *isolate, void *internals) {
+    v8::Local<v8::Object> object = GetTemplate(isolate)->InstanceTemplate()->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
+    BaseClassInstanceMetadata *instance = new BaseClassInstanceMetadata(isolate, object, internals, drop_instance_);
+    object->SetAlignedPointerInInternalField(0, instance);
+    return object;
+  }
+
 private:
 
   NeonSys_AllocateCallback allocate_callback_;

--- a/tests/lib/classes.js
+++ b/tests/lib/classes.js
@@ -20,4 +20,12 @@ describe('JsClass', function() {
     assert.equal(u.get('email'), "else");
     assert.throw(function() { u.get('not_a_field') }, TypeError);
   });
+
+  it('can build class instances directly in Rust', function () {
+    u = addon.construct_js_class_instance();
+    assert.equal(u.get('id'), 1);
+    assert.equal(u.get('first_name'), "Jane");
+    assert.equal(u.get('last_name'), "Doe");
+    assert.equal(u.get('email'), "jane@doe.gov");
+  })
 });

--- a/tests/native/src/js/classes.rs
+++ b/tests/native/src/js/classes.rs
@@ -56,3 +56,12 @@ declare_types! {
     }
   }
 }
+
+pub fn construct_js_class_instance(call: Call) -> JsResult<JsObject> {
+    JsUser::new(call.scope, User {
+        id: 1,
+        first_name: String::from("Jane"),
+        last_name: String::from("Doe"),
+        email: String::from("jane@doe.gov")
+    })
+}

--- a/tests/native/src/lib.rs
+++ b/tests/native/src/lib.rs
@@ -52,5 +52,7 @@ register_module!(m, {
     let constructor: Handle<JsFunction<JsUser>> = try!(class.constructor(m.scope));
     try!(m.exports.set("User", constructor));
 
+    try!(m.export("construct_js_class_instance", construct_js_class_instance));
+
     Ok(())
 });


### PR DESCRIPTION
Previously, you could only create instances of Rust classes via JS. This PR adds a static `::new` method to every declared JS class on the Rust side. This method  takes a scope and a raw backing struct and creates an instance of the JS class wrapping the struct without running the constructor code defined in `init`.

/cc @maxbrunsfeld @as-cii
