### PR TITLE
Implement a safe wrapper for persistent handles.

### DIFF
--- a/crates/neon-runtime/src/mem.rs
+++ b/crates/neon-runtime/src/mem.rs
@@ -12,6 +12,9 @@ extern "C" {
     #[link_name = "Neon_Mem_NewPersistent"]
     pub fn new_persistent(h: Local) -> *mut c_void;
 
+    #[link_name = "Neon_Mem_ClonePersistent"]
+    pub fn clone_persistent(p: *mut c_void) -> *mut c_void;
+
     #[link_name = "Neon_Mem_New"]
     pub fn new(out: &mut Local, p: *mut c_void);
 

--- a/crates/neon-runtime/src/mem.rs
+++ b/crates/neon-runtime/src/mem.rs
@@ -1,4 +1,6 @@
 //! A helper function for comparing `v8::Local` handles.
+
+use std::os::raw::c_void;
 use raw::Local;
 
 extern "C" {
@@ -6,5 +8,11 @@ extern "C" {
     /// Indicates if two `v8::Local` handles are the same.
     #[link_name = "Neon_Mem_SameHandle"]
     pub fn same_handle(h1: Local, h2: Local) -> bool;
+
+    #[link_name = "Neon_Mem_NewPersistent"]
+    pub fn new_persistent(h: Local) -> *mut c_void;
+
+    #[link_name = "Neon_Mem_New"]
+    pub fn new(out: &mut Local, p: *mut c_void);
 
 }

--- a/crates/neon-runtime/src/mem.rs
+++ b/crates/neon-runtime/src/mem.rs
@@ -15,4 +15,7 @@ extern "C" {
     #[link_name = "Neon_Mem_New"]
     pub fn new(out: &mut Local, p: *mut c_void);
 
+    #[link_name = "Neon_Mem_DeletePersistent"]
+    pub fn delete_persistent(p: *mut c_void);
+
 }

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -538,7 +538,7 @@ extern "C" bool Neon_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value
 }
 
 extern "C" void *Neon_Mem_NewPersistent(v8::Local<v8::Value> val) {
-  return static_cast<void*>(new Nan::Persistent<v8::Value>(val));
+  return new Nan::Persistent<v8::Value>(val);
 }
 
 extern "C" void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent) {
@@ -550,12 +550,11 @@ extern "C" void *Neon_Mem_ClonePersistent(void *persistent) {
   Nan::Persistent<v8::Value>* original = static_cast<Nan::Persistent<v8::Value>*>(persistent);
   Nan::Persistent<v8::Value>* copy = new Nan::Persistent<v8::Value>();
   copy->Reset(*original);
-  return static_cast<void*>(copy);
+  return copy;
 }
 
 extern "C" void Neon_Mem_DeletePersistent(void *persistent) {
   Nan::Persistent<v8::Value>* p = static_cast<Nan::Persistent<v8::Value>*>(persistent);
-  p->Reset();
   delete p;
 }
 

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -537,6 +537,15 @@ extern "C" bool Neon_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value
   return v1 == v2;
 }
 
+extern "C" void *Neon_Mem_NewPersistent(v8::Local<v8::Value> val) {
+  return (void*)(new Nan::Persistent<v8::Value>(val));
+}
+
+extern "C" void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent) {
+  Nan::Persistent<v8::Value> *p = (Nan::Persistent<v8::Value> *)persistent;
+  *out = Nan::New(*p);
+}
+
 extern "C" void Neon_Task_Schedule(void *task, Neon_TaskPerformCallback perform, Neon_TaskCompleteCallback complete, v8::Local<v8::Function> callback) {
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   neon::Task *internal_task = new neon::Task(isolate, task, perform, complete, callback);

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -538,12 +538,17 @@ extern "C" bool Neon_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value
 }
 
 extern "C" void *Neon_Mem_NewPersistent(v8::Local<v8::Value> val) {
-  return (void*)(new Nan::Persistent<v8::Value>(val));
+  return static_cast<void*>(new Nan::Persistent<v8::Value>(val));
 }
 
 extern "C" void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent) {
-  Nan::Persistent<v8::Value> *p = (Nan::Persistent<v8::Value> *)persistent;
+  Nan::Persistent<v8::Value>* p = static_cast<Nan::Persistent<v8::Value>*>(persistent);
   *out = Nan::New(*p);
+}
+
+extern "C" void Neon_Mem_DeletePersistent(void *persistent) {
+  Nan::Persistent<v8::Value>* p = static_cast<Nan::Persistent<v8::Value>*>(persistent);
+  delete p;
 }
 
 extern "C" void Neon_Task_Schedule(void *task, Neon_TaskPerformCallback perform, Neon_TaskCompleteCallback complete, v8::Local<v8::Function> callback) {

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -546,8 +546,16 @@ extern "C" void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent) {
   *out = Nan::New(*p);
 }
 
