### PR TITLE
Add artifacts.json and index.node to exclude

### DIFF
--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -8,6 +8,7 @@ authors = ["{{project.author}}{{#if project.email}} <{{project.email}}>{{/if}}"]
 license = "{{project.license}}"
 {{/if}}
 build = "build.rs"
+exclude = ["artifacts.json", "index.node"]
 
 [lib]
 name = "{{project.name.cargo.internal}}"


### PR DESCRIPTION
This can be removed if workspaces are implemented and the .gitignore file is accurately picked up (https://github.com/neon-bindings/rfcs/pull/4).