### PR TITLE
Get c++ tag_t back in sync with Rust Tag

### DIFF
--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -428,8 +428,6 @@ extern "C" tag_t Neon_Tag_Of(v8::Local<v8::Value> val) {
   return val->IsNull()                    ? tag_null
     : val->IsUndefined()                  ? tag_undefined
     : (val->IsTrue() || val->IsFalse())   ? tag_boolean
-    // ISSUE(#78): kill this
-    : (val->IsInt32() || val->IsUint32()) ? tag_integer
     : val->IsNumber()                     ? tag_number
     : val->IsString()                     ? tag_string
     : val->IsArray()                      ? tag_array

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -15,7 +15,6 @@ typedef enum {
   tag_null,
   tag_undefined,
   tag_boolean,
-  tag_integer,
   tag_number,
   tag_string,
   tag_object,


### PR DESCRIPTION
This fixes #277 

I'm sure this caused many more bugs than just that. Seeing as variant would be incorrect for anything in the enum after boolean.