### PR TITLE
Task trait should be marked 'static. Fixes #288.

### DIFF
--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -12,12 +12,12 @@ use neon_runtime;
 use neon_runtime::raw;
 
 /// A Rust task that can be executed in a background thread.
-pub trait Task: Send + Sized {
+pub trait Task: Send + Sized + 'static {
     /// The task's result type, which is sent back to the main thread to communicate a successful result back to JavaScript.
-    type Output: Send;
+    type Output: Send + 'static;
 
     /// The task's error type, which is sent back to the main thread to communicate a task failure back to JavaScript.
-    type Error: Send;
+    type Error: Send + 'static;
 
     /// The type of JavaScript value that gets produced to the asynchronous callback on the main thread after the task is completed.
     type JsEvent: Value;


### PR DESCRIPTION
The same applies here.

> The 'static constraint means that the closure and its return value must have a lifetime of the whole program execution. The reason for this is that threads can detach and outlive the lifetime they have been created in. Indeed if the thread, and by extension its return value, can outlive their caller, we need to make sure that they will be valid afterwards, and since we can't know when it will return we need to have them valid as long as possible, that is until the end of the program, hence the 'static lifetime.

https://doc.rust-lang.org/std/thread/fn.spawn.html