### PR TITLE
Create an API for accessing the global object #249

### DIFF
--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -248,6 +248,11 @@ extern "C" size_t Neon_Scope_AlignofEscapable() {
   return alignof(v8::EscapableHandleScope);
 }
 
+extern "C" void Neon_Scope_GetGlobal(v8::Isolate *isolate, v8::Local<v8::Value> *out) {
+  auto ctx = isolate->GetCurrentContext();
+  *out = ctx->Global();
+}
+
 extern "C" void Neon_Fun_ExecKernel(void *kernel, Neon_RootScopeCallback callback, v8::FunctionCallbackInfo<v8::Value> *info, void *scope) {
   Nan::HandleScope v8_scope;
   callback(info, kernel, scope);

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -83,6 +83,7 @@ extern "C" {
   size_t Neon_Scope_Alignof();
   size_t Neon_Scope_SizeofEscapable();
   size_t Neon_Scope_AlignofEscapable();
+  void Neon_Scope_GetGlobal(v8::Isolate *isolate, v8::Local<v8::Value> *out);
 
   bool Neon_Fun_New(v8::Local<v8::Function> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *kernel);
   void Neon_Fun_ExecKernel(void *kernel, Neon_RootScopeCallback callback, v8::FunctionCallbackInfo<v8::Value> *info, void *scope);

--- a/crates/neon-runtime/src/scope.rs
+++ b/crates/neon-runtime/src/scope.rs
@@ -43,4 +43,9 @@ extern "C" {
     #[link_name = "Neon_Scope_AlignofEscapable"]
     pub fn escapable_alignment() -> usize;
 
+    /// Mutates the `out` argument provided to refer to the `v8::Local` value of the `global`
+    /// object
+    #[link_name = "Neon_Scope_GetGlobal"]
+    pub fn get_global(isolate: *mut c_void, out: &mut Local);
+
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -25,7 +25,7 @@ pub trait Scope<'a>: ScopeInternal {
     fn nested<T, F: for<'inner> FnOnce(&mut NestedScope<'inner>) -> T>(&self, f: F) -> T;
     fn chained<T, F: for<'inner> FnOnce(&mut ChainedScope<'inner, 'a>) -> T>(&self, f: F) -> T;
 
-    fn global(&self) -> Handle<JsObject> {
+    fn global(&self) -> Handle<'a, JsObject> {
         JsObject::build(|out| {
             unsafe {
                 neon_runtime::scope::get_global(self.isolate().to_raw(), out);

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use neon_runtime;
 use neon_runtime::raw;
 use mem::Handle;
-use js::Value;
+use js::{Value, JsObject};
 use vm::internal::Isolate;
 use self::internal::ScopeInternal;
 
@@ -24,6 +24,14 @@ pub(crate) mod internal {
 pub trait Scope<'a>: ScopeInternal {
     fn nested<T, F: for<'inner> FnOnce(&mut NestedScope<'inner>) -> T>(&self, f: F) -> T;
     fn chained<T, F: for<'inner> FnOnce(&mut ChainedScope<'inner, 'a>) -> T>(&self, f: F) -> T;
+
+    fn global(&self) -> Handle<JsObject> {
+        JsObject::build(|out| {
+            unsafe {
+                neon_runtime::scope::get_global(self.isolate().to_raw(), out);
+            }
+        })
+    }
 }
 
 fn ensure_active<T: ScopeInternal>(scope: &T) {

--- a/test/dynamic/lib/objects.js
+++ b/test/dynamic/lib/objects.js
@@ -2,6 +2,10 @@ var addon = require('../native');
 var assert = require('chai').assert;
 
 describe('JsObject', function() {
+  it('return the v8::Global object', function () {
+      assert(global === addon.return_js_global_object());
+  });
+
   it('return a JsObject built in Rust', function () {
     assert.deepEqual({}, addon.return_js_object());
   });

--- a/test/dynamic/native/src/js/objects.rs
+++ b/test/dynamic/native/src/js/objects.rs
@@ -1,6 +1,12 @@
 use neon::vm::{Call, JsResult};
 use neon::mem::Handle;
 use neon::js::{JsNumber, JsString, JsObject, Object};
+use neon::scope::Scope;
+
+pub fn return_js_global_object(call: Call) -> JsResult<JsObject> {
+    let scope = call.scope;
+    Ok(scope.global())
+}
 
 pub fn return_js_object(call: Call) -> JsResult<JsObject> {
     Ok(JsObject::new(call.scope))

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -40,6 +40,7 @@ register_module!(m, {
     m.export("return_js_array_with_number", return_js_array_with_number)?;
     m.export("return_js_array_with_string", return_js_array_with_string)?;
 
+    m.export("return_js_global_object", return_js_global_object)?;
     m.export("return_js_object", return_js_object)?;
     m.export("return_js_object_with_number", return_js_object_with_number)?;
     m.export("return_js_object_with_string", return_js_object_with_string)?;


### PR DESCRIPTION
I've implemented the api for getting a reference to the global object as per #249. 
I've made it a method on scope such that the following works
```rust
pub fn call_console_log(call: Call) -> JsResult<JsObject> {
    let scope = call.scope;
    
    let global = scope.global();
    let console = global.get(scope, "console")?.check::<JsObject>()?;
    let log = console.get(scope, "log")?.check::<JsFunction>()?;
    let args: Vec<Handle<JsString>> = vec![JsString::new(scope, "hello world").unwrap()];
    log.call(scope, console, args.into_iter())?;
...
```