### PR TITLE
`JsBuffer::new()` always produces a zeroed buffer.

### DIFF
--- a/crates/neon-runtime/src/buffer.rs
+++ b/crates/neon-runtime/src/buffer.rs
@@ -5,10 +5,15 @@ use std::os::raw::c_void;
 
 extern "C" {
 
-    /// Mutates the `out` argument provided to refer to a newly created `node::Buffer` object.
+    /// Mutates the `out` argument provided to refer to a newly created and zero-filled `node::Buffer` object.
     /// Returns `false` if the value couldn't be created.
     #[link_name = "Neon_Buffer_New"]
     pub fn new(out: &mut Local, size: u32) -> bool;
+
+    /// Mutates the `out` argument provided to refer to a newly created `node::Buffer` object.
+    /// Returns `false` if the value couldn't be created.
+    #[link_name = "Neon_Buffer_Uninitialized"]
+    pub fn uninitialized(out: &mut Local, size: u32) -> bool;
 
     /// Mutates the `base_out` and `size_out` arguments to access the data of a `node::Buffer` object.
     #[link_name = "Neon_Buffer_Data"]

--- a/crates/neon-runtime/src/neon.cc
+++ b/crates/neon-runtime/src/neon.cc
@@ -179,6 +179,17 @@ extern "C" bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::
 
 extern "C" bool Neon_Buffer_New(v8::Local<v8::Object> *out, uint32_t size) {
   Nan::MaybeLocal<v8::Object> maybe = Nan::NewBuffer(size);
+  if (!maybe.ToLocal(out)) {
+    return false;
+  }
+
+  void *data = node::Buffer::Data(*out);
+  memset(data, 0, size);
+  return true;
+}
+
+extern "C" bool Neon_Buffer_Uninitialized(v8::Local<v8::Object> *out, uint32_t size) {
+  Nan::MaybeLocal<v8::Object> maybe = Nan::NewBuffer(size);
   return maybe.ToLocal(out);
 }
 

--- a/crates/neon-runtime/src/neon.h
+++ b/crates/neon-runtime/src/neon.h
@@ -53,6 +53,7 @@ extern "C" {
   void Neon_Buffer_Data(void **base_out, size_t *len_out, v8::Local<v8::Object> obj);
 
   bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
+  bool Neon_ArrayBuffer_Uninitialized(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
   void Neon_ArrayBuffer_Data(void **base_out, size_t *len_out, v8::Local<v8::ArrayBuffer> buffer);
 
   typedef void(*Neon_ChainedScopeCallback)(void *, void *, void *, void *);

--- a/src/value/binary.rs
+++ b/src/value/binary.rs
@@ -20,9 +20,14 @@ pub struct JsBuffer(raw::Local);
 
 impl JsBuffer {
 
-    /// Constructs a new `Buffer` object.
+    /// Constructs a new `Buffer` object, safely zero-filled.
     pub fn new<'a, C: Context<'a>>(_: &mut C, size: u32) -> JsResult<'a, JsBuffer> {
         build(|out| { unsafe { neon_runtime::buffer::new(out, size) } })
+    }
+
+    /// Constructs a new `Buffer` object, safely zero-filled.
+    pub unsafe fn uninitialized<'a, C: Context<'a>>(_: &mut C, size: u32) -> JsResult<'a, JsBuffer> {
+        build(|out| { neon_runtime::buffer::uninitialized(out, size) })
     }
 
 }


### PR DESCRIPTION
`JsBuffer::uninitialized()` produces a non-zero-filled buffer but is marked `unsafe`.