### PR TITLE
Update README.md with new rust version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Support for [LTS versions of Node](https://github.com/nodejs/LTS#lts-schedule) a
 
 ### Rust
 
-Neon supports Rust stable version 1.15 and higher. We test on the latest stable, beta, and nightly versions of Rust.
+Neon supports Rust stable version 1.18 and higher. We test on the latest stable, beta, and nightly versions of Rust.
 
 # A Taste...
 


### PR DESCRIPTION
Neon requires Rust 1.18 since https://github.com/neon-bindings/neon/pull/231