### PR TITLE
gcc build change requires gcc 0.3.52+

### DIFF
--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -16,5 +16,5 @@ build = "build.rs"
 cslice = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+gcc = "0.3.52"
 regex = "0.2"


### PR DESCRIPTION
331852ff1dd642ea3429ef822cd1ecf3ba4f031e fixed a deprecation in [gcc-rs](https://github.com/alexcrichton/gcc-rs). This requires a bump to at least `0.3.52` or this error will happen during build:

```
   |
87 |     gcc::Build::new().object(object_path).compile("libneon.a");
   |     ^^^^^^^^^^^^^^^ Could not find `Build` in `gcc`

error: aborting due to previous error(s)
```