### PR TITLE
Use delayed loading for windows

### DIFF
--- a/README ELECTRON 4.md
+++ b/README ELECTRON 4.md
@@ -2,7 +2,7 @@ Electron 4 and windows
 ======================
 
 
-*** only tested with hello world, not yet with a real life project, though it should be no different, it's just a hook ***
+*** Only tested with hello world, not yet with a real life project, though it should be no different, it's just a hook ***
 ----------------------------------------------------------------------
 
 Electron 4 uses delayed loading to circumvent the need to name the executable node.exe. See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
@@ -13,12 +13,12 @@ The hook used is the same as node-gyp uses. It is build with the neon runtime. T
 
 ```
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:__load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
+rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
 ```
 
 **the cli has been patched to do this**
 
-A few far from obvious (to me) things happen here. The (patched) neon-runtime library contains the hook. For the linker to find the related symbols and use those in creating the hook they must be explicitly included. The windows library with the helpers, `delayimp.lib`, must be included as well, but it must be included AFTER the library with the hook. Thus we simply add it to the linker flags, adding it sooner, eg with `cargo:rustc-link-lib=delayimp` makes it add a default hook that does nothing and results in a duplicate symbol warning for our `_pfnDliNotifyHook2`.
+A few far from obvious (to me) things happen here. The (patched) neon-runtime library contains the hook. For the linker to find the related symbol and use it in creating the hook it must be explicitly included. The windows library with the helpers, `delayimp.lib`, must be included as well, but it must be included AFTER the library with the hook. Thus we simply add it to the linker flags, adding it sooner, eg with `cargo:rustc-link-lib=delayimp` makes it add a default hook that does nothing and results in a duplicate symbol warning for our `_pfnDliNotifyHook2`.
 
 If you're using version 0.2.0 of neon that doesn't have this patch, it is possible to build the hook in your own project (first create the .cargo/config file as mentioned above):
 

--- a/README ELECTRON 4.md
+++ b/README ELECTRON 4.md
@@ -1,6 +1,10 @@
 Electron 4 and windows
 ======================
 
+
+*** only tested with hello world, not yet with a real life project ***
+----------------------------------------------------------------------
+
 Electron 4 uses delayed loading to circumvent the need to name the exectutable node.exe. See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
 
 The library build with neon therefore must be build with delayed loading. This slightly complicates the build process.

--- a/README ELECTRON 4.md
+++ b/README ELECTRON 4.md
@@ -7,18 +7,18 @@ Electron 4 and windows
 
 Electron 4 uses delayed loading to circumvent the need to name the executable node.exe. See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
 
-The library build with neon therefore must be build with delayed loading. This slightly complicates the build process.
+Therefore the library build with neon must be build with delayed loading. This slightly complicates the build process.
 
 The hook used is the same as node-gyp uses. It is build with the neon runtime. To add the hook to the resulting dynamic library a `.cargo/config` file must be made with the following contents to make the linker jump through the right hoops.
 
 ```
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
+rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:__load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
 ```
 
-**cli has been patched to do this**
+**the cli has been patched to do this**
 
-A few far from obvious (to me) things happen here. The (patched) neon-runtime library contains the hook, but for the linker to find the symbols and use them for creating the hook they must be included. The library with the hook `delayimp.lib` must be included as well, but it must be included AFTER the library with the hook. Thus we simply add it to the linker flags, adding it sooner, eg with `cargo:rustc-link-lib=delayimp` makes it add a default hook that does nothing and results in a duplicate symbol warning for our `_pfnDliNotifyHook2`.
+A few far from obvious (to me) things happen here. The (patched) neon-runtime library contains the hook. For the linker to find the related symbols and use those in creating the hook they must be explicitly included. The windows library with the helpers, `delayimp.lib`, must be included as well, but it must be included AFTER the library with the hook. Thus we simply add it to the linker flags, adding it sooner, eg with `cargo:rustc-link-lib=delayimp` makes it add a default hook that does nothing and results in a duplicate symbol warning for our `_pfnDliNotifyHook2`.
 
 If you're using version 0.2.0 of neon that doesn't have this patch, it is possible to build the hook in your own project (first create the .cargo/config file as mentioned above):
 

