### PR TITLE
Use `node::MakeCallback` instead of calling a method directly on Task callbacks

### DIFF
--- a/crates/neon-runtime/src/neon_task.h
+++ b/crates/neon-runtime/src/neon_task.h
@@ -59,7 +59,9 @@ public:
     }
 
     v8::Local<v8::Function> callback = v8::Local<v8::Function>::New(isolate_, callback_);
-    callback->Call(context, v8::Null(isolate_), 2, argv);
+    node::MakeCallback(isolate_, context->Global(), callback, 2, argv);
+    callback_.Reset();
+    context_.Reset();
   }
 
   void *get_result() {

--- a/test/dynamic/lib/tasks.js
+++ b/test/dynamic/lib/tasks.js
@@ -27,4 +27,16 @@ describe('Task', function() {
       }
     });
   });
+
+  it('executes microtasks after callback', function () {
+    return new Promise((resolve, reject) => {
+      addon.perform_async_task((err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
Also, fixes memory leak in Task API.

* Ensures `nextTick` is processed
* Captures the error domain
* Fixes #289

This is how handles callbacks on async tasks.

1. [`Nan::Callback` created to queue task](https://github.com/nodejs/nan/blob/b2455ac52e97568456089c5658bbd64a016112b8/examples/async_pi_estimate/async.cc#L61)
1. [`Nan::Callback` tracked by `AsyncWorker`](https://github.com/nodejs/nan/blob/b2455ac52e97568456089c5658bbd64a016112b8/nan.h#L1506)
1. [`node::MakeCallback` used to execute `nan::Callback`](https://github.com/nodejs/nan/blob/b2455ac52e97568456089c5658bbd64a016112b8/nan.h#L1478-L1484)
  