### PR TITLE
Windows Compilation Fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,23 @@
 os: Visual Studio 2015
 
-platform:
-  - x64
-  - x86
-
 environment:
-  NODEJS_VERSION: "6"
   RUST_BACKTRACE: 1
   matrix:
-    - NODE_ARCHITECTURE: x64
+    - PLATFORM: x64
+      NODEJS_VERSION: "6"
       RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-
-    - NODE_ARCHITECTURE: x86
+    - PLATFORM: x86
+      NODEJS_VERSION: "6"
+      RUST_TOOLCHAIN: stable-i686-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "8"
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
+    - PLATFORM: x86
+      NODEJS_VERSION: "8"
       RUST_TOOLCHAIN: stable-i686-pc-windows-msvc
 
 install:
-  - ps: Install-Product node $env:NODEJS_VERSION $env:NODE_ARCHITECTURE
+  - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
   - npm config set msvs_version 2015
   - node -e "console.log(process.argv[0], process.arch, process.versions)"
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use std::env;
 fn main() {
     if cfg!(windows) {
         println!("cargo:node_root_dir={}", env::var("DEP_NEON_NODE_ROOT_DIR").unwrap());
+        println!("cargo:node_arch={}", env::var("DEP_NEON_NODE_ARCH").unwrap());
         println!("cargo:node_lib_file={}", env::var("DEP_NEON_NODE_LIB_FILE").unwrap());
     }
 }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -8,9 +8,12 @@ pub fn setup() {
         let configuration = if debug { "Debug" } else { "Release" };
         let node_root_dir = env::var("DEP_NEON_RUNTIME_NODE_ROOT_DIR").unwrap();
         let node_lib_file = env::var("DEP_NEON_RUNTIME_NODE_LIB_FILE").unwrap();
-        let node_lib_path = Path::new(&node_lib_file);
+        let node_arch = env::var("DEP_NEON_RUNTIME_NODE_ARCH").unwrap();
+        let node_lib_file_path = Path::new(&node_lib_file);
+        let mut node_lib_path = Path::new(&node_root_dir).to_path_buf();
+        node_lib_path.push(&node_arch);
         println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
-        println!("cargo:rustc-link-search=native={}", &node_lib_path.parent().unwrap().display());
-        println!("cargo:rustc-link-lib={}", &node_lib_path.file_stem().unwrap().to_str().unwrap());
+        println!("cargo:rustc-link-search=native={}", &node_lib_path.display());
+        println!("cargo:rustc-link-lib={}", &node_lib_file_path.file_stem().unwrap().to_str().unwrap());
     }
 }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 
 /// Set up the build environment by setting Cargo configuration variables.
 pub fn setup() {
@@ -7,7 +8,9 @@ pub fn setup() {
         let configuration = if debug { "Debug" } else { "Release" };
         let node_root_dir = env::var("DEP_NEON_RUNTIME_NODE_ROOT_DIR").unwrap();
         let node_lib_file = env::var("DEP_NEON_RUNTIME_NODE_LIB_FILE").unwrap();
+        let node_lib_path = Path::new(&node_lib_file);
         println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
-        println!("cargo:rustc-link-lib={}", node_lib_file);
+        println!("cargo:rustc-link-search=native={}", &node_lib_path.parent().unwrap().display());
+        println!("cargo:rustc-link-lib={}", &node_lib_path.file_stem().unwrap().to_str().unwrap());
     }
 }

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -17,3 +17,4 @@ cslice = "0.2"
 
 [build-dependencies]
 gcc = "0.3"
+regex = "0.2"

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -49,6 +49,7 @@ fn build_object_file() {
         let node_gyp_output = String::from_utf8_lossy(&output.stderr);
         let version_regex = Regex::new(r"node@(?P<version>\d+\.\d+\.\d+)\s+\|\s+(?P<platform>\w+)\s+\|\s(?P<arch>ia32|x64)").unwrap();
         let captures = version_regex.captures(&node_gyp_output).unwrap();
+        println!("cargo:node_arch={}", &captures["arch"]);
         let node_root_dir_flag_pattern = "'-Dnode_root_dir=";
         let node_root_dir_start_index = node_gyp_output
             .find(node_root_dir_flag_pattern)
@@ -62,7 +63,7 @@ fn build_object_file() {
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
         let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
-        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index].replace("<(target_arch)", &captures["arch"]);
+        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index];
         println!("cargo:node_lib_file={}", node_lib_file);
     }
 

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -1,7 +1,9 @@
 extern crate gcc;
+extern crate regex;
 
 use std::process::Command;
 use std::env;
+use regex::Regex;
 
 fn main() {
     // 1. Build the object file from source using node-gyp.
@@ -45,6 +47,8 @@ fn build_object_file() {
 
     if cfg!(windows) {
         let node_gyp_output = String::from_utf8_lossy(&output.stderr);
+        let version_regex = Regex::new(r"node@(?P<version>\d+\.\d+\.\d+)\s+\|\s+(?P<platform>\w+)\s+\|\s(?P<arch>ia32|x64)").unwrap();
+        let captures = version_regex.captures(&node_gyp_output).unwrap();
         let node_root_dir_flag_pattern = "'-Dnode_root_dir=";
         let node_root_dir_start_index = node_gyp_output
             .find(node_root_dir_flag_pattern)
@@ -58,7 +62,7 @@ fn build_object_file() {
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
         let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
-        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index];
+        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index].replace("<(target_arch)", &captures["arch"]);
         println!("cargo:node_lib_file={}", node_lib_file);
     }
 

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -57,8 +57,9 @@ fn build_object_file() {
             .find(node_lib_file_flag_pattern)
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
-        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find(".lib").unwrap() + node_lib_file_start_index;
-        println!("cargo:node_lib_file={}", &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index]);
+        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
+        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index];
+        println!("cargo:node_lib_file={}", node_lib_file);
     }
 
     // Run `node-gyp build`.

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -84,7 +84,7 @@ fn link_library() {
         format!("build\\{}\\obj\\neon\\neon.obj", configuration)
     };
 
-    gcc::Config::new().object(object_path).compile("libneon.a");
+    gcc::Build::new().object(object_path).compile("libneon.a");
 }
 
 fn debug() -> bool {


### PR DESCRIPTION
This fixes linking neon on Windows to account for rust-lang/rust#38850.

It also replaces the gyp `<(target_arch)` var, so `rustc` can find the `node.lib` directory.