--- a/README ELECTRON 4.md
+++ b/README ELECTRON 4.md
@@ -2,17 +2,17 @@ Electron 4 and windows
 ======================
 
 
-*** only tested with hello world, not yet with a real life project ***
+*** only tested with hello world, not yet with a real life project, though it should be no different, it's just a hook ***
 ----------------------------------------------------------------------
 
-Electron 4 uses delayed loading to circumvent the need to name the exectutable node.exe. See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
+Electron 4 uses delayed loading to circumvent the need to name the executable node.exe. See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
 
 The library build with neon therefore must be build with delayed loading. This slightly complicates the build process.
 
 The hook used is the same as node-gyp uses. It is build with the neon runtime. To add the hook to the resulting dynamic library a `.cargo/config` file must be made with the following contents to make the linker jump through the right hoops.
 
 ```
-[build]
+[target.'cfg(windows)']
 rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
 ```
 
@@ -48,4 +48,4 @@ neon-build = "0.2.0"
 cc = "1.0"
 ```
 
-Have fun using neon with electron 4 (and hopefully up) in electron!
+Have fun using neon with electron 4 (and hopefully up) in windows!

--- a/README ELECTRON 4.md
+++ b/README ELECTRON 4.md
@@ -16,7 +16,7 @@ The hook used is the same as node-gyp uses. It is build with the neon runtime. T
 rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
 ```
 
-**neon cli should be patched to do this**
+**cli has been patched to do this**
 
 A few far from obvious (to me) things happen here. The (patched) neon-runtime library contains the hook, but for the linker to find the symbols and use them for creating the hook they must be included. The library with the hook `delayimp.lib` must be included as well, but it must be included AFTER the library with the hook. Thus we simply add it to the linker flags, adding it sooner, eg with `cargo:rustc-link-lib=delayimp` makes it add a default hook that does nothing and results in a duplicate symbol warning for our `_pfnDliNotifyHook2`.
 

