### PR TITLE
attempt to fix Windows

### DIFF
--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -4,13 +4,8 @@ use std::path::Path;
 /// Set up the build environment by setting Cargo configuration variables.
 pub fn setup() {
     if cfg!(windows) {
-        let debug = env::var("DEBUG").ok().map_or(false, |s| s == "true");
-        let configuration = if debug { "Debug" } else { "Release" };
         let node_root_dir = env::var("DEP_NEON_RUNTIME_NODE_ROOT_DIR").unwrap();
-        let node_lib_file = env::var("DEP_NEON_RUNTIME_NODE_LIB_FILE").unwrap();
-        let node_lib_path = Path::new(&node_lib_file);
-        println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
-        println!("cargo:rustc-link-search=native={}", &node_lib_path.parent().unwrap().display());
-        println!("cargo:rustc-link-lib={}", &node_lib_path.file_stem().unwrap().to_str().unwrap());
+        println!("cargo:rustc-link-search=native={}", node_root_dir);
+        println!("cargo:rustc-link-lib=node");
     }
 }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 /// Set up the build environment by setting Cargo configuration variables.
 pub fn setup() {
     if cfg!(windows) {
-        let node_root_dir = env::var("DEP_NEON_RUNTIME_NODE_ROOT_DIR").unwrap();
+        let node_root_dir = env::var("DEP_NEON_RUNTIME_NODE_ROOT_DIR").expect("env var DEP_NEON_RUNTIME_NODE_ROOT_DIR");
         println!("cargo:rustc-link-search=native={}", node_root_dir);
-        println!("cargo:rustc-link-lib=node");
+        println!("cargo:rustc-link-lib=native=node");
     }
 }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 
 /// Set up the build environment by setting Cargo configuration variables.
 pub fn setup() {
@@ -7,7 +8,9 @@ pub fn setup() {
         let configuration = if debug { "Debug" } else { "Release" };
         let node_root_dir = env::var("DEP_NEON_RUNTIME_NODE_ROOT_DIR").unwrap();
         let node_lib_file = env::var("DEP_NEON_RUNTIME_NODE_LIB_FILE").unwrap();
+        let node_lib_path = Path::new(&node_lib_file);
         println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
-        println!("cargo:rustc-link-lib={}", node_lib_file);
+        println!("cargo:rustc-link-search=native={}", &node_lib_path.parent().unwrap().display());
+        println!("cargo:rustc-link-lib={}", &node_lib_path.file_stem().unwrap().to_str().unwrap());
     }
 }

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -17,3 +17,4 @@ cslice = "0.2"
 
 [build-dependencies]
 gcc = "0.3"
+regex = "0.2"

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -1,7 +1,9 @@
 extern crate gcc;
+extern crate regex;
 
 use std::process::Command;
 use std::env;
+use regex::Regex;
 
 fn main() {
     // 1. Build the object file from source using node-gyp.
@@ -45,6 +47,8 @@ fn build_object_file() {
 
     if cfg!(windows) {
         let node_gyp_output = String::from_utf8_lossy(&output.stderr);
+        let version_regex = Regex::new(r"node@(?P<version>\d+\.\d+\.\d+)\s+\|\s+(?P<platform>\w+)\s+\|\s(?P<arch>ia32|x64)").unwrap();
+        let captures = version_regex.captures(&node_gyp_output).unwrap();
         let node_root_dir_flag_pattern = "'-Dnode_root_dir=";
         let node_root_dir_start_index = node_gyp_output
             .find(node_root_dir_flag_pattern)
@@ -58,7 +62,7 @@ fn build_object_file() {
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
         let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
-        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index];
+        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index].replace("<(target_arch)", &captures["arch"]);
         println!("cargo:node_lib_file={}", node_lib_file);
     }
 

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -57,8 +57,9 @@ fn build_object_file() {
             .find(node_lib_file_flag_pattern)
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
-        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find(".lib").unwrap() + node_lib_file_start_index;
-        println!("cargo:node_lib_file={}", &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index]);
+        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
+        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index];
+        println!("cargo:node_lib_file={}", node_lib_file);
     }
 
     // Run `node-gyp build`.

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -55,15 +55,7 @@ fn build_object_file() {
             .map(|i| i + node_root_dir_flag_pattern.len())
             .expect("Couldn't find node_root_dir in node-gyp output.");
         let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find("'").unwrap() + node_root_dir_start_index;
-        println!("cargo:node_root_dir={}", &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index]);
-        let node_lib_file_flag_pattern = "'-Dnode_lib_file=";
-        let node_lib_file_start_index = node_gyp_output
-            .find(node_lib_file_flag_pattern)
-            .map(|i| i + node_lib_file_flag_pattern.len())
-            .expect("Couldn't find node_lib_file in node-gyp output.");
-        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find(".lib").unwrap() + node_lib_file_start_index;
-        let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index].replace("<(target_arch)", &captures["arch"]);
-        println!("cargo:node_lib_file={}", node_lib_file);
+        println!("cargo:node_root_dir={}\\{}", &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index], &captures["arch"]);
     }
 
     // Run `node-gyp build`.

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -55,7 +55,7 @@ fn build_object_file() {
             .map(|i| i + node_root_dir_flag_pattern.len())
             .expect("Couldn't find node_root_dir in node-gyp output.");
         let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find("'").unwrap() + node_root_dir_start_index;
-        println!("cargo:node_root_dir={}\\{}", &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index], &captures["arch"]);
+        println!("cargo:node_root_dir={}\\\\{}", &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index], &captures["arch"]);
     }
 
     // Run `node-gyp build`.

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -47,14 +47,14 @@ fn build_object_file() {
 
     if cfg!(windows) {
         let node_gyp_output = String::from_utf8_lossy(&output.stderr);
-        let version_regex = Regex::new(r"node@(?P<version>\d+\.\d+\.\d+)\s+\|\s+(?P<platform>\w+)\s+\|\s(?P<arch>ia32|x64)").unwrap();
-        let captures = version_regex.captures(&node_gyp_output).unwrap();
+        let version_regex = Regex::new(r"node@(?P<version>\d+\.\d+\.\d+)\s+\|\s+(?P<platform>\w+)\s+\|\s(?P<arch>ia32|x64)").expect("regex compiles");
+        let captures = version_regex.captures(&node_gyp_output).expect("regex match");
         let node_root_dir_flag_pattern = "'-Dnode_root_dir=";
         let node_root_dir_start_index = node_gyp_output
             .find(node_root_dir_flag_pattern)
             .map(|i| i + node_root_dir_flag_pattern.len())
             .expect("Couldn't find node_root_dir in node-gyp output.");
-        let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find("'").unwrap() + node_root_dir_start_index;
+        let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find("'").expect("single quote end found") + node_root_dir_start_index;
         println!("cargo:node_root_dir={}\\\\{}", &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index], &captures["arch"]);
     }
 

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -61,7 +61,7 @@ fn build_object_file() {
             .find(node_lib_file_flag_pattern)
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
-        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
+        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find(".lib").unwrap() + node_lib_file_start_index;
         let node_lib_file = &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index].replace("<(target_arch)", &captures["arch"]);
         println!("cargo:node_lib_file={}", node_lib_file);
     }

