### PR TITLE
Fix build failure

### DIFF
--- a/crates/neon-runtime/package.json
+++ b/crates/neon-runtime/package.json
@@ -7,11 +7,9 @@
     "build-release": "node-gyp build",
     "build-debug": "node-gyp build --debug"
   },
-  "devDependencies": {
-    "nan": "^2.10.0"
-  },
   "dependencies": {
     "bindings": "1.2.1",
-    "node-gyp": "^3.5.0"
+    "node-gyp": "^3.5.0",
+    "nan": "^2.10.0"
   }
 }


### PR DESCRIPTION
On MacOS and some Linux distro's the build failure caused by a devDependendy that should have been a dependency seems to be fixed by this commit, as outlined [here](https://github.com/neon-bindings/neon/issues/340#issuecomment-406991368).