### PR TITLE
Revert `neon::thread` back to `neon::task`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod types;
 pub mod object;
 pub mod borrow;
 pub mod result;
-pub mod thread;
+pub mod task;
 pub mod meta;
 pub mod prelude;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,4 +6,4 @@ pub use object::{Object, Class};
 pub use borrow::{Borrow, BorrowMut};
 pub use context::{CallKind, Context, ModuleContext, ExecuteContext, ComputeContext, CallContext, FunctionContext, MethodContext, TaskContext};
 pub use result::{NeonResult, JsResult, JsResultExt};
-pub use thread::Task;
+pub use task::Task;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,4 +1,4 @@
-//! Asynchronous access to multithreaded computation in a Node plugin.
+//! Asynchronous background _tasks_ that run in the Node thread pool.
 
 use std::marker::{Send, Sized};
 use std::mem;


### PR DESCRIPTION
Per the final version of the RFC.