### PR TITLE
Consistent calling convention

### DIFF
--- a/crates/neon-sys/src/array.rs
+++ b/crates/neon-sys/src/array.rs
@@ -2,7 +2,7 @@
 
 use raw::{Local, Isolate};
 
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to a newly created `v8::Array`.
     #[link_name = "NeonSys_Array_New"]

--- a/crates/neon-sys/src/buffer.rs
+++ b/crates/neon-sys/src/buffer.rs
@@ -5,7 +5,7 @@ use cslice::CMutSlice;
 
 // Suppress a spurious rustc warning about the use of CMutSlice.
 #[allow(improper_ctypes)]
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to a newly created `node::Buffer` object.
     /// Returns `false` if the value couldn't be created.

--- a/crates/neon-sys/src/call.rs
+++ b/crates/neon-sys/src/call.rs
@@ -2,7 +2,7 @@
 
 use raw::{FunctionCallbackInfo, Isolate, Local};
 
-extern "system" {
+extern "C" {
 
     /// Sets the return value of the function call.
     #[link_name = "NeonSys_Call_SetReturn"]

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_void;
 use raw::{Isolate, Local};
 
-extern "system" {
+extern "C" {
 
     #[link_name = "NeonSys_Class_GetClassMap"]
     pub fn get_class_map(isolate: *mut Isolate) -> *mut c_void;

--- a/crates/neon-sys/src/convert.rs
+++ b/crates/neon-sys/src/convert.rs
@@ -2,7 +2,7 @@
 
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     /// Casts the value provided to a `v8::Object` and mutates the `out` argument provided to refer
     /// to `v8::Local` handle of the converted value. Returns `false` if the conversion didn't

--- a/crates/neon-sys/src/error.rs
+++ b/crates/neon-sys/src/error.rs
@@ -2,7 +2,7 @@
 
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     /// Throws an `Error` object in the current context.
     #[link_name = "NeonSys_Error_Throw"]

--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -3,7 +3,7 @@
 use std::os::raw::c_void;
 use raw::{FunctionCallbackInfo, Local};
 
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to a newly created `v8::Function`. Returns
     /// `false` if the value couldn't be created.

--- a/crates/neon-sys/src/mem.rs
+++ b/crates/neon-sys/src/mem.rs
@@ -1,7 +1,7 @@
 //! A helper function for comparing `v8::Local` handles.
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     /// Indicates if two `v8::Local` handles are the same.
     #[link_name = "NeonSys_Mem_SameHandle"]

--- a/crates/neon-sys/src/module.rs
+++ b/crates/neon-sys/src/module.rs
@@ -3,7 +3,7 @@
 use std::os::raw::c_void;
 use raw::Local;
 
-extern "system" {
+extern "C" {
 
     /// Creates a new `v8::HandleScope` and calls `callback` provided with the argument signature
     /// `(kernal, exports, scope)`.

--- a/crates/neon-sys/src/object.rs
+++ b/crates/neon-sys/src/object.rs
@@ -2,7 +2,7 @@
 
 use raw::{Isolate, Local};
 
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to a newly created `v8::Object`.
     #[link_name = "NeonSys_Object_New"]

--- a/crates/neon-sys/src/primitive.rs
+++ b/crates/neon-sys/src/primitive.rs
@@ -2,7 +2,7 @@
 
 use raw::{Local, Isolate};
 
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to the `v8::Undefined` object.
     #[link_name = "NeonSys_Primitive_Undefined"]

--- a/crates/neon-sys/src/scope.rs
+++ b/crates/neon-sys/src/scope.rs
@@ -3,7 +3,7 @@
 use std::os::raw::c_void;
 use raw::{HandleScope, EscapableHandleScope, Local};
 
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to the newly escaped `v8::Local` value.
     #[link_name = "NeonSys_Scope_Escape"]

--- a/crates/neon-sys/src/string.rs
+++ b/crates/neon-sys/src/string.rs
@@ -2,7 +2,7 @@
 
 use raw::{Local, Isolate};
 
-extern "system" {
+extern "C" {
 
     /// Mutates the `out` argument provided to refer to a newly created `v8::String`. Returns
     /// `false` if the value couldn't be created.

--- a/crates/neon-sys/src/tag.rs
+++ b/crates/neon-sys/src/tag.rs
@@ -18,7 +18,7 @@ pub enum Tag {
     Other
 }
 
-extern "system" {
+extern "C" {
 
     /// Returns the `Tag` of the value provided.
     #[link_name = "NeonSys_Tag_Of"]


### PR DESCRIPTION
Consistently use the "C" calling convention for neon-sys.

(This PR was separated out from #122.)