### PR TITLE
Minor incompatible changes from RFC 22

### DIFF
--- a/crates/neon-runtime/src/call.rs
+++ b/crates/neon-runtime/src/call.rs
@@ -43,11 +43,6 @@ extern "C" {
     pub fn this(info: &FunctionCallbackInfo, out: &mut Local);
 
     /// Mutates the `out` argument provided to refer to the `v8::Local` handle value of the
-    /// currently executing function.
-    #[link_name = "Neon_Call_Callee"]
-    pub fn callee(info: &FunctionCallbackInfo, out: &mut Local) -> bool;
-
-    /// Mutates the `out` argument provided to refer to the `v8::Local` handle value of the
     /// `v8::FunctionCallbackInfo` `Data`.
     #[link_name = "Neon_Call_Data"]
     pub fn data(info: &FunctionCallbackInfo, out: &mut Local);

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -436,18 +436,6 @@ extern "C" bool Neon_Fun_Construct(v8::Local<v8::Object> *out, v8::Isolate *isol
   return maybe_result.ToLocal(out);
 }
 
-extern "C" tag_t Neon_Tag_Of(v8::Local<v8::Value> val) {
-  return val->IsNull()                    ? tag_null
-    : val->IsUndefined()                  ? tag_undefined
-    : (val->IsTrue() || val->IsFalse())   ? tag_boolean
-    : val->IsNumber()                     ? tag_number
-    : val->IsString()                     ? tag_string
-    : val->IsArray()                      ? tag_array
-    : val->IsFunction()                   ? tag_function
-    : val->IsObject()                     ? tag_object
-                                          : tag_other;
-}
-
 extern "C" bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val) {
   return val->IsUndefined();
 }

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -85,11 +85,6 @@ extern "C" bool Neon_Primitive_BooleanValue(v8::Local<v8::Boolean> p) {
   return p->Value();
 }
 
-// DEPRECATE(0.2)
-extern "C" void Neon_Primitive_Integer(v8::Local<v8::Integer> *out, v8::Isolate *isolate, int32_t x) {
-  *out = v8::Integer::New(isolate, x);
-}
-
 extern "C" void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value) {
   *out = v8::Number::New(isolate, value);
 }
