### PR TITLE
Use FunctionTemplate instead of Function for adding methods to a class

### DIFF
--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -10,6 +10,11 @@ extern "system" {
     #[link_name = "NeonSys_Fun_New"]
     pub fn new(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
 
+    /// Mutates the `out` argument provided to refer to a newly created `v8::FunctionTemplate`.
+    /// Returns `false` if the value couldn't be created.
+    #[link_name = "NeonSys_Fun_Template_New"]
+    pub fn new_template(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
+
     /// Creates a new `v8::HandleScope` and calls the `callback` provided with the the argument
     /// signature `(info, kernel, scope)`.
     #[link_name = "NeonSys_Fun_ExecKernel"]

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -351,7 +351,7 @@ extern "C" void NeonSys_Class_ThrowThisError(v8::Isolate *isolate, void *metadat
   Nan::ThrowTypeError(metadata->GetThisError().ToJsString(isolate, "this is not an object of the expected type."));
 }
 
-extern "C" bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata_pointer, const char *name, uint32_t byte_length, v8::Local<v8::Function> method) {
+extern "C" bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata_pointer, const char *name, uint32_t byte_length, v8::Local<v8::FunctionTemplate> method) {
   neon::ClassMetadata *metadata = static_cast<neon::ClassMetadata *>(metadata_pointer);
   v8::Local<v8::FunctionTemplate> ft = metadata->GetTemplate(isolate);
   v8::Local<v8::ObjectTemplate> pt = ft->PrototypeTemplate();
@@ -373,6 +373,15 @@ extern "C" void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj) {
   return static_cast<neon::BaseClassInstanceMetadata *>(obj->GetAlignedPointerFromInternalField(0))->GetInternals();
 }
 
+extern "C" bool NeonSys_Fun_Template_New(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel) {
+  v8::Local<v8::External> wrapper = v8::External::New(isolate, kernel);
+  if (wrapper.IsEmpty()) {
+    return false;
+  }
+
+  v8::MaybeLocal<v8::FunctionTemplate> maybe_result = v8::FunctionTemplate::New(isolate, callback, wrapper);
+  return maybe_result.ToLocal(out);
+}
 
 extern "C" bool NeonSys_Fun_New(v8::Local<v8::Function> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel) {
   v8::Local<v8::External> wrapper = v8::External::New(isolate, kernel);

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -115,7 +115,7 @@ extern "C" {
   bool NeonSys_Class_HasInstance(void *metadata, v8::Local<v8::Value> v);
   bool NeonSys_Class_SetName(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length);
   void NeonSys_Class_ThrowThisError(v8::Isolate *isolate, void *metadata_pointer);
-  bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length, v8::Local<v8::Function> method);
+  bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length, v8::Local<v8::FunctionTemplate> method);
   void NeonSys_Class_MetadataToClass(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, void *metadata);
   void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj);
 

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -274,9 +274,9 @@ pub trait ClassInternal: Class {
             }
 
             for (name, method) in descriptor.methods {
-                let method: Handle<JsFunction> = try!(build(|out| {
+                let method: Handle<JsValue> = try!(build(|out| {
                     let (method_callback, method_kernel) = method.export();
-                    neon_sys::fun::new(out, isolate, method_callback, method_kernel)
+                    neon_sys::fun::new_template(out, isolate, method_callback, method_kernel)
                 }));
                 if !neon_sys::class::add_method(isolate, metadata_pointer, name.as_ptr(), name.len() as u32, method.to_raw()) {
                     return Err(Throw);


### PR DESCRIPTION
This is the commit from #123 that resolves #119. I fixed a minor merge conflict with master and added a doc comment for the `fun::new_template` function.

I also looked at the possibility of using `Nan::SetMethod` but it didn't seem like the right solution in this case.

I tested this on linux with node 4, 6, and 7.