### PR TITLE
Squash mem::uninitialized() warnings. Fixes #424.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ neon-build = { version = "=0.3.1", path = "crates/neon-build" }
 
 [dev-dependencies]
 rustc_version = "0.2"
-lazy_static = "0.2.8"
+lazy_static = "1.4.0"
 
 [dependencies]
 cslice = "0.2"

--- a/crates/neon-runtime/native/src/neon.cc
+++ b/crates/neon-runtime/native/src/neon.cc
@@ -197,9 +197,10 @@ extern "C" bool Neon_Buffer_Uninitialized(v8::Local<v8::Object> *out, uint32_t s
   return maybe.ToLocal(out);
 }
 
-extern "C" void Neon_Buffer_Data(void **base_out, size_t *len_out, v8::Local<v8::Object> obj) {
+extern "C" size_t Neon_Buffer_Data(void **base_out, v8::Local<v8::Object> obj) {
   *base_out = node::Buffer::Data(obj);
-  *len_out = node::Buffer::Length(obj);
+
+  return node::Buffer::Length(obj);
 }
 
 extern "C" bool Neon_Tag_IsBuffer(v8::Local<v8::Value> obj) {
@@ -211,10 +212,11 @@ extern "C" bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolat
   return true;
 }
 
-extern "C" void Neon_ArrayBuffer_Data(void **base_out, size_t *len_out, v8::Local<v8::ArrayBuffer> buffer) {
+extern "C" size_t Neon_ArrayBuffer_Data(void **base_out, v8::Local<v8::ArrayBuffer> buffer) {
   v8::ArrayBuffer::Contents contents = buffer->GetContents();
   *base_out = contents.Data();
-  *len_out = contents.ByteLength();
+
+  return contents.ByteLength();
 }
 
 
@@ -364,11 +366,12 @@ extern "C" bool Neon_Class_SetName(v8::Isolate *isolate, void *metadata_pointer,
   return true;
 }
 
-extern "C" void Neon_Class_GetName(const char **chars_out, size_t *len_out, v8::Isolate *isolate, void *metadata_pointer) {
+extern "C" size_t Neon_Class_GetName(const char **chars_out, v8::Isolate *isolate, void *metadata_pointer) {
   neon::ClassMetadata *metadata = static_cast<neon::ClassMetadata *>(metadata_pointer);
   neon::Slice name = metadata->GetName();
   *chars_out = name.GetBuffer();
-  *len_out = name.GetLength();
+
+  return name.GetLength();
 }
 
 extern "C" void Neon_Class_ThrowCallError(v8::Isolate *isolate, void *metadata_pointer) {

--- a/crates/neon-runtime/native/src/neon.h
+++ b/crates/neon-runtime/native/src/neon.h
@@ -50,11 +50,11 @@ extern "C" {
   bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::Value> *value);
 
   bool Neon_Buffer_New(v8::Local<v8::Object> *out, uint32_t size);
-  void Neon_Buffer_Data(void **base_out, size_t *len_out, v8::Local<v8::Object> obj);
+  size_t Neon_Buffer_Data(void **base_out, v8::Local<v8::Object> obj);
 
   bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
   bool Neon_ArrayBuffer_Uninitialized(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
-  void Neon_ArrayBuffer_Data(void **base_out, size_t *len_out, v8::Local<v8::ArrayBuffer> buffer);
+  size_t Neon_ArrayBuffer_Data(void **base_out, v8::Local<v8::ArrayBuffer> buffer);
 
   typedef void(*Neon_ChainedScopeCallback)(void *, void *, void *, void *);
   typedef void(*Neon_NestedScopeCallback)(void *, void *, void *);
@@ -101,7 +101,7 @@ extern "C" {
   bool Neon_Class_Constructor(v8::Local<v8::Function> *out, v8::Local<v8::FunctionTemplate> ft);
   bool Neon_Class_HasInstance(void *metadata, v8::Local<v8::Value> v);
   bool Neon_Class_SetName(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length);
-  void Neon_Class_GetName(const char **chars_out, size_t *len_out, v8::Isolate *isolate, void *metadata);
+  size_t Neon_Class_GetName(const char **chars_out, v8::Isolate *isolate, void *metadata);
   void Neon_Class_ThrowThisError(v8::Isolate *isolate, void *metadata_pointer);
   bool Neon_Class_AddMethod(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length, v8::Local<v8::FunctionTemplate> method);
   bool Neon_Class_MetadataToConstructor(v8::Local<v8::Function> *out, v8::Isolate *isolate, void *metadata);

--- a/crates/neon-runtime/src/arraybuffer.rs
+++ b/crates/neon-runtime/src/arraybuffer.rs
@@ -12,5 +12,5 @@ extern "C" {
 
     /// Mutates the `base_out` and `size_out` arguments to access the data of a `v8::ArrayBuffer` object.
     #[link_name = "Neon_ArrayBuffer_Data"]
-    pub fn data<'a, 'b>(base_out: &'a mut *mut c_void, size_out: &'a mut usize, obj: Local);
+    pub fn data<'a, 'b>(base_out: &'a mut *mut c_void, obj: Local) -> usize;
 }

--- a/crates/neon-runtime/src/buffer.rs
+++ b/crates/neon-runtime/src/buffer.rs
@@ -17,6 +17,6 @@ extern "C" {
 
     /// Mutates the `base_out` and `size_out` arguments to access the data of a `node::Buffer` object.
     #[link_name = "Neon_Buffer_Data"]
-    pub fn data<'a, 'b>(base_out: &'a mut *mut c_void, size_out: &'a mut usize, obj: Local);
+    pub fn data<'a, 'b>(base_out: &'a mut *mut c_void, obj: Local) -> usize;
 
 }

--- a/crates/neon-runtime/src/class.rs
+++ b/crates/neon-runtime/src/class.rs
@@ -18,7 +18,7 @@ extern "C" {
                        drop: extern "C" fn(*mut c_void)) -> *mut c_void;
 
     #[link_name = "Neon_Class_GetName"]
-    pub fn get_name<'a>(base_out: &'a mut *mut u8, size_out: &'a mut usize, isolate: *mut Isolate, metadata: *const c_void);
+    pub fn get_name<'a>(base_out: &'a mut *mut u8, isolate: *mut Isolate, metadata: *const c_void) -> usize;
 
     #[link_name = "Neon_Class_SetName"]
     pub fn set_name(isolate: *mut Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,6 +388,12 @@ mod tests {
         log("package_test");
 
         let test_package = project_root().join("crates").join("neon-runtime");
-        run("cargo package", &test_package);
+
+        // Allow uncommitted changes outside of CI
+        if std::env::var("CI") == Ok("true".to_string()) {
+            run("cargo package", &test_package);
+        } else {
+            run("cargo package --allow-dirty", &test_package);            
+        }
     }
 }

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -200,11 +200,16 @@ impl<T: Class> ValueInternal for T {
         let map = isolate.class_map();
         match map.get(&TypeId::of::<T>()) {
             None => "unknown".to_string(),
-            Some(ref metadata) => unsafe {
-                let mut chars: *mut u8 = mem::uninitialized();
-                let mut len: usize = mem::uninitialized();
-                neon_runtime::class::get_name(&mut chars, &mut len, raw_isolate, metadata.pointer);
-                String::from_utf8_lossy(slice::from_raw_parts_mut(chars, len)).to_string()
+            Some(ref metadata) => {
+                let mut chars = std::ptr::null_mut();
+
+                let buf = unsafe {
+                    let len = neon_runtime::class::get_name(&mut chars, raw_isolate, metadata.pointer);
+
+                    slice::from_raw_parts_mut(chars, len)
+                };
+
+                String::from_utf8_lossy(buf).to_string()
             }
         }
     }

--- a/src/types/binary.rs
+++ b/src/types/binary.rs
@@ -1,7 +1,7 @@
 //! Types and traits representing binary JavaScript data.
 
 use std::marker::PhantomData;
-use std::mem;
+use std::mem::{self, MaybeUninit};
 use std::os::raw::c_void;
 use std::slice;
 use context::{Context, Lock};
@@ -172,10 +172,17 @@ impl<'a> Borrow for &'a JsBuffer {
     type Target = BinaryData<'a>;
 
     fn try_borrow<'b>(self, guard: &'b Lock<'b>) -> Result<Ref<'b, Self::Target>, LoanError> {
-        let mut pointer: BinaryData = unsafe { mem::uninitialized() };
+        let mut data = MaybeUninit::<BinaryData>::uninit();
+
+        // Initialize pointer
         unsafe {
-            neon_runtime::buffer::data(&mut pointer.base, &mut pointer.size, self.to_raw());
-            Ref::new(guard, pointer)
+            let pointer = data.as_mut_ptr();
+            (*pointer).size = neon_runtime::buffer::data(&mut (*pointer).base, self.to_raw());
+        }
+
+        // UB if pointer is not initialized!
+        unsafe {
+            Ref::new(guard, data.assume_init())
         }
     }
 }
@@ -190,10 +197,17 @@ impl<'a> Borrow for &'a mut JsBuffer {
 
 impl<'a> BorrowMut for &'a mut JsBuffer {
     fn try_borrow_mut<'b>(self, guard: &'b Lock<'b>) -> Result<RefMut<'b, Self::Target>, LoanError> {
-        let mut pointer: BinaryData = unsafe { mem::uninitialized() };
+        let mut data = MaybeUninit::<BinaryData>::uninit();
+
+        // Initialize pointer
         unsafe {
-            neon_runtime::buffer::data(&mut pointer.base, &mut pointer.size, self.to_raw());
-            RefMut::new(guard, pointer)
+            let pointer = data.as_mut_ptr();
+            (*pointer).size = neon_runtime::buffer::data(&mut (*pointer).base, self.to_raw());
+        }
+
+        // UB if pointer is not initialized!
+        unsafe {
+            RefMut::new(guard, data.assume_init())
         }
     }
 }
@@ -202,10 +216,17 @@ impl<'a> Borrow for &'a JsArrayBuffer {
     type Target = BinaryData<'a>;
 
     fn try_borrow<'b>(self, guard: &'b Lock<'b>) -> Result<Ref<'b, Self::Target>, LoanError> {
-        let mut pointer: BinaryData = unsafe { mem::uninitialized() };
+        let mut data = MaybeUninit::<BinaryData>::uninit();
+
+        // Initialize pointer
         unsafe {
-            neon_runtime::arraybuffer::data(&mut pointer.base, &mut pointer.size, self.to_raw());
-            Ref::new(guard, pointer)
+            let pointer = data.as_mut_ptr();
+            (*pointer).size = neon_runtime::arraybuffer::data(&mut (*pointer).base, self.to_raw());
+        }
+
+        // UB if pointer is not initialized!
+        unsafe {
+            Ref::new(guard, data.assume_init())
         }
     }
 }
@@ -220,10 +241,17 @@ impl<'a> Borrow for &'a mut JsArrayBuffer {
 
 impl<'a> BorrowMut for &'a mut JsArrayBuffer {
     fn try_borrow_mut<'b>(self, guard: &'b Lock<'b>) -> Result<RefMut<'b, Self::Target>, LoanError> {
-        let mut pointer: BinaryData = unsafe { mem::uninitialized() };
+        let mut data = MaybeUninit::<BinaryData>::uninit();
+
+        // Initialize pointer
         unsafe {
-            neon_runtime::arraybuffer::data(&mut pointer.base, &mut pointer.size, self.to_raw());
-            RefMut::new(guard, pointer)
+            let pointer = data.as_mut_ptr();
+            (*pointer).size = neon_runtime::arraybuffer::data(&mut (*pointer).base, self.to_raw());
+        }
+
+        // UB if pointer is not initialized!
+        unsafe {
+            RefMut::new(guard, data.assume_init())
         }
     }
 }


### PR DESCRIPTION
* Moved to safer `mem::MaybeUninit` for buffers
* Switched to more appropriate `ptr::null_mut()` for `class::get_name()`
* Limited size of unsafe blocks
* Return sizes directly instead of output parameters