### PR TITLE
Allow mutable borrow of self for Tasks.

### DIFF
--- a/test/dynamic/native/src/js/tasks.rs
+++ b/test/dynamic/native/src/js/tasks.rs
@@ -11,7 +11,7 @@ impl Task for SuccessTask {
     type Error = String;
     type JsEvent = JsNumber;
 
-    fn perform(&self) -> Result<Self::Output, Self::Error> {
+    fn perform(&mut self) -> Result<Self::Output, Self::Error> {
         Ok(17)
     }
 
@@ -33,7 +33,7 @@ impl Task for FailureTask {
     type Error = String;
     type JsEvent = JsNumber;
 
-    fn perform(&self) -> Result<Self::Output, Self::Error> {
+    fn perform(&mut self) -> Result<Self::Output, Self::Error> {
         Err(format!("I am a failing task"))
     }
 


### PR DESCRIPTION
Some `Task` implementations might need mutable access to the struct data during `perform`. Nobody else will have access to the struct after calling `schedule` since it takes ownership of `self`, so we can safely allow mutable access inside of `perform`.