### PR TITLE
Allow any type in `declare_types`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,11 +230,11 @@ macro_rules! impl_managed {
 /// ```
 #[macro_export]
 macro_rules! declare_types {
-    { $(#[$attr:meta])* pub class $cls:ident for $typ:ident { $($body:tt)* } $($rest:tt)* } => {
+    { $(#[$attr:meta])* pub class $cls:ident for $typ:ty { $($body:tt)* } $($rest:tt)* } => {
         declare_types! { $(#[$attr])* pub class $cls as $typ for $typ { $($body)* } $($rest)* }
     };
 
-    { $(#[$attr:meta])* class $cls:ident for $typ:ident { $($body:tt)* } $($rest:tt)* } => {
+    { $(#[$attr:meta])* class $cls:ident for $typ:ty { $($body:tt)* } $($rest:tt)* } => {
         declare_types! { $(#[$attr])* class $cls as $typ for $typ { $($body)* } $($rest)* }
     };
 


### PR DESCRIPTION
Closes https://github.com/neon-bindings/neon/issues/168, https://github.com/neon-bindings/neon/issues/167, https://github.com/neon-bindings/neon/issues/207. This appears to be an oversight, as using the `as $name` form does allow any type.