### PR TITLE
Fix Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,23 +4,37 @@ environment:
   RUST_BACKTRACE: 1
   matrix:
     - PLATFORM: x64
+      NODEJS_VERSION: "4"
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
+    - PLATFORM: x64
       NODEJS_VERSION: "6"
       RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-    - PLATFORM: x86
-      NODEJS_VERSION: "6"
-      RUST_TOOLCHAIN: stable-i686-pc-windows-msvc
     - PLATFORM: x64
       NODEJS_VERSION: "8"
       RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-    - PLATFORM: x86
+    - PLATFORM: x64
+      NODEJS_VERSION: "4"
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "6"
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
       NODEJS_VERSION: "8"
-      RUST_TOOLCHAIN: stable-i686-pc-windows-msvc
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "4"
+      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "6"
+      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "8"
+      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
 
 install:
   - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
   - npm config set msvs_version 2015
   - node -e "console.log(process.argv[0], process.arch, process.versions)"
-
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe -y --default-toolchain %RUST_TOOLCHAIN%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
@@ -31,8 +45,9 @@ install:
 build: false
 
 test_script:
-  - cd tests
-  - npm test
+  - cd cli && npm install && npm run transpile && cd ..
+  - cd test/dynamic && npm install && npm test && cd ../..
+  - if "%RUST_TOOLCHAIN%" == nightly-x86_64-pc-windows-msvc (cd test/static && cargo test && cd ../..)
 
 cache:
   - target

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,30 +4,6 @@ environment:
   RUST_BACKTRACE: 1
   matrix:
     - PLATFORM: x64
-      NODEJS_VERSION: "4"
-      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "6"
-      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "8"
-      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "4"
-      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "6"
-      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "8"
-      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "4"
-      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
-    - PLATFORM: x64
-      NODEJS_VERSION: "6"
-      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
-    - PLATFORM: x64
       NODEJS_VERSION: "8"
       RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
 
@@ -47,7 +23,7 @@ build: false
 test_script:
   - cd cli && npm install && npm run transpile && cd ..
   - cd test/dynamic && npm install && npm test && cd ../..
-  - if "%RUST_TOOLCHAIN%" == nightly-x86_64-pc-windows-msvc (cd test/static && cargo test && cd ../..)
+  - if %RUST_TOOLCHAIN% == nightly-x86_64-pc-windows-msvc (cd test/static && cargo test && cd ../..)
 
 cache:
   - target

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,30 @@ environment:
   RUST_BACKTRACE: 1
   matrix:
     - PLATFORM: x64
+      NODEJS_VERSION: "4"
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "6"
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "8"
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "4"
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "6"
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "8"
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "4"
+      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "6"
+      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
+    - PLATFORM: x64
       NODEJS_VERSION: "8"
       RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,7 +14,7 @@
   },
   "license": "SEE LICENSE IN LICENSE-*",
   "dependencies": {
-    "chalk": "^2.1.0",
+    "chalk": "~2.1.0",
     "command-line-args": "^4.0.2",
     "command-line-commands": "^2.0.0",
     "command-line-usage": "^4.0.0",

--- a/test/cli/package.json
+++ b/test/cli/package.json
@@ -9,7 +9,7 @@
   },
   "license": "SEE LICENSE IN LICENSE-*",
   "dependencies": {
-    "chalk": "^2.1.0",
+    "chalk": "~2.1.0",
     "command-line-args": "^4.0.2",
     "command-line-commands": "^2.0.0",
     "command-line-usage": "^4.0.0",

--- a/test/cli/src/support/acceptance.ts
+++ b/test/cli/src/support/acceptance.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { spawn } from 'nexpect';
 
 const NODE = process.execPath;
-const NEON = path.join(__dirname, '..', '..', '..', '..', 'cli/bin/cli.js');
+const NEON = path.join(__dirname, '..', '..', '..', '..', 'cli', 'bin', 'cli.js');
 
 export interface Spawnable {
   cwd: string;


### PR DESCRIPTION
Fixes: https://github.com/neon-bindings/neon/issues/248

There are currently a few issues with the broken appveyor build.

1) The newest versions of chalk (2.2.0 at this time) export typescript definitions that conflict with those used from DefinitelyTyped
2) The directory structure appears to have changed since the appveyor build was last passing
3) The cli tests fail (and will continue to do so) due to nexpect not passing `shell` or `windowsVerbatimArguments` to `spawn`

This PR fixes all three of those and updates the appveyor script to more closely mirror the build matrix of travis.

Regarding number 3, since nexpect hasn't been updated in ~3 years I think to get the desired support for windows sub-process spawning you'll either have to fork nexpect or move the test suite away from using it. Until then, the cli tests aren't running on appveyor.