### PR TITLE
Fail build script if node-gyp configure fails to run.

### DIFF
--- a/crates/neon-runtime/build.rs
+++ b/crates/neon-runtime/build.rs
@@ -91,6 +91,14 @@ fn build_object_file() {
         .output()
         .expect("Failed to run \"node-gyp configure\" for neon-runtime!");
 
+    if !output.status.success() {
+        panic!(format!(
+            "Failed to run \"node-gyp configure\" for neon-runtime!\n Out: {}\n Err: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
     if cfg!(windows) {
         let node_gyp_output = String::from_utf8_lossy(&output.stderr);
         println!("cargo:node_arch={}", parse_node_arch(&node_gyp_output));


### PR DESCRIPTION
If `node-gyp configure` fails to run correctly, build script will still fail, but in the next step `node-gyp build[-debug]` which makes it harder to grasp what went wrong (build script will end with something like

```
error: failed to run custom build command for `neon-runtime v0.2.0 (https://github.com/neon-bindings/neon#ac15216c)`

Caused by:
  process didn't exit successfully: `/Users/adam/Work/<somedir>/target/debug/build/neon-runtime-5f1c231504acd57b/build-script-build` (exit code: 1)
--- stdout
Skipping node-gyp installation as part of npm install.
added 96 packages from 70 contributors and audited 184 packages in 2.638s
found 4 vulnerabilities (1 moderate, 3 high)
  run `npm audit fix` to fix them, or `npm audit` for details

> @ build-debug /Users/adam/.cargo/git/checkouts/neon-c7726a943d80a72d/ac15216/crates/neon-runtime
> node-gyp build --debug

TARGET = Some("x86_64-apple-darwin")
HOST = Some("x86_64-apple-darwin")
AR_x86_64-apple-darwin = None
AR_x86_64_apple_darwin = None
HOST_AR = None
AR = None
running: "ar" "crs" "/Users/adam/Work/<somedir>/target/debug/build/neon-runtime-e2b184400667751e/out/libneon.a" "build/Debug/obj.target/neon/src/neon.o"
cargo:warning=ar: build/Debug/obj.target/neon/src/neon.o: No such file or directory
exit code: 1

--- stderr
gyp ERR! build error
gyp ERR! stack Error: You must run `node-gyp configure` first!
gyp ERR! stack     at ReadFileContext.<anonymous> (/Users/adam/.nvm/versions/node/v10.16.3/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:53:20)
gyp ERR! stack     at ReadFileContext.callback (/Users/adam/.nvm/versions/node/v10.16.3/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:90:16)
gyp ERR! stack     at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:237:13)

```
)

(to explain why this happened to me - I'm using `pyenv` for managing python versions on my system and I use python 3.7.x as a default python - so this is at first a) my problem of using pyenv and not a system-wide python and b) node-gyp depending on deprecated python version but still I think this could be usefull for someone.