### PR TITLE
Update the travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,13 @@ dist: trusty
 rust:
   - stable
   - beta
-  - nightly-2016-04-29
   - nightly
 
 env:
   matrix:
+    - TRAVIS_NODE_VERSION="4"
     - TRAVIS_NODE_VERSION="6"
-    - TRAVIS_NODE_VERSION="5"
-    - TRAVIS_NODE_VERSION="5.11"
-    - TRAVIS_NODE_VERSION="4.2"
+    - TRAVIS_NODE_VERSION="7"
   global:
   - secure: WmqMxkn6Wdtips/1a4nQlknDRvjudIsw1EWzYWiYdsKFwy6HSfiSU4R/SYI6jHkWsFkDUFyVEbN2EqGQGAQXfh/GC7h1xlAR13yGMeXku/avSgYBZtDuNoHqxulWF2nmD4JAnR5Tps6g+PPO8tr192PALQ1VPI5BnQuO7XNvDQH7mf6Sd51w6coJttvxQog6RrnmUWYLhqqYOB9CEfdRaXkka5V+Sgm7AY5vF44Ico9sSHDHhqvrzbh+RFboJID2oIoS/7uwxWEWMTJWf9mPMY7BDUREI/wlQFwnU4kvTC0im+c1XlnY5Dib7SsRx+EJFJJoZobMlzZMJLtzGcIfLQIw7c+DtTUhWGakGlCN6cfz7huk9SzBAHl24pOxW0MJjgZ2TEcb2udcocQOpy/KNlneR3OZgH/N2X08QhzXorU3llZnnO85lsU4pd4Aeux5sSCFTSDX5mkopBYhaViIJkJ48+alSjkbAXTV//z/HqTfSzaUVd/8E/7MsF+7cTf2HB7iK+Vjs/ZDzjnqcoK6xxXO037o0FOZCYKcxT+7MuAMBMq/SzZSF1DptoHn6/wTtuyHdhHVfAmbpEazK5fimhN78WtzY5f10crWAZ5jj9cVFqRFkQhfxZY9yIhrcfYni2AC882FyZEfFnkcpzE50OrKsgbHtGyQ8cusSS4TloI=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
   global:
   - secure: WmqMxkn6Wdtips/1a4nQlknDRvjudIsw1EWzYWiYdsKFwy6HSfiSU4R/SYI6jHkWsFkDUFyVEbN2EqGQGAQXfh/GC7h1xlAR13yGMeXku/avSgYBZtDuNoHqxulWF2nmD4JAnR5Tps6g+PPO8tr192PALQ1VPI5BnQuO7XNvDQH7mf6Sd51w6coJttvxQog6RrnmUWYLhqqYOB9CEfdRaXkka5V+Sgm7AY5vF44Ico9sSHDHhqvrzbh+RFboJID2oIoS/7uwxWEWMTJWf9mPMY7BDUREI/wlQFwnU4kvTC0im+c1XlnY5Dib7SsRx+EJFJJoZobMlzZMJLtzGcIfLQIw7c+DtTUhWGakGlCN6cfz7huk9SzBAHl24pOxW0MJjgZ2TEcb2udcocQOpy/KNlneR3OZgH/N2X08QhzXorU3llZnnO85lsU4pd4Aeux5sSCFTSDX5mkopBYhaViIJkJ48+alSjkbAXTV//z/HqTfSzaUVd/8E/7MsF+7cTf2HB7iK+Vjs/ZDzjnqcoK6xxXO037o0FOZCYKcxT+7MuAMBMq/SzZSF1DptoHn6/wTtuyHdhHVfAmbpEazK5fimhN78WtzY5f10crWAZ5jj9cVFqRFkQhfxZY9yIhrcfYni2AC882FyZEfFnkcpzE50OrKsgbHtGyQ8cusSS4TloI=
 
-install:
-  - . $HOME/.nvm/nvm.sh
+before_install:
+  - source $HOME/.nvm/nvm.sh
   - nvm install ${TRAVIS_NODE_VERSION}
   - nvm use ${TRAVIS_NODE_VERSION}
 
@@ -37,11 +37,6 @@ addons:
 matrix:
   allow_failures:
     - rust: nightly
-
-before_install:
-  - source $HOME/.nvm/nvm.sh
-  - nvm install stable
-  - nvm use stable
 
 script:
 - |

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Although Neon is only tested on the latest stable Rust, it will likely work on a
 
 Support for [LTS versions of Node](https://github.com/nodejs/LTS#lts-schedule) and current are expected. If you're using a differnt version of Node and believe it should be supported, let us know.
 
-* [Download Node](http://nodejs.org)
-* [Download Rust](http://rust-lang.org)
+* [Download Node](https://nodejs.org)
+* [Download Rust](https://www.rust-lang.org)
 
 # A Taste...
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Windows support is on the way. Follow [#122](https://github.com/neon-bindings/ne
 | Rust beta    | x      | x      | x      |
 | Rust nightly |        |        |        |
 
-Support for Rust stable and beta are expected. We do run builds against nightly, but allow them to fail.
+Although Neon is only tested on the latest stable Rust, it will likely work on a range of stable versions of Rust. It is known to require at least Rust 1.13.
 
 Support for [LTS versions of Node](https://github.com/nodejs/LTS#lts-schedule) and current are expected. If you're using a differnt version of Node and believe it should be supported, let us know.
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,33 @@ This will ask you a few questions and then generate a project skeleton for you. 
 
 # Requirements
 
-You'll need the following on all OSes:
+### Operating Systems
 
-* [Node](http://nodejs.org) v4 or later;
-* [Rust](http://rust-lang.org) v1.7 or later;
-* [multirust](https://github.com/brson/multirust) (only required for Neon projects that override the system default Rust).
+| Linux  | macOS | Windows |
+| ------ | ----- | ------- |
+| x      | x     | soon    |
 
-For Mac OS X, you'll need:
+For macOS, you'll need:
 
 * OS X 10.7 or later;
 * [XCode](https://developer.apple.com/xcode/download/).
+
+Windows support is on the way. Follow [#122](https://github.com/neon-bindings/neon/pull/122#issuecomment-268957333) to track the progress.
+
+### Rust and Node
+
+|              | Node 4 | Node 6 | Node 7 |
+| ------------ | ------ | ------ | ------ |
+| Rust stable  | x      | x      | x      |
+| Rust beta    | x      | x      | x      |
+| Rust nightly |        |        |        |
+
+Support for Rust stable and beta are expected. We do run builds against nightly, but allow them to fail.
+
+Support for [LTS versions of Node](https://github.com/nodejs/LTS#lts-schedule) and current are expected. If you're using a differnt version of Node and believe it should be supported, let us know.
+
+* [Download Node](http://nodejs.org)
+* [Download Rust](http://rust-lang.org)
 
 # A Taste...
 


### PR DESCRIPTION
This resolves #149.

👍 Looks like builds are faster. If we could remove `sudo: true` one day, we'd be able to use Travis' container-based infrastructure, and save more time.