### PR TITLE
Run node-gyp by finding the node-gyp.js in the node installation…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,8 @@ environment:
 
 install:
   - ps: Install-Product node $env:NODEJS_VERSION $env:NODE_ARCHITECTURE
-  - node -e "console.log(process.arch, process.versions)"
+  - npm config set msvs_version 2015
+  - node -e "console.log(process.argv[0], process.arch, process.versions)"
 
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe -y --default-toolchain %RUST_TOOLCHAIN%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ platform:
 
 environment:
   NODEJS_VERSION: "6"
+  RUST_BACKTRACE: 1
   matrix:
     - NODE_ARCHITECTURE: x64
       RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc


### PR DESCRIPTION
…instead of expecting node-gyp{.cmd} to be in the PATH. It's unclear when
the executable is installed, but it might only be when you've installed
node-gyp via `npm install -g`. This goes partway towards addressing
issue #179.