--- a/README ELECTRON 4.md
+++ b/README ELECTRON 4.md
@@ -1,0 +1,39 @@
+Electron 4 and windows
+======================
+
+Electron 4 uses delayed loading to circumvent the need to name the exectutable node.exe. See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
+
+The library build with neon therefore must be build with delayed loading. This slightly complicates the build process.
+
+The hook used is the same as node-gyp uses. It is build with the neon runtime. To add the hook to the resulting dynamic library a `.cargo/config` file must be made with the following contents to make the linker jump through the right hoops.
+
+```
+[build]
+rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
+```
+
+**neon cli should be patched to do this**
+
+A few far from obvious (to me) things happen here. The (patched) neon-runtime library contains the hook, but for the linker to find the symbols and use them for creating the hook they must be included. The library with the hook `delayimp.lib` must be included as well, but it must be included AFTER the library with the hook. Thus we simply add it to the linker flags, adding it sooner, eg with `cargo:rustc-link-lib=delayimp` makes it add a default hook that does nothing and results in a duplicate symbol warning for our `_pfnDliNotifyHook2`.
+
+If you're using version 0.2.0 of neon that doesn't have this patch, it is possible to build the hook in your own project (first create the .cargo/config file as mentioned above):
+
+Asjust `build.rs` so it contains the following
+
+```
+extern crate neon_build;
+extern crate cc;
+
+fn main() {
+   neon_build::setup(); // must be called in build.rs
+   cc::Build::new()
+        .cpp(true)
+        .static_crt(true)
+        .file("src/win_delay_load_hook.cc")
+        .compile("hook");
+}
+```
+
+Add the file [crates/neon-runtime/src/win_delay_load_hook.cc](https://github.com/jrd-rocks/neon/blob/electron_delay_hook/crates/neon-runtime/src/win_delay_load_hook.cc) to your project's `native/src`
+
+Have fun using neon with electron 4 (and hopefully up) in electron!

--- a/cli/src/ops/neon_new.ts
+++ b/cli/src/ops/neon_new.ts
@@ -29,6 +29,7 @@ const INDEXJS_TEMPLATE   = compile('index.js.hbs');
 const LIBRS_TEMPLATE     = compile('lib.rs.hbs');
 const README_TEMPLATE    = compile('README.md.hbs');
 const BUILDRS_TEMPLATE   = compile('build.rs.hbs');
+const CONFIG_TEMPLATE   = compile('config.hbs');
 
 async function guessAuthor() {
   let author = {
@@ -129,9 +130,11 @@ export default async function wizard(pwd: string, name: string) {
   let lib = path.resolve(root, path.dirname(answers.node));
   let native_ = path.resolve(root, 'native');
   let src = path.resolve(native_, 'src');
+  let cargo = path.resolve(native_, '.cargo');
 
   await mkdirs(lib);
   await mkdirs(src);
+  await mkdirs(cargo);
 
   await writeFile(path.resolve(root,    '.gitignore'),   (await GITIGNORE_TEMPLATE)(ctx), { flag: 'wx' });
   await writeFile(path.resolve(root,    'package.json'), (await NPM_TEMPLATE)(ctx),       { flag: 'wx' });
@@ -140,7 +143,8 @@ export default async function wizard(pwd: string, name: string) {
   await writeFile(path.resolve(root,    answers.node),   (await INDEXJS_TEMPLATE)(ctx),   { flag: 'wx' });
   await writeFile(path.resolve(src,     'lib.rs'),       (await LIBRS_TEMPLATE)(ctx),     { flag: 'wx' });
   await writeFile(path.resolve(native_, 'build.rs'),     (await BUILDRS_TEMPLATE)(ctx),   { flag: 'wx' });
-
+  await writeFile(path.resolve(cargo,   'config'),       (await CONFIG_TEMPLATE)(ctx),    { flag: 'wx' });  
+  
   let relativeRoot = path.relative(pwd, root);
   let relativeNode = path.relative(pwd, path.resolve(root, answers.node));
   let relativeRust = path.relative(pwd, path.resolve(src, 'lib.rs'));

--- a/cli/templates/config.hbs
+++ b/cli/templates/config.hbs
@@ -1,2 +1,2 @@
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
+rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:__load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]

--- a/cli/templates/config.hbs
+++ b/cli/templates/config.hbs
@@ -1,2 +1,2 @@
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:__load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]
+rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]

--- a/cli/templates/config.hbs
+++ b/cli/templates/config.hbs
@@ -1,0 +1,2 @@
+[target.'cfg(windows)']
+rustflags = ["-C", "link-args=/DELAYLOAD:node.exe /INCLUDE:load_exe_hook /INCLUDE:__pfnDliNotifyHook2 delayimp.lib"]

--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -9,6 +9,10 @@ fn main() {
     // 1. Build the object file from source using node-gyp.
     build_object_file();
 
+    if cfg!(windows) {
+        build_delay_load_hook();
+    }
+
     // 2. Link the library from the object file using gcc.
     link_library();
 }
@@ -104,6 +108,14 @@ fn build_object_file() {
         .status()
         .ok()
         .expect("Failed to run \"node-gyp build\" for neon-runtime!");
+}
+
+fn build_delay_load_hook() {
+     cc::Build::new()
+        .cpp(true)
+        .static_crt(true)
+        .file("src/win_delay_load_hook.cc")
+        .compile("win_delay_load_hook");
 }
 
 // Link the built object file into a static library.

--- a/crates/neon-runtime/package-lock.json
+++ b/crates/neon-runtime/package-lock.json
@@ -395,8 +395,7 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "node-gyp": {
       "version": "3.6.2",

--- a/crates/neon-runtime/src/win_delay_load_hook.cc
+++ b/crates/neon-runtime/src/win_delay_load_hook.cc
@@ -12,7 +12,6 @@
 
 #include <delayimp.h>
 #include <string.h>
-#include <stdexcept>
 
 extern "C" FARPROC WINAPI load_exe_hook(unsigned int, DelayLoadInfo*);
 
@@ -21,7 +20,6 @@ FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   if (event != dliNotePreLoadLibrary)
     return NULL;
 
- printf ( "loading hook\n" );
   if (_stricmp(info->szDll, "iojs.exe") != 0 &&
       _stricmp(info->szDll, "node.exe") != 0)
     return NULL;

--- a/crates/neon-runtime/src/win_delay_load_hook.cc
+++ b/crates/neon-runtime/src/win_delay_load_hook.cc
@@ -13,9 +13,7 @@
 #include <delayimp.h>
 #include <string.h>
 
-extern "C" FARPROC WINAPI __load_exe_hook(unsigned int, DelayLoadInfo*);
-
-FARPROC WINAPI __load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   HMODULE m;
   if (event != dliNotePreLoadLibrary)
     return NULL;
@@ -28,4 +26,4 @@ FARPROC WINAPI __load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   return (FARPROC) m;
 }
 
-decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = __load_exe_hook;
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;

--- a/crates/neon-runtime/src/win_delay_load_hook.cc
+++ b/crates/neon-runtime/src/win_delay_load_hook.cc
@@ -1,0 +1,34 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
+ * dynamically. Instead of trying to locate the .exe file it'll just return
+ * a handle to the process image.
+ *
+ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ */
+
+ 
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+#include <stdexcept>
+
+extern "C" FARPROC WINAPI load_exe_hook(unsigned int, DelayLoadInfo*);
+
+FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  HMODULE m;
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+ printf ( "loading hook\n" );
+  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
+      _stricmp(info->szDll, "node.exe") != 0)
+    return NULL;
+
+	
+  m = GetModuleHandle(NULL);
+  return (FARPROC) m;
+}
+
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;

