### PR TITLE
Eliminate ABI environment variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,8 @@ macro_rules! register_module {
                 }
 
                 unsafe {
-                    // Set the ABI version, which is passed in by `neon build` as an env var.
-                    __NODE_MODULE.version = option_env!("NEON_NODE_ABI")
-                        .map(|s| s.parse().unwrap())
-                        .unwrap_or_else(|| $crate::macro_internal::sys::module::get_version());
-
+                    // Set the ABI version based on the NODE_MODULE_VERSION constant provided by the current node headers.
+                    __NODE_MODULE.version = $crate::macro_internal::sys::module::get_version();
                     node_module_register(&mut __NODE_MODULE);
                 }
             }


### PR DESCRIPTION
This brings in the commit that eliminates the ABI environment variable entirely, as discussed in the thread in #123.