### PR TITLE
add badge for appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <img align="right" src="neon.jpg" alt="neon"/>
 
-[![Build Status](https://travis-ci.org/neon-bindings/neon.svg?branch=master)](https://travis-ci.org/neon-bindings/neon)
+[![Travis Build Status](https://travis-ci.org/neon-bindings/neon.svg?branch=master)](https://travis-ci.org/neon-bindings/neon)
+![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/neon-bindings/neon?branch=master&svg=true)]
+
 [![](http://meritbadge.herokuapp.com/neon)](https://crates.io/crates/neon)
 
 A safe Rust abstraction layer for native Node.js modules.


### PR DESCRIPTION
This PR adds the Appveyor badge to the README. However I didn't include a link to the build history (like we do for Travis) because the URL is tied to my `jedireza` Appveyor account:

https://ci.appveyor.com/project/jedireza/neon

I'd like to contact them first and see if we can make the URL:

https://ci.appveyor.com/project/neon-bindings/neon

UPDATE: I just noticed that the "Details" link for Appveyor below links to Dave's `dherman` URL. 😆 