@@ -104,11 +99,6 @@ extern "C" bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p) {
 
 extern "C" bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p) {
   return p->IsInt32();
-}
-
-// DEPRECATE(0.2)
-extern "C" int64_t Neon_Primitive_IntegerValue(v8::Local<v8::Integer> i) {
-  return i->Value();
 }
 
 extern "C" bool Neon_Object_Get_Index(v8::Local<v8::Value> *out, v8::Local<v8::Object> obj, uint32_t index) {
@@ -450,8 +440,6 @@ extern "C" tag_t Neon_Tag_Of(v8::Local<v8::Value> val) {
   return val->IsNull()                    ? tag_null
     : val->IsUndefined()                  ? tag_undefined
     : (val->IsTrue() || val->IsFalse())   ? tag_boolean
-    // DEPRECATE(0.2)
-    : (val->IsInt32() || val->IsUint32()) ? tag_integer
     : val->IsNumber()                     ? tag_number
     : val->IsString()                     ? tag_string
     : val->IsArray()                      ? tag_array
@@ -466,11 +454,6 @@ extern "C" bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val) {
 
 extern "C" bool Neon_Tag_IsNull(v8::Local<v8::Value> val) {
   return val->IsNull();
-}
-
-// DEPRECATE(0.2)
-extern "C" bool Neon_Tag_IsInteger(v8::Local<v8::Value> val) {
-  return val->IsInt32() || val->IsUint32();
 }
 
 extern "C" bool Neon_Tag_IsNumber(v8::Local<v8::Value> val) {

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -29,15 +29,6 @@ extern "C" void Neon_Call_This(v8::FunctionCallbackInfo<v8::Value> *info, v8::Lo
   *out = info->This();
 }
 
-extern "C" bool Neon_Call_Callee(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Function> *out) {
-#if NODE_MAJOR_VERSION < 10
-  *out = info->Callee();
-  return true;
-#else
-  return false;
-#endif
-}
-
 extern "C" void Neon_Call_Data(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Value> *out) {
   /*
   printf("Call_Data: v8 info  = %p\n", *(void **)info);

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -18,7 +18,6 @@ extern "C" {
   void *Neon_Call_CurrentIsolate();
   bool Neon_Call_IsConstruct(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_This(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out);
-  bool Neon_Call_Callee(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Function> *out);
   void Neon_Call_Data(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Value> *out);
   int32_t Neon_Call_Length(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -10,8 +10,6 @@ typedef enum {
   tag_null,
   tag_undefined,
   tag_boolean,
-  // DEPRECATE(0.2)
-  tag_integer,
   tag_number,
   tag_string,
   tag_object,
@@ -38,16 +36,12 @@ extern "C" {
   int32_t Neon_Call_Length(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);
 
-  // DEPRECATE(0.2)
-  void Neon_Primitive_Integer(v8::Local<v8::Integer> *out, v8::Isolate *isolate, int32_t x);
   void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value);
   void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out);
   void Neon_Primitive_Null(v8::Local<v8::Primitive> *out);
   void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, bool b);
   bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p);
   bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p);
-  // DEPRECATE(0.2)
-  int64_t Neon_Primitive_IntegerValue(v8::Local<v8::Integer> i);
 
   void Neon_Object_New(v8::Local<v8::Object> *out);
   bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Local<v8::Object> obj);
@@ -132,8 +126,6 @@ extern "C" {
   bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val);
   bool Neon_Tag_IsNull(v8::Local<v8::Value> val);
   bool Neon_Tag_IsBoolean(v8::Local<v8::Value> val);
-  // DEPRECATE(0.2)
-  bool Neon_Tag_IsInteger(v8::Local<v8::Value> val);
   bool Neon_Tag_IsNumber(v8::Local<v8::Value> val);
   bool Neon_Tag_IsString(v8::Local<v8::Value> val);
   bool Neon_Tag_IsObject(v8::Local<v8::Value> val);

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -5,19 +5,6 @@
 #include <stdint.h>
 #include <v8.h>
 
-// analog Rust enum `Tag` defined in lib.rs
-typedef enum {
-  tag_null,
-  tag_undefined,
-  tag_boolean,
-  tag_number,
-  tag_string,
-  tag_object,
-  tag_array,
-  tag_function,
-  tag_other
-} tag_t;
-
 // corresponding Rust struct `CCallback` defined in fun.rs
 typedef struct {
   void* static_callback;
@@ -122,7 +109,6 @@ extern "C" {
 
   uint32_t Neon_Module_GetVersion();
 
-  tag_t Neon_Tag_Of(v8::Local<v8::Value> val);
   bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val);
   bool Neon_Tag_IsNull(v8::Local<v8::Value> val);
   bool Neon_Tag_IsBoolean(v8::Local<v8::Value> val);

--- a/crates/neon-runtime/src/tag.rs
+++ b/crates/neon-runtime/src/tag.rs
@@ -2,26 +2,7 @@
 
 use raw::Local;
 
-// analog C enum `tag_t` defined in neon.h
-#[repr(C)]
-#[derive(PartialEq, Eq)]
-pub enum Tag {
-    Null,
-    Undefined,
-    Boolean,
-    Number,
-    String,
-    Object,
-    Array,
-    Function,
-    Other
-}
-
 extern "C" {
-
-    /// Returns the `Tag` of the value provided.
-    #[link_name = "Neon_Tag_Of"]
-    pub fn of(val: Local) -> Tag;
 
     /// Indicates if the value type is `Undefined`.
     #[link_name = "Neon_Tag_IsUndefined"]

--- a/crates/neon-runtime/src/tag.rs
+++ b/crates/neon-runtime/src/tag.rs
@@ -9,8 +9,6 @@ pub enum Tag {
     Null,
     Undefined,
     Boolean,
-    // DEPRECATE(0.2)
-    Integer,
     Number,
     String,
     Object,
@@ -32,11 +30,6 @@ extern "C" {
     /// Indicates if the value type is `Null`.
     #[link_name = "Neon_Tag_IsNull"]
     pub fn is_null(val: Local) -> bool;
-
-    // DEPRECATE(0.2)
-    /// Indicates if the value type is `Integer`.
-    #[link_name = "Neon_Tag_IsInteger"]
-    pub fn is_integer(val: Local) -> bool;
 
     /// Indicates if the value type is `Number`.
     #[link_name = "Neon_Tag_IsNumber"]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -316,17 +316,6 @@ impl CallbackInfo {
             local
         }
     }
-
-    pub fn callee<'a, C: Context<'a>>(&self, _: &mut C) -> Handle<'a, JsFunction> {
-        unsafe {
-            let mut local: raw::Local = mem::zeroed();
-            if neon_runtime::call::callee(mem::transmute(&self.info), &mut local) {
-                Handle::new_internal(JsFunction::from_raw(local))
-            } else {
-                panic!("Arguments::callee() is not supported in Node >= 10")
-            }
-        }
-    }
 }
 
 /// The trait of types that can be a function's `this` binding.
@@ -689,11 +678,6 @@ impl<'a, T: This> CallContext<'a, T> {
     /// Produces a handle to the `this`-binding.
     pub fn this(&mut self) -> Handle<'a, T> {
         Handle::new_internal(T::as_this(self.info.this(self)))
-    }
-
-    /// Produces a handle to this function.
-    pub fn callee(&mut self) -> Handle<'a, JsFunction> {
-        self.info.callee(self)
     }
 }
 

--- a/test/dynamic/lib/functions.js
+++ b/test/dynamic/lib/functions.js
@@ -62,13 +62,6 @@ describe('JsFunction', function() {
     assert.equal(addon.return_this.call(undefined), global);
   });
 
-  it('returns its own function', function() {
-    // callee dynamically fails in Node >= 10, so only test it in older Nodes
-    if (process.versions.node.substring(0, process.versions.node.indexOf('.')) < 10) {
-      assert.equal(addon.return_callee(), addon.return_callee);
-    }
-  });
-
   it('exposes an argument via arguments_opt iff it is there', function() {
     assert.equal(addon.is_argument_zero_some(), false);
     assert.equal(addon.is_argument_zero_some('a'), true);

--- a/test/dynamic/lib/numbers.js
+++ b/test/dynamic/lib/numbers.js
@@ -22,11 +22,6 @@ describe('JsNumber', function() {
     assert.equal(addon.return_negative_float_js_number(), -1.4747);
   });
 
-  // DEPRECATE(0.2)
-  it('return a JsInteger built in Rust', function () {
-    assert.equal(addon.return_js_integer(), 17);
-  });
-
   describe('round trips', function () {
     it('accept and return a number', function () {
       assert.equal(addon.accept_and_return_js_number(1), 1);
@@ -50,11 +45,6 @@ describe('JsNumber', function() {
 
     it('accept and return a negative number as a JsNumber', function () {
       assert.equal(addon.accept_and_return_negative_js_number(-55), -55);
-    });
-
-    // DEPRECATE(0.2)
-    it('accept and return an integer as a JsInteger', function () {
-      assert.equal(addon.accept_and_return_js_integer(42), 42);
     });
   });
 

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -70,11 +70,6 @@ pub fn require_object_this(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     Ok(cx.undefined())
 }
 
-pub fn return_callee(mut cx: FunctionContext) -> JsResult<JsFunction> {
-    let f = cx.callee();
-    Ok(f)
-}
-
 pub fn is_argument_zero_some(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let b = cx.argument_opt(0).is_some();
     Ok(cx.boolean(b))

--- a/test/dynamic/native/src/js/numbers.rs
+++ b/test/dynamic/native/src/js/numbers.rs
@@ -1,5 +1,5 @@
 use neon::vm::{FunctionContext, JsResult, Context};
-use neon::js::{JsNumber, JsInteger};
+use neon::js::JsNumber;
 use neon::mem::Handle;
 
 pub fn return_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
@@ -22,11 +22,6 @@ pub fn return_negative_float_js_number(mut cx: FunctionContext) -> JsResult<JsNu
     Ok(cx.number(-1.4747_f64))
 }
 
-// DEPRECATE(0.2)
-pub fn return_js_integer(mut cx: FunctionContext) -> JsResult<JsInteger> {
-    Ok(JsInteger::new(&mut cx, 17))
-}
-
 pub fn accept_and_return_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let number: Handle<JsNumber> = cx.argument(0)?;
     Ok(number)
@@ -45,10 +40,4 @@ pub fn accept_and_return_float_js_number(mut cx: FunctionContext) -> JsResult<Js
 pub fn accept_and_return_negative_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let number: Handle<JsNumber> = cx.argument(0)?;
     Ok(number)
-}
-
-// DEPRECATE(0.2)
-pub fn accept_and_return_js_integer(mut cx: FunctionContext) -> JsResult<JsInteger> {
-    let x: Handle<JsInteger> = cx.argument(0)?;
-    Ok(x)
 }

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -57,7 +57,6 @@ register_module!(mut cx, {
     cx.export_function("num_arguments", num_arguments)?;
     cx.export_function("return_this", return_this)?;
     cx.export_function("require_object_this", require_object_this)?;
-    cx.export_function("return_callee", return_callee)?;
     cx.export_function("is_argument_zero_some", is_argument_zero_some)?;
     cx.export_function("require_argument_zero_string", require_argument_zero_string)?;
     cx.export_function("execute_scoped", execute_scoped)?;

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -27,14 +27,10 @@ register_module!(mut cx, {
     cx.export_function("return_negative_js_number", return_negative_js_number)?;
     cx.export_function("return_float_js_number", return_float_js_number)?;
     cx.export_function("return_negative_float_js_number", return_negative_float_js_number)?;
-    // DEPRECATE(0.2)
-    cx.export_function("return_js_integer", return_js_integer)?;
     cx.export_function("accept_and_return_js_number", accept_and_return_js_number)?;
     cx.export_function("accept_and_return_large_js_number", accept_and_return_large_js_number)?;
     cx.export_function("accept_and_return_float_js_number", accept_and_return_float_js_number)?;
     cx.export_function("accept_and_return_negative_js_number", accept_and_return_negative_js_number)?;
-    // DEPRECATE(0.2)
-    cx.export_function("accept_and_return_js_integer", accept_and_return_js_integer)?;
 
     cx.export_function("return_js_array", return_js_array)?;
     cx.export_function("return_js_array_with_number", return_js_array_with_number)?;


### PR DESCRIPTION
Implements all minor changes from [RFC 22](https://github.com/neon-bindings/rfcs/pull/22) ("incompatible changes for Neon 0.2") that don't have their own separate RFC:
- Eliminate `JsInteger`
- Eliminate `Variant`
- Rename `Key` to `PropertyKey` and `get`/`set` to `get_from`/`set_from`
- Eliminate `callee()`