--- a/tests/native/.cargo/config
+++ b/tests/native/.cargo/config
@@ -1,0 +1,2 @@
+[term]
+verbose = true


### PR DESCRIPTION
@dherman @hone

This was my attempt to fix Windows builds last night, but I failed. I was trying to set:

```
cargo:rustc-link-search=native=C:\\Users\\camer\\.node-gyp\\8.0.0\\x64
cargo:rustc-link-lib=native=node
```

I'm not sure about the `native=` part that I saw a few places and that I added.

But this code kept failing for me with:
```
   Compiling neon-runtime v0.1.19 (file:///C:/Users/camer/rs/neon/crates/neon-runtime)
error: failed to run custom build command for `neon v0.1.19 (file:///C:/Users/camer/rs/neon)`
process didn't exit successfully: `C:\Users\camer\rs\neon\target\debug\build\neon-b76afb4d4fb8ea00\build-script-build` (
exit code: 101)
--- stdout
cargo:node_root_dir=C:\\Users\\camer\\.node-gyp\\8.0.0\\x64

--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: NotPresent', src\libcore\result.rs:860
stack backtrace:
   0: std::sys_common::backtrace::_print
             at C:\projects\rust\src\libstd\sys_common\backtrace.rs:71
   1: std::panicking::default_hook::{{closure}}
             at C:\projects\rust\src\libstd\panicking.rs:354
   2: std::panicking::default_hook
             at C:\projects\rust\src\libstd\panicking.rs:371
   3: std::panicking::rust_panic_with_hook
             at C:\projects\rust\src\libstd\panicking.rs:549
   4: std::panicking::begin_panic<collections::string::String>
             at C:\projects\rust\src\libstd\panicking.rs:511
   5: std::panicking::begin_panic_fmt
             at C:\projects\rust\src\libstd\panicking.rs:495
   6: std::panicking::rust_begin_panic
             at C:\projects\rust\src\libstd\panicking.rs:471
   7: core::panicking::panic_fmt
             at C:\projects\rust\src\libcore\panicking.rs:69
   8: core::result::unwrap_failed<std::env::VarError>
             at C:\projects\rust\src\libcore\macros.rs:29
   9: core::result::Result<collections::string::String, std::env::VarError>::unwrap<collections::string::String,std::env
::VarError>
             at C:\projects\rust\src\libcore\result.rs:738
  10: build_script_build::main
             at .\build.rs:6
  11: panic_unwind::__rust_maybe_catch_panic
             at C:\projects\rust\src\libpanic_unwind\lib.rs:98
  12: std::rt::lang_start
             at C:\projects\rust\src\libstd\rt.rs:52
  13: main
  14: __scrt_common_main_seh
             at f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl:283
  15: BaseThreadInitThunk

Build failed, waiting for other jobs to finish...
error: build failed
```

And I wasn't sure what was wrong.