--- a/crates/neon-runtime/src/win_delay_load_hook.cc
+++ b/crates/neon-runtime/src/win_delay_load_hook.cc
@@ -13,15 +13,14 @@
 #include <delayimp.h>
 #include <string.h>
 
-extern "C" FARPROC WINAPI load_exe_hook(unsigned int, DelayLoadInfo*);
+extern "C" FARPROC WINAPI __load_exe_hook(unsigned int, DelayLoadInfo*);
 
-FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+FARPROC WINAPI __load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   HMODULE m;
   if (event != dliNotePreLoadLibrary)
     return NULL;
 
-  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
-      _stricmp(info->szDll, "node.exe") != 0)
+  if (_stricmp(info->szDll, "node.exe") != 0)
     return NULL;
 
 	
@@ -29,4 +28,4 @@ FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   return (FARPROC) m;
 }
 
-decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = __load_exe_hook;

--- a/test/cli/src/acceptance/new.ts
+++ b/test/cli/src/acceptance/new.ts
@@ -41,6 +41,9 @@ describe('neon new', function() {
           let librs = readFile(this.cwd, 'my-app/native/src/lib.rs');
           assert.include(librs, `extern crate neon;`);
 
+          let config = readFile(this.cwd, 'my-app/native/.cargo/config');
+          assert.include(config, `[target.'cfg(windows)']`);
+
           done();
         });
   });


### PR DESCRIPTION
Electron on windows needs to use delayed loading. For node.js delayed loading works as well (it's the default when building with node.gyp)

For full details see https://github.com/jrd-rocks/neon/blob/electron_delay_hook/README%20ELECTRON%204.md #389 

~~The neon command that creates a default project still needs fixing to add a .cargo/config file with the linker command.~~ Never mind that, i updated the cli script as well (a breeze after figuring out the linker delay load black magic)