### PR TITLE
reinstates the removed `JsInteger` feature for a 0.1.22 release

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -79,6 +79,11 @@ extern "C" bool Neon_Primitive_BooleanValue(v8::Local<v8::Boolean> p) {
   return p->Value();
 }
 
+// DEPRECATE(0.2)
+extern "C" void Neon_Primitive_Integer(v8::Local<v8::Integer> *out, v8::Isolate *isolate, int32_t x) {
+  *out = v8::Integer::New(isolate, x);
+}
+
 extern "C" void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value) {
   *out = v8::Number::New(isolate, value);
 }
@@ -93,6 +98,11 @@ extern "C" bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p) {
 
 extern "C" bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p) {
   return p->IsInt32();
+}
+
+// DEPRECATE(0.2)
+extern "C" int64_t Neon_Primitive_IntegerValue(v8::Local<v8::Integer> i) {
+  return i->Value();
 }
 
 extern "C" bool Neon_Object_Get_Index(v8::Local<v8::Value> *out, v8::Local<v8::Object> obj, uint32_t index) {
@@ -428,6 +438,8 @@ extern "C" tag_t Neon_Tag_Of(v8::Local<v8::Value> val) {
   return val->IsNull()                    ? tag_null
     : val->IsUndefined()                  ? tag_undefined
     : (val->IsTrue() || val->IsFalse())   ? tag_boolean
+    // DEPRECATE(0.2)
+    : (val->IsInt32() || val->IsUint32()) ? tag_integer
     : val->IsNumber()                     ? tag_number
     : val->IsString()                     ? tag_string
     : val->IsArray()                      ? tag_array
@@ -442,6 +454,11 @@ extern "C" bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val) {
 
 extern "C" bool Neon_Tag_IsNull(v8::Local<v8::Value> val) {
   return val->IsNull();
+}
+
+// DEPRECATE(0.2)
+extern "C" bool Neon_Tag_IsInteger(v8::Local<v8::Value> val) {
+  return val->IsInt32() || val->IsUint32();
 }
 
 extern "C" bool Neon_Tag_IsNumber(v8::Local<v8::Value> val) {

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -15,6 +15,8 @@ typedef enum {
   tag_null,
   tag_undefined,
   tag_boolean,
+  // DEPRECATE(0.2)
+  tag_integer,
   tag_number,
   tag_string,
   tag_object,
@@ -35,12 +37,16 @@ extern "C" {
   int32_t Neon_Call_Length(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);
 
+  // DEPRECATE(0.2)
+  void Neon_Primitive_Integer(v8::Local<v8::Integer> *out, v8::Isolate *isolate, int32_t x);
   void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value);
   void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out);
   void Neon_Primitive_Null(v8::Local<v8::Primitive> *out);
   void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, bool b);
   bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p);
   bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p);
+  // DEPRECATE(0.2)
+  int64_t Neon_Primitive_IntegerValue(v8::Local<v8::Integer> i);
 
   void Neon_Object_New(v8::Local<v8::Object> *out);
   bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Local<v8::Object> obj);
@@ -126,6 +132,8 @@ extern "C" {
   bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val);
   bool Neon_Tag_IsNull(v8::Local<v8::Value> val);
   bool Neon_Tag_IsBoolean(v8::Local<v8::Value> val);
+  // DEPRECATE(0.2)
+  bool Neon_Tag_IsInteger(v8::Local<v8::Value> val);
   bool Neon_Tag_IsNumber(v8::Local<v8::Value> val);
   bool Neon_Tag_IsString(v8::Local<v8::Value> val);
   bool Neon_Tag_IsObject(v8::Local<v8::Value> val);

