### PR TITLE
Default to release builds

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -149,15 +149,10 @@ const spec: Spec = {
     }, {
       header: "Options",
       optionList: [{
-        name: "rust",
+        name: "release",
         alias: "r",
-        type: channel,
-        description: "Rust channel (default, nightly, beta, or stable). [default: default]"
-      }, {
-        name: "debug",
-        alias: "d",
         type: Boolean,
-        description: "Debug build."
+        description: "Release build."
       }, {
         name: "path",
         alias: "p",
@@ -178,9 +173,7 @@ const spec: Spec = {
       for (let module of modules) {
         logIf(multiple, "building", this.cwd, module);
 
-        await neon_build(module,
-                         options.rust as Toolchain,
-                         !options.debug);
+        await neon_build(module, this.toolchain, !!options.release);
       }
     }
   },
@@ -245,11 +238,19 @@ const spec: Spec = {
 };
 
 export default class CLI {
+  readonly toolchain: Toolchain | null;
   readonly argv: string[];
   readonly cwd: string;
 
   constructor(argv: string[], cwd: string) {
-    this.argv = argv.slice(2);
+    // Check for a toolchain argument in the style of Rust tools (e.g., `neon +nightly build`).
+    if (argv.length > 2 && argv[2].trim().startsWith('+')) {
+      this.toolchain = argv[2].substring(1).trim();
+      this.argv = argv.slice(3);
+    } else {
+      this.toolchain = null;
+      this.argv = argv.slice(2);
+    }
     this.cwd = cwd;
   }
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -15,13 +15,6 @@ import { Toolchain } from './rust';
 
 let metadata = JSON.loadSync(path.resolve(__dirname, '..', 'package.json'));
 
-function channel(value: string) {
-  if (['default', 'nightly', 'beta', 'stable'].indexOf(value) < 0) {
-    throw new Error("Expected one of 'default', 'nightly', 'beta', or 'stable', got '" + value + "'");
-  }
-  return value;
-}
-
 function commandUsage(command: string) {
   if (!spec[command]) {
     let e = new Error();
@@ -134,9 +127,8 @@ const spec: Spec = {
   },
 
   build: {
-    args: [{ name: "debug", alias: "d", type: Boolean },
+    args: [{ name: "release", alias: "r", type: Boolean },
            { name: "path", alias: "p", type: Boolean },
-           { name: "rust", alias: "r", type: channel, defaultValue: "default" },
            { name: "modules", type: String, multiple: true, defaultOption: true },
            { name: "help", alias: "h", type: Boolean }],
     usage: [{

--- a/cli/src/ops/neon_build.ts
+++ b/cli/src/ops/neon_build.ts
@@ -2,7 +2,7 @@ import Project from '../project';
 import * as rust from '../rust';
 
 export default async function neon_build(root: string,
-                                         toolchain: rust.Toolchain,
+                                         toolchain: rust.Toolchain | null,
                                          release: boolean) {
   let project = new Project(root);
   await project.build(toolchain, release);

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -21,11 +21,11 @@ export default class Project {
     this.crate = new Crate(this, { subdirectory: crate });
   }
 
-  async build(toolchain: rust.Toolchain,
+  async build(toolchain: rust.Toolchain | null,
               release: boolean)
   {
     let target = new Target(this.crate, { release: release });
-    let settings = BuildSettings.current(toolchain);
+    let settings = BuildSettings.current(toolchain || 'default');
 
     // 1. Force a rebuild if build settings have changed.
     if (!target.inState(settings)) {

--- a/cli/src/rust.ts
+++ b/cli/src/rust.ts
@@ -1,15 +1,15 @@
 import * as async from './async/child_process';
 import * as child_process from 'child_process';
 
-export type Toolchain = 'default' | 'nightly' | 'beta' | 'stable';
+export type Toolchain = string;
 
-function toolchainPrefix(toolchain: Toolchain) {
-  return toolchain === 'default' ? [] : ["+" + toolchain];
+function toolchainPrefix(toolchain: Toolchain | null) {
+  return toolchain ? ["+" + toolchain] : [];
 }
 
 export function spawnSync(tool: string,
                           args: string[],
-                          toolchain: Toolchain = 'default',
+                          toolchain: Toolchain | null,
                           options?: child_process.SpawnOptions)
 {
   return child_process.spawnSync(tool, toolchainPrefix(toolchain).concat(args), options);
@@ -17,7 +17,7 @@ export function spawnSync(tool: string,
 
 export function spawn(tool: string,
                       args: string[],
-                      toolchain: Toolchain = 'default',
+                      toolchain: Toolchain | null,
                       options?: child_process.SpawnOptions)
 {
   return async.spawn(tool, toolchainPrefix(toolchain).concat(args), options);

--- a/cli/src/target.ts
+++ b/cli/src/target.ts
@@ -70,7 +70,7 @@ export default class Target {
     this.crate.saveArtifacts();
   }
 
-  async build(toolchain: rust.Toolchain,
+  async build(toolchain: rust.Toolchain | null,
               settings: BuildSettings)
   {
     let macos = process.platform === 'darwin';

--- a/test/cli/src/acceptance/help.ts
+++ b/test/cli/src/acceptance/help.ts
@@ -102,8 +102,7 @@ function testHelpBuild(proc: SpawnChain, done: () => void) {
     .wait("$ neon build [options]")
     .wait("$ neon build [options] module ...")
     .wait("Options")
-    .wait("-r, --rust")
-    .wait("-d, --debug")
+    .wait("-r, --release")
     .wait("-p, --path")
     .run(err => {
       if (err) throw err;

--- a/test/dynamic/package.json
+++ b/test/dynamic/package.json
@@ -6,7 +6,7 @@
   "author": "The Neon Community",
   "license": "MIT",
   "scripts": {
-    "install": "node ../../cli/bin/cli.js build",
+    "install": "node ../../cli/bin/cli.js build --release",
     "test": "mocha --recursive lib"
   },
   "devDependencies": {


### PR DESCRIPTION
And take Rust toolchain in the Cargo syntax (e.g., `neon +nightly build`).