+extern "C" void *Neon_Mem_ClonePersistent(void *persistent) {
+  Nan::Persistent<v8::Value>* original = static_cast<Nan::Persistent<v8::Value>*>(persistent);
+  Nan::Persistent<v8::Value>* copy = new Nan::Persistent<v8::Value>();
+  copy->Reset(*original);
+  return static_cast<void*>(copy);
+}
+
 extern "C" void Neon_Mem_DeletePersistent(void *persistent) {
   Nan::Persistent<v8::Value>* p = static_cast<Nan::Persistent<v8::Value>*>(persistent);
+  p->Reset();
   delete p;
 }
 

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -158,6 +158,7 @@ extern "C" {
   bool Neon_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value> v2);
   void *Neon_Mem_NewPersistent(v8::Local<v8::Value> val);
   void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent);
+  void *Neon_Mem_ClonePersistent(void *persistent);
   void Neon_Mem_DeletePersistent(void *persistent);
 
   typedef void* (*Neon_TaskPerformCallback)(void *);

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -158,6 +158,7 @@ extern "C" {
   bool Neon_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value> v2);
   void *Neon_Mem_NewPersistent(v8::Local<v8::Value> val);
   void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent);
+  void Neon_Mem_DeletePersistent(void *persistent);
 
   typedef void* (*Neon_TaskPerformCallback)(void *);
   typedef void (*Neon_TaskCompleteCallback)(void *, void *, v8::Local<v8::Value> *out);

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -156,6 +156,8 @@ extern "C" {
   void Neon_Error_ThrowSyntaxErrorFromCString(const char *msg);
 
   bool Neon_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value> v2);
+  void *Neon_Mem_NewPersistent(v8::Local<v8::Value> val);
+  void Neon_Mem_New(v8::Local<v8::Value> *out, void *persistent);
 
   typedef void* (*Neon_TaskPerformCallback)(void *);
   typedef void (*Neon_TaskCompleteCallback)(void *, void *, v8::Local<v8::Value> *out);

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -109,10 +109,11 @@ impl<'a, T: Value> Lock for LockedHandle<'a, T> {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
 pub struct PersistentHandle {
     ptr: *mut c_void,
 }
+
+unsafe impl Send for PersistentHandle { }
 
 impl PersistentHandle {
     pub fn new<T: Value>(h: Handle<T>) -> PersistentHandle {
@@ -127,5 +128,11 @@ impl PersistentHandle {
             neon_runtime::mem::new(&mut local, self.ptr);
             JsValue::new_internal(local)
         }
+    }
+}
+
+impl Drop for PersistentHandle {
+    fn drop(&mut self) {
+        unsafe { neon_runtime::mem::delete_persistent(self.ptr) }
     }
 }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -131,6 +131,14 @@ impl PersistentHandle {
     }
 }
 
+impl Clone for PersistentHandle {
+    fn clone(&self) -> Self {
+        PersistentHandle {
+            ptr: unsafe { neon_runtime::mem::clone_persistent(self.ptr) },
+        }
+    }
+}
+
 impl Drop for PersistentHandle {
     fn drop(&mut self) {
         unsafe { neon_runtime::mem::delete_persistent(self.ptr) }


### PR DESCRIPTION
I plan to write up an RFC, but I thought I would put the code up to solicit feedback since I've already implemented it.

Create a `PersistentHandle` type that can hold references to managed v8 objects. The `PersistentHandle` stores a pointer to a `Nan::Persistent<v8::Value>` object. Since the underlying pointer references heap memory, the pointer can be safely passed between threads. A `Drop` trait implementation ensures that the v8 reference is cleared using `Reset()` and the memory is deallocated. There's also a `Clone` implementation that allows cloning the underlying reference. **Note:** The `Clone` trait only borrows `&self`, but I am unsure if `Reset(Nan::Persistent)` is thread-safe or not.