--- a/crates/neon-runtime/src/primitive.rs
+++ b/crates/neon-runtime/src/primitive.rs
@@ -20,6 +20,11 @@ extern "C" {
     #[link_name = "Neon_Primitive_BooleanValue"]
     pub fn boolean_value(p: Local) -> bool;
 
+    // DEPRECATE(0.2)
+    /// Mutates the `out` argument provided to refer to a newly created `v8::Integer` object.
+    #[link_name = "Neon_Primitive_Integer"]
+    pub fn integer(out: &mut Local, isolate: *mut Isolate, x: i32);
+
     /// Indicates if the value is a 32-bit unsigned integer.
     #[link_name = "Neon_Primitive_IsUint32"]
     pub fn is_u32(p: Local) -> bool;
@@ -27,6 +32,11 @@ extern "C" {
     /// Indicates if the value is a 32-bit signed integer.
     #[link_name = "Neon_Primitive_IsInt32"]
     pub fn is_i32(p: Local) -> bool;
+
+    // DEPRECATE(0.2)
+    /// Gets the underlying value of a `v8::Integer` object.
+    #[link_name = "Neon_Primitive_IntegerValue"]
+    pub fn integer_value(p: Local) -> i64;
 
     /// Mutates the `out` argument provided to refer to a newly created `v8::Number` object.
     #[link_name = "Neon_Primitive_Number"]

--- a/crates/neon-runtime/src/tag.rs
+++ b/crates/neon-runtime/src/tag.rs
@@ -9,6 +9,8 @@ pub enum Tag {
     Null,
     Undefined,
     Boolean,
+    // DEPRECATE(0.2)
+    Integer,
     Number,
     String,
     Object,
@@ -30,6 +32,11 @@ extern "C" {
     /// Indicates if the value type is `Null`.
     #[link_name = "Neon_Tag_IsNull"]
     pub fn is_null(val: Local) -> bool;
+
+    // DEPRECATE(0.2)
+    /// Indicates if the value type is `Integer`.
+    #[link_name = "Neon_Tag_IsInteger"]
+    pub fn is_integer(val: Local) -> bool;
 
     /// Indicates if the value type is `Number`.
     #[link_name = "Neon_Tag_IsNumber"]

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -112,6 +112,8 @@ pub enum Variant<'a> {
     Null(Handle<'a, JsNull>),
     Undefined(Handle<'a, JsUndefined>),
     Boolean(Handle<'a, JsBoolean>),
+    // DEPRECATE(0.2)
+    Integer(Handle<'a, JsInteger>),
     Number(Handle<'a, JsNumber>),
     String(Handle<'a, JsString>),
     Object(Handle<'a, JsObject>),
@@ -152,6 +154,8 @@ impl<'a> Handle<'a, JsValue> {
             Tag::Null => Variant::Null(JsNull::new()),
             Tag::Undefined => Variant::Undefined(JsUndefined::new()),
             Tag::Boolean => Variant::Boolean(Handle::new_internal(JsBoolean(self.to_raw()))),
+            // DEPRECATE(0.2)
+            Tag::Integer => Variant::Integer(Handle::new_internal(JsInteger(self.to_raw()))),
             Tag::Number => Variant::Number(Handle::new_internal(JsNumber(self.to_raw()))),
             Tag::String => Variant::String(Handle::new_internal(JsString(self.to_raw()))),
             Tag::Object => Variant::Object(Handle::new_internal(JsObject(self.to_raw()))),
@@ -383,6 +387,58 @@ fn lower_str_unwrap(s: &str) -> (*const u8, i32) {
     lower_str(s).unwrap_or_else(|| {
         panic!("{} < i32::MAX", s.len())
     })
+}
+
+// DEPRECATE(0.2)
+/// A JavaScript number value whose value is known statically to be a
+/// 32-bit integer.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct JsInteger(raw::Local);
+
+impl JsInteger {
+    pub fn new<'a, T: Scope<'a>>(scope: &mut T, i: i32) -> Handle<'a, JsInteger> {
+        JsInteger::new_internal(scope.isolate(), i)
+    }
+
+    pub(crate) fn new_internal<'a>(isolate: Isolate, i: i32) -> Handle<'a, JsInteger> {
+        unsafe {
+            let mut local: raw::Local = mem::zeroed();
+            neon_runtime::primitive::integer(&mut local, isolate.to_raw(), i);
+            Handle::new_internal(JsInteger(local))
+        }
+    }
+
+    pub fn is_u32(self) -> bool {
+        unsafe {
+            neon_runtime::primitive::is_u32(self.to_raw())
+       }
+    }
+    pub fn is_i32(self) -> bool {
+        unsafe {
+            neon_runtime::primitive::is_i32(self.to_raw())
+        }
+    }
+
+    pub fn value(self) -> i64 {
+        unsafe {
+            neon_runtime::primitive::integer_value(self.to_raw())
+        }
+    }
+}
+
+impl Value for JsInteger { }
+
+impl Managed for JsInteger {
+    fn to_raw(self) -> raw::Local { self.0 }
+
+    fn from_raw(h: raw::Local) -> Self { JsInteger(h) }
+}
+
+impl ValueInternal for JsInteger {
+    fn is_typeof<Other: Value>(other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_integer(other.to_raw()) }
+    }
 }
 
 /// A JavaScript number value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,7 @@ mod tests {
         run("npm test", &test_cli);
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn static_test() {
         let _guard = TEST_MUTEX.lock();

--- a/test/dynamic/lib/numbers.js
+++ b/test/dynamic/lib/numbers.js
@@ -22,6 +22,11 @@ describe('JsNumber', function() {
     assert.equal(addon.return_negative_float_js_number(), -1.4747);
   });
 
+  // DEPRECATE(0.2)
+  it('return a JsInteger built in Rust', function () {
+    assert.equal(addon.return_js_integer(), 17);
+  });
+
   describe('round trips', function () {
     it('accept and return a number', function () {
       assert.equal(addon.accept_and_return_js_number(1), 1);
@@ -45,6 +50,11 @@ describe('JsNumber', function() {
 
     it('accept and return a negative number as a JsNumber', function () {
       assert.equal(addon.accept_and_return_negative_js_number(-55), -55);
+    });
+
+    // DEPRECATE(0.2)
+    it('accept and return an integer as a JsInteger', function () {
+      assert.equal(addon.accept_and_return_js_integer(42), 42);
     });
   });
 

--- a/test/dynamic/native/src/js/numbers.rs
+++ b/test/dynamic/native/src/js/numbers.rs
@@ -1,5 +1,5 @@
 use neon::vm::{Call, JsResult};
-use neon::js::{JsNumber};
+use neon::js::{JsNumber, JsInteger};
 use neon::mem::Handle;
 
 pub fn return_js_number(call: Call) -> JsResult<JsNumber> {
@@ -22,6 +22,11 @@ pub fn return_negative_float_js_number(call: Call) -> JsResult<JsNumber> {
     Ok(JsNumber::new(call.scope, -1.4747_f64))
 }
 
+// DEPRECATE(0.2)
+pub fn return_js_integer(call: Call) -> JsResult<JsInteger> {
+    Ok(JsInteger::new(call.scope, 17))
+}
+
 pub fn accept_and_return_js_number(call: Call) -> JsResult<JsNumber> {
     let number: Handle<JsNumber> = call.arguments.require(call.scope, 0)?.check::<JsNumber>()?;
     Ok(number)
@@ -40,4 +45,10 @@ pub fn accept_and_return_float_js_number(call: Call) -> JsResult<JsNumber> {
 pub fn accept_and_return_negative_js_number(call: Call) -> JsResult<JsNumber> {
     let number: Handle<JsNumber> = call.arguments.require(call.scope, 0)?.check::<JsNumber>()?;
     Ok(number)
+}
+
+// DEPRECATE(0.2)
+pub fn accept_and_return_js_integer(call: Call) -> JsResult<JsInteger> {
+    let x: Handle<JsInteger> = call.arguments.require(call.scope, 0)?.check::<JsInteger>()?;
+    Ok(x)
 }

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -31,10 +31,14 @@ register_module!(m, {
     m.export("return_negative_js_number", return_negative_js_number)?;
     m.export("return_float_js_number", return_float_js_number)?;
     m.export("return_negative_float_js_number", return_negative_float_js_number)?;
+    // DEPRECATE(0.2)
+    m.export("return_js_integer", return_js_integer)?;
     m.export("accept_and_return_js_number", accept_and_return_js_number)?;
     m.export("accept_and_return_large_js_number", accept_and_return_large_js_number)?;
     m.export("accept_and_return_float_js_number", accept_and_return_float_js_number)?;
     m.export("accept_and_return_negative_js_number", accept_and_return_negative_js_number)?;
+    // DEPRECATE(0.2)
+    m.export("accept_and_return_js_integer", accept_and_return_js_integer)?;
 
     m.export("return_js_array", return_js_array)?;
     m.export("return_js_array_with_number", return_js_array_with_number)?;

--- a/test/static/Cargo.toml
+++ b/test/static/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 neon = { path = "../../" }
-compiletest_rs = "0.2.9"
+compiletest_rs = "0.3.2"


### PR DESCRIPTION
We'll batch up a small number of incompatible changes for 0.2 and remove `JsInteger` then.

fixes #279