### PR TITLE
Run appveyor against node@12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,12 @@ matrix:
       rust: beta
     - env: TRAVIS_NODE_VERSION="8"
       rust: nightly
-    - env: TRAVIS_NODE_VERSION="6"
-      rust: beta
-    - env: TRAVIS_NODE_VERSION="6"
-      rust: nightly
 
 env:
   matrix:
     - TRAVIS_NODE_VERSION="12"
     - TRAVIS_NODE_VERSION="10"
     - TRAVIS_NODE_VERSION="8"
-    - TRAVIS_NODE_VERSION="6"
   global:
   - secure: mO6uooJGRkDISBZbTq0zvjOfjQ6BeclkxVZN3XWaXrZ/4KjPi7/fRzkm9c8brPe7LWnD4bQ9Bhp7/I6+SVRlvw+uGXNhBiiIyl95jp9s9mOEN+8V7TyShIHEYjbVJf/EGiv5Rz7ni9cNG6iBHcxy5ehycodPtVdAn/VKw31Og/JNWFTu6OzaDZL6gsFIk7VEnHUHgGtl4/iPPdPgAN18oxWbf0CjaknFxXaQiwJXuevd+fuZU16HygBn2Kmj7gqbAKyG8T6wJ1LAQpTkIduXAcgW/PJnj+Stzu48GRVoWoqMQ9Ksk2oSX70fxksC3U3SH4tIQW1+68fXZz4Y0I6b7LkwxovRxkcE4rgoU15xxJuMjxXlQ/csupwhpnBdHhh+Fmjsr0n5KFFLCI7m04ZqAn7+xx9g2NhyuPmO7/ETW24XV9fRy7IywcqR8UgLmftI36r0nV5iO500t4o13DJ0hBTIUgX6KVenbr7v68WO+M/XSRU81RPGjQKsAFM60EpCtn36uCLAZbKyxQi1kYk6UFJLfb/bfrvSS6dzUQ7fEcNRekLMn8Fo4CKAmYCJ70tvhyx/EN0HrIpCfIYedMTLYf11ZQ/bKWcHE4GzU77cRgNwBYLsY6tFjchFukyK14F6jWgpqF81g0yzG0pRJRxZqrtwEI63Db/eLidGctmcEyQ=
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
   RUST_BACKTRACE: 1
   matrix:
     - PLATFORM: x64
-      NODEJS_VERSION: "6"
-      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
-    - PLATFORM: x64
       NODEJS_VERSION: "8"
       RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
     - PLATFORM: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,15 @@ environment:
     - PLATFORM: x64
       NODEJS_VERSION: "10"
       RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "12"
+      RUST_TOOLCHAIN: stable-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "12"
+      RUST_TOOLCHAIN: beta-x86_64-pc-windows-msvc
+    - PLATFORM: x64
+      NODEJS_VERSION: "12"
+      RUST_TOOLCHAIN: nightly-x86_64-pc-windows-msvc
 
 install:
   - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM

--- a/cli/package.json
+++ b/cli/package.json
@@ -60,5 +60,8 @@
   "bugs": {
     "url": "https://github.com/neon-bindings/neon/issues"
   },
-  "homepage": "https://www.neon-bindings.com"
+  "homepage": "https://www.neon-bindings.com",
+  "engines": {
+    "node": ">=8"
+  }
 }


### PR DESCRIPTION
Complements https://github.com/neon-bindings/neon/pull/410

- Drop node@6 on CI
- Restrict node engines to node@8

Also node@6 builds seem to be failing. Should we drop support for it or fix it?