### PR TITLE
Add error message for missing Rust executable

### DIFF
--- a/cli/src/build-settings.ts
+++ b/cli/src/build-settings.ts
@@ -28,8 +28,13 @@ export default class BuildSettings {
   }
 
   static current(toolchain: rust.Toolchain) {
-    let rustc = rust.spawnSync("rustc", ["--version"], toolchain)
-      .stdout
+    const stdout = rust.spawnSync("rustc", ["--version"], toolchain).stdout;
+
+    if (!stdout) {
+      throw new Error('Rust is not installed or rustc is not in your path.');
+    }
+
+    let rustc = stdout
       .toString('utf8')
       .trim();
 

--- a/cli/src/build-settings.ts
+++ b/cli/src/build-settings.ts
@@ -28,13 +28,16 @@ export default class BuildSettings {
   }
 
   static current(toolchain: rust.Toolchain) {
-    const stdout = rust.spawnSync("rustc", ["--version"], toolchain).stdout;
+    const spawnResult = rust.spawnSync("rustc", ["--version"], toolchain);
 
-    if (!stdout) {
-      throw new Error('Rust is not installed or rustc is not in your path.');
+    if (spawnResult.error) {
+      if (spawnResult.error.message.includes("ENOENT")) {
+        throw new Error('Rust is not installed or rustc is not in your path.');
+      }
+      throw spawnResult.error;
     }
 
-    let rustc = stdout
+    let rustc = spawnResult.stdout
       .toString('utf8')
       .trim();
 


### PR DESCRIPTION
This adds an error message (instead of complaining about `Cannot read property 'toString' of null`) if Rust (particularly `rustc`) is not found.

Fixes #216.