### PR TITLE
Fixed crate type

### DIFF
--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -12,7 +12,7 @@ exclude = ["artifacts.json", "index.node"]
 
 [lib]
 name = "{{project.name.cargo.internal}}"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [build-dependencies]
 neon-build = "0.2.0"


### PR DESCRIPTION
The proper crate type should be "cdylib" not "dylib" because "dylib" produces an extra dependency from `libstd.so` which cannot be resolved at runtime in common case.

With "dylib":
```
$ ldd native/index.node
        linux-vdso.so.1 (0x00007fff3cd1b000)
        libstd-0cce0e0e34e933aa.so => not found
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007ff4cc07c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ff4cbcdd000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ff4cc545000)
```

The "not found" means the problems with module loading by node:

```
$ node
> require("./")
Error: libstd-0cce0e0e34e933aa.so: cannot open shared object file: No such file or directory
    at Object.Module._extensions..node (module.js:681:18)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
```

With "cdylib":
```
$ ldd native/index.node                                                                
        linux-vdso.so.1 (0x00007ffcc1dc0000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f6ddae13000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f6ddac0b000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f6dda9ee000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6dda7d7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6dda438000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f6ddb25c000)
```

```
$ nodejs                                                                               
> require("./")
hello node
{}
```