### PR TITLE
Escape quotes in certain `neon new` input values

### DIFF
--- a/cli/src/ops/neon_new.ts
+++ b/cli/src/ops/neon_new.ts
@@ -113,6 +113,10 @@ export default async function wizard(pwd: string, name: string) {
       internal: local.replace(/-/g, "_")
     }
   };
+  answers.description = escapeQuotes(answers.description);
+  answers.git = encodeURI(answers.git);
+  answers.author = escapeQuotes(answers.author);
+
   let ctx = {
     project: answers,
     "neon-cli": {
@@ -152,3 +156,7 @@ export default async function wizard(pwd: string, name: string) {
   console.log();
   console.log("Happy hacking!");
 };
+
+function escapeQuotes(str: string): string {
+  return str.replace(/"/g, '\\"');
+}


### PR DESCRIPTION
Addresses https://github.com/neon-bindings/neon/issues/238. The description, author, and git fields could potentially have quotes in them, and we only need to escape double quotes, so this escapes double quotes in those fields only. For the git url though, I simply `encodeURI`.