### PR TITLE
Fix for release builds (issue #362)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ macro_rules! register_module {
         #[cfg_attr(target_os = "linux", link_section = ".ctors")]
         #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
         #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
+        #[used]
         pub static __LOAD_NEON_MODULE: extern "C" fn() = {
             fn __init_neon_module($module: $crate::context::ModuleContext) -> $crate::result::NeonResult<()> $init
 


### PR DESCRIPTION
During link-time optimization (particularly when you build with --release)
linker removes unused static symbol `__LOAD_NEON_MODULE`.

I forced it to be used to avoid such incorrect behavior.