### PR TITLE
On Windows, build the C code in release mode always.

### DIFF
--- a/crates/neon-sys/native/binding.gyp
+++ b/crates/neon-sys/native/binding.gyp
@@ -13,6 +13,15 @@
                         'LinkTimeCodeGeneration': 0
                     }
                 }
+            },
+            'Debug': {
+                'msvs_settings': {
+                    'VCCLCompilerTool': {
+                        'RuntimeLibrary': '0',
+                        'UndefinePreprocessorDefinitions': ['DEBUG', '_DEBUG'],
+                        'PreprocessorDefinitions': ['NDEBUG']
+                    },
+                }
             }
         }
     }]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,9 +352,6 @@ macro_rules! neon_stringify {
     }
 }
 
-#[cfg(all(windows, not(neon_profile = "release")))]
-compile_error!("Neon only builds with --release. For tests, try `cargo test --release`.");
-
 #[cfg(test)]
 mod tests {
     extern crate rustversion;


### PR DESCRIPTION
Rust always uses the release CRT, even in debug mode, so the C code should do the same.

Fixes https://github.com/neon-bindings/neon/issues/357