### PR TITLE
CLI dev flags

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -107,6 +107,7 @@ const spec: Spec = {
   new: {
     args: [{ name: "name", type: String, defaultOption: true },
            { name: "neon", alias: "n", type: String },
+           { name: "features", alias: "f", type: String },
            { name: "help", alias: "h", type: Boolean }],
     usage: [{
       header: "neon new",
@@ -121,6 +122,11 @@ const spec: Spec = {
         alias: "n",
         type: String,
         description: "Specify a semver version of Neon or path to a local Neon repository."
+      }, {
+        name: "features",
+        alias: "f",
+        type: String,
+        description: "Space-separated list of experimental Neon features to enable."
       }]
     }],
     action: function(options) {
@@ -129,7 +135,10 @@ const spec: Spec = {
       } else if (!options.name) {
         console.error(cliUsage(spec.new.usage));
       } else {
-        return neon_new(this.cwd, options.name as string, (options.neon || null) as (string | null));
+        return neon_new(this.cwd,
+                        options.name as string,
+                        (options.neon || null) as (string | null),
+                        (options.features || null) as (string | null));
       }
       return;
     }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -106,13 +106,22 @@ const spec: Spec = {
 
   new: {
     args: [{ name: "name", type: String, defaultOption: true },
+           { name: "neon", alias: "n", type: String },
            { name: "help", alias: "h", type: Boolean }],
     usage: [{
       header: "neon new",
       content: "Create a new Neon project."
     }, {
       header: "Synopsis",
-      content: "$ neon new [@<scope>/]<name>"
+      content: "$ neon new [options] [@<scope>/]<name>"
+    }, {
+      header: "Options",
+      optionList: [{
+        name: "neon",
+        alias: "n",
+        type: String,
+        description: "Specify a semver version of Neon or path to a local Neon repository."
+      }]
     }],
     action: function(options) {
       if (options.help) {
@@ -120,7 +129,7 @@ const spec: Spec = {
       } else if (!options.name) {
         console.error(cliUsage(spec.new.usage));
       } else {
-        return neon_new(this.cwd, options.name as string);
+        return neon_new(this.cwd, options.name as string, (options.neon || null) as (string | null));
       }
       return;
     }

--- a/cli/src/ops/neon_new.ts
+++ b/cli/src/ops/neon_new.ts
@@ -154,27 +154,30 @@ export default async function wizard(pwd: string, name: string, neon: string | n
 
   if (neonVersion.type === 'relative') {
     let neon = path.relative(name, neonVersion.value);
-    libs.paths = { neon, 'neon-build': path.join(neon, 'crates', 'neon-build') };
+    libs.paths = {
+      neon: JSON.stringify(neon),
+      'neon-build': JSON.stringify(path.join(neon, 'crates', 'neon-build'))
+    };
   } else if (neonVersion.type === 'absolute') {
     libs.paths = {
-      neon: neonVersion.value,
-      'neon-build': path.resolve(neonVersion.value, 'crates', 'neon-build')
+      neon: JSON.stringify(neonVersion.value),
+      'neon-build': JSON.stringify(path.resolve(neonVersion.value, 'crates', 'neon-build'))
     };
   } else {
-    libs.version = neonVersion.value;
+    libs.version = JSON.stringify(neonVersion.value);
   }
 
   if (features) {
-    libs.features = features.split(/\s+/);
+    libs.features = features.split(/\s+/).map(JSON.stringify);
   }
 
-  let cli = neonVersion.type === 'version'
+  let cli = JSON.stringify(neonVersion.type === 'version'
     ? "^" + neonVersion.value
     : neonVersion.type === 'relative'
     ? "file:" + path.join(path.relative(name, neonVersion.value), 'cli')
     : neonVersion.type === 'absolute'
     ? "file:" + path.resolve(neonVersion.value, 'cli')
-    : neonVersion.value;
+    : neonVersion.value);
 
   let ctx = {
     project: answers,

--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -16,14 +16,14 @@ crate-type = ["cdylib"]
 
 [build-dependencies]
 {{#if neon.libs.simple}}
-neon-build = "{{neon.libs.version}}"
+neon-build = {{neon.libs.version}}
 {{else}}
-neon-build = { {{#if neon.libs.version}}version = "{{neon.libs.version}}"{{else}}path = "{{neon.libs.paths.neon-build}}"{{/if}}{{#if neon.libs.features}}, features = [{{#each neon.libs.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
+neon-build = { {{#if neon.libs.version}}version = {{neon.libs.version}}{{else}}path = {{neon.libs.paths.neon-build}}{{/if}}{{#if neon.libs.features}}, features = [{{#each neon.libs.features as |feature index|}}{{#if index}}, {{/if}}{{feature}}{{/each}}]{{/if}} }
 {{/if}}
 
 [dependencies]
 {{#if neon.libs.simple}}
-neon = "{{neon.libs.version}}"
+neon = {{neon.libs.version}}
 {{else}}
-neon = { {{#if neon.libs.version}}version = "{{neon.libs.version}}"{{else}}path = "{{neon.libs.paths.neon}}"{{/if}}{{#if neon.libs.features}}, features = [{{#each neon.libs.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
+neon = { {{#if neon.libs.version}}version = {{neon.libs.version}}{{else}}path = {{neon.libs.paths.neon}}{{/if}}{{#if neon.libs.features}}, features = [{{#each neon.libs.features as |feature index|}}{{#if index}}, {{/if}}{{feature}}{{/each}}]{{/if}} }
 {{/if}}

--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -18,12 +18,12 @@ crate-type = ["cdylib"]
 {{#if neon.rust.simple}}
 neon-build = "{{neon.rust.simple}}"
 {{else}}
-neon-build = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}} }
+neon-build = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}}{{#if neon.rust.features}}, features = [{{#each neon.rust.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
 {{/if}}
 
 [dependencies]
 {{#if neon.rust.simple}}
 neon = "{{neon.rust.simple}}"
 {{else}}
-neon = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}} }
+neon = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}}{{#if neon.rust.features}}, features = [{{#each neon.rust.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
 {{/if}}

--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -15,7 +15,15 @@ name = "{{project.name.cargo.internal}}"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.3.1"
+{{#if neon.rust.simple}}
+neon-build = "{{neon.rust.simple}}"
+{{else}}
+neon-build = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}} }
+{{/if}}
 
 [dependencies]
-neon = "0.3.1"
+{{#if neon.rust.simple}}
+neon = "{{neon.rust.simple}}"
+{{else}}
+neon = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}} }
+{{/if}}

--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -15,15 +15,15 @@ name = "{{project.name.cargo.internal}}"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-{{#if neon.rust.simple}}
-neon-build = "{{neon.rust.simple}}"
+{{#if neon.libs.simple}}
+neon-build = "{{neon.libs.version}}"
 {{else}}
-neon-build = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}}{{#if neon.rust.features}}, features = [{{#each neon.rust.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
+neon-build = { {{#if neon.libs.version}}version = "{{neon.libs.version}}"{{else}}path = "{{neon.libs.paths.neon-build}}"{{/if}}{{#if neon.libs.features}}, features = [{{#each neon.libs.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
 {{/if}}
 
 [dependencies]
-{{#if neon.rust.simple}}
-neon = "{{neon.rust.simple}}"
+{{#if neon.libs.simple}}
+neon = "{{neon.libs.version}}"
 {{else}}
-neon = { {{#if neon.rust.version}}version = "{{neon.rust.version}}"{{else}}path = "{{neon.rust.path}}"{{/if}}{{#if neon.rust.features}}, features = [{{#each neon.rust.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
+neon = { {{#if neon.libs.version}}version = "{{neon.libs.version}}"{{else}}path = "{{neon.libs.paths.neon}}"{{/if}}{{#if neon.libs.features}}, features = [{{#each neon.libs.features as |feature index|}}{{#if index}}, {{/if}}"{{feature}}"{{/each}}]{{/if}} }
 {{/if}}

--- a/cli/templates/package.json.hbs
+++ b/cli/templates/package.json.hbs
@@ -16,7 +16,7 @@
   "license": "{{project.license}}",
 {{/if}}
   "dependencies": {
-    "neon-cli": "^{{neon-cli.major}}.{{neon-cli.minor}}.{{neon-cli.patch}}"
+    "neon-cli": "{{neon.javascript}}"
   },
   "scripts": {
     "install": "neon build"

--- a/cli/templates/package.json.hbs
+++ b/cli/templates/package.json.hbs
@@ -16,7 +16,7 @@
   "license": "{{project.license}}",
 {{/if}}
   "dependencies": {
-    "neon-cli": "{{neon.javascript}}"
+    "neon-cli": "{{neon.cli}}"
   },
   "scripts": {
     "install": "neon build"

--- a/cli/templates/package.json.hbs
+++ b/cli/templates/package.json.hbs
@@ -16,7 +16,7 @@
   "license": "{{project.license}}",
 {{/if}}
   "dependencies": {
-    "neon-cli": "{{neon.cli}}"
+    "neon-cli": {{neon.cli}}
   },
   "scripts": {
     "install": "neon build"

--- a/test/cli/src/acceptance/help.ts
+++ b/test/cli/src/acceptance/help.ts
@@ -81,7 +81,7 @@ function testHelpNew(proc: SpawnChain, done: () => void) {
     .wait("neon new")
     .wait("Create a new Neon project")
     .wait("Synopsis")
-    .wait("$ neon new [@<scope>/]<name>")
+    .wait("$ neon new [options] [@<scope>/]<name>")
     .run(err => {
       if (err) throw err;
       done();

--- a/test/cli/src/acceptance/new.ts
+++ b/test/cli/src/acceptance/new.ts
@@ -61,7 +61,17 @@ function assertNormalNeonCli(pkg: any) {
 
 function assertLocalNeonCli(pkg: any) {
   assert.nestedProperty(pkg, 'dependencies.neon-cli');
-  assert.match(pkg.dependencies['neon-cli'], /cli$/);
+  assert.match(pkg.dependencies['neon-cli'], /^file:.*cli$/);
+}
+
+function assertRelativeNeonCli(pkg: any) {
+  assert.match(pkg.dependencies['neon-cli'], /^file:/);
+}
+
+function assertAbsoluteNeonCli(pkg: any) {
+  assert.match(pkg.dependencies['neon-cli'], /^file:/);
+  let local = pkg.dependencies['neon-cli'].substring(5).trim();
+  assert.isTrue(path.isAbsolute(local));
 }
 
 function assertLocalNeon(cargo: any) {
@@ -136,10 +146,21 @@ describe('neon new', function() {
     });
   });
 
-  it('supports paths to Neon source directories', function(done) {
+  it('supports relative paths to Neon source directories', function(done) {
     spawnNeonNew(this, 'my-app', {neon: '.'}, () => {
       let { pkg, cargo } = manifests(this.cwd, 'my-app');
       assertLocalNeonCli(pkg);
+      assertRelativeNeonCli(pkg);
+      assertLocalNeon(cargo);
+      done();
+    });
+  });
+
+  it('supports absolute paths to Neon source directories', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: path.resolve('.')}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assertLocalNeonCli(pkg);
+      assertAbsoluteNeonCli(pkg);
       assertLocalNeon(cargo);
       done();
     });

--- a/test/cli/src/acceptance/new.ts
+++ b/test/cli/src/acceptance/new.ts
@@ -2,6 +2,7 @@ import * as TOML from 'toml';
 import { assert } from 'chai';
 import { setup, spawnable } from '../support/acceptance';
 import { readFile } from '../support/fs';
+import * as path from 'path';
 
 type SpawnNeonNewOptions = {
   version?: string,
@@ -10,11 +11,27 @@ type SpawnNeonNewOptions = {
   git?: string,
   author?: string,
   email?: string,
-  license?: string
+  license?: string,
+  neon?: string,
+  features?: string
 };
 
 function spawnNeonNew(cx: Mocha.ITestCallbackContext, name: string, opts: SpawnNeonNewOptions = {}, cb: () => void) {
-  spawnable(cx).spawn(['new', name])
+  let args = ['new'];
+
+  if (opts.neon) {
+    args.push("--neon");
+    args.push(opts.neon);
+  }
+
+  if (opts.features) {
+    args.push('--features');
+    args.push(opts.features);
+  }
+
+  args.push(name);
+
+  spawnable(cx).spawn(args)
     .wait('This utility will walk you through creating the')
     .wait('version').sendline(opts.version || '')
     .wait('desc').sendline(opts.desc || '')
@@ -26,9 +43,36 @@ function spawnNeonNew(cx: Mocha.ITestCallbackContext, name: string, opts: SpawnN
     .sendEof()
     .run(err => {
       if (err) throw err;
-
       cb();
     });
+}
+
+function manifests(cwd: string, lib: string) : { pkg: any, cargo: any } {
+  return {
+    pkg: JSON.parse(readFile(cwd, lib, 'package.json')),
+    cargo: TOML.parse(readFile(cwd, lib, 'native', 'Cargo.toml'))
+  };
+}
+
+function assertNormalNeonCli(pkg: any) {
+  assert.typeOf(pkg.dependencies['neon-cli'], 'string');
+  assert.match(pkg.dependencies['neon-cli'], /^\^\d+\.\d+\.\d+$/);
+}
+
+function assertLocalNeonCli(pkg: any) {
+  assert.nestedProperty(pkg, 'dependencies.neon-cli');
+  assert.match(pkg.dependencies['neon-cli'], /cli$/);
+}
+
+function assertLocalNeon(cargo: any) {
+  assert.typeOf(cargo.dependencies.neon.path, 'string');
+  assert.typeOf(cargo['build-dependencies']['neon-build'].path, 'string');
+  assert.nestedPropertyVal(cargo, 'build-dependencies.neon-build.path', path.join(cargo.dependencies.neon.path, "crates", "neon-build"));
+}
+
+function assertNeonFeatureFlags(cargo: any) {
+  assert.deepEqual(cargo['build-dependencies']['neon-build'].features, ["n-api"]);
+  assert.deepEqual(cargo.dependencies.neon.features, ["n-api"]);
 }
 
 describe('neon new', function() {
@@ -36,14 +80,13 @@ describe('neon new', function() {
 
   it('should create a new project', function(done) {
     spawnNeonNew(this, 'my-app', {desc: 'My new app!'}, () => {
-      let pkg = JSON.parse(readFile(this.cwd, 'my-app/package.json'));
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
       assert.propertyVal(pkg, 'name', 'my-app');
       assert.propertyVal(pkg, 'version', '0.1.0');
       assert.propertyVal(pkg, 'description', 'My new app!');
       assert.propertyVal(pkg, 'license', 'MIT');
       assert.nestedProperty(pkg, 'dependencies.neon-cli');
 
-      let cargo = TOML.parse(readFile(this.cwd, 'my-app/native/Cargo.toml'));
       assert.nestedPropertyVal(cargo, 'package.name', 'my-app');
       assert.nestedPropertyVal(cargo, 'package.version', '0.1.0');
       assert.nestedPropertyVal(cargo, 'package.license', 'MIT');
@@ -62,13 +105,12 @@ describe('neon new', function() {
 
   it('should create a new project as a scoped package', function(done) {
     spawnNeonNew(this, '@me/my-package', {}, () => {
-      let pkg = JSON.parse(readFile(this.cwd, 'my-package/package.json'));
+      let { pkg, cargo } = manifests(this.cwd, 'my-package');
       assert.propertyVal(pkg, 'name', '@me/my-package');
 
       let readme = readFile(this.cwd, 'my-package/README.md');
       assert.match(readme, /@me\/my-package/);
 
-      let cargo = TOML.parse(readFile(this.cwd, 'my-package/native/Cargo.toml'));
       assert.nestedPropertyVal(cargo, 'package.name', 'my-package');
       assert.nestedPropertyVal(cargo, 'lib.name', 'my_package');
 
@@ -85,15 +127,85 @@ describe('neon new', function() {
     };
 
     spawnNeonNew(this, 'my-app', opts, () => {
-      let pkg = JSON.parse(readFile(this.cwd, 'my-app/package.json'));
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
       assert.propertyVal(pkg, 'description', 'Foo "bar"');
       assert.nestedPropertyVal(pkg, 'repository.url', 'http://www.example.com/foo.git?bar=%22baz%22');
       assert.propertyVal(pkg, 'author', 'Foo "Bar" Baz <haywoodjabuzoff@example.com>');
-
-      let cargo = TOML.parse(readFile(this.cwd, 'my-app/native/Cargo.toml'));
       assert.includeDeepMembers(cargo.package.authors, ['Foo "Bar" Baz <haywoodjabuzoff@example.com>'])
-
       done();
     });
   });
+
+  it('supports paths to Neon source directories', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: '.'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assertLocalNeonCli(pkg);
+      assertLocalNeon(cargo);
+      done();
+    });
+  });
+
+  it('supports paths to Neon source directories and feature flags', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: '.', features: 'n-api'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assertLocalNeonCli(pkg);
+      assertLocalNeon(cargo);
+      assertNeonFeatureFlags(cargo);
+      done();
+    });
+  });
+
+  it('supports Neon feature flags', function(done) {
+    spawnNeonNew(this, 'my-app', {features: 'n-api'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assertNormalNeonCli(pkg);
+      assertNeonFeatureFlags(cargo);
+      done();
+    });
+  });
+
+  it('supports semver ranges of Neon', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: '^0.2'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assert.nestedPropertyVal(pkg, 'dependencies.neon-cli', '^0.2');
+      assert.nestedPropertyVal(cargo, 'dependencies.neon', '^0.2');
+      assert.nestedPropertyVal(cargo, 'build-dependencies.neon-build', '^0.2');
+      done();
+    });
+  });
+
+  it('supports semver ranges of Neon with feature flags', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: '^0.2', features: 'n-api'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assert.nestedPropertyVal(pkg, 'dependencies.neon-cli', '^0.2');
+      assert.nestedPropertyVal(cargo, 'dependencies.neon.version', '^0.2');
+      assert.deepEqual(cargo.dependencies.neon.features, ['n-api']);
+      assert.nestedPropertyVal(cargo, 'build-dependencies.neon-build.version', '^0.2');
+      assert.deepEqual(cargo['build-dependencies']['neon-build'].features, ['n-api']);
+      done();
+    });
+  });
+
+  it('supports specific semver versions of Neon', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: '0.2.2'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assert.nestedPropertyVal(pkg, 'dependencies.neon-cli', '^0.2.2');
+      assert.nestedPropertyVal(cargo, 'dependencies.neon', '0.2.2');
+      assert.nestedPropertyVal(cargo, 'build-dependencies.neon-build', '0.2.2');
+      done();
+    });
+  });
+
+  it('supports specific semver versions of Neon with feature flags', function(done) {
+    spawnNeonNew(this, 'my-app', {neon: '0.2.2', features: 'n-api'}, () => {
+      let { pkg, cargo } = manifests(this.cwd, 'my-app');
+      assert.nestedPropertyVal(pkg, 'dependencies.neon-cli', '^0.2.2');
+      assert.nestedPropertyVal(cargo, 'dependencies.neon.version', '0.2.2');
+      assert.deepEqual(cargo.dependencies.neon.features, ['n-api']);
+      assert.nestedPropertyVal(cargo, 'build-dependencies.neon-build.version', '0.2.2');
+      assert.deepEqual(cargo['build-dependencies']['neon-build'].features, ['n-api']);
+      done();
+    });
+  });
+
 });

--- a/test/cli/src/acceptance/new.ts
+++ b/test/cli/src/acceptance/new.ts
@@ -3,101 +3,97 @@ import { assert } from 'chai';
 import { setup, spawnable } from '../support/acceptance';
 import { readFile } from '../support/fs';
 
+type SpawnNeonNewOptions = {
+  version?: string,
+  desc?: string,
+  node?: string,
+  git?: string,
+  author?: string,
+  email?: string,
+  license?: string
+};
+
+function spawnNeonNew(cx: Mocha.ITestCallbackContext, name: string, opts: SpawnNeonNewOptions = {}, cb: () => void) {
+  spawnable(cx).spawn(['new', name])
+    .wait('This utility will walk you through creating the')
+    .wait('version').sendline(opts.version || '')
+    .wait('desc').sendline(opts.desc || '')
+    .wait('node').sendline(opts.node || '')
+    .wait('git').sendline(opts.git || '')
+    .wait('author').sendline(opts.author || '')
+    .wait('email').sendline(opts.email || '')
+    .wait('license').sendline(opts.license || '')
+    .sendEof()
+    .run(err => {
+      if (err) throw err;
+
+      cb();
+    });
+}
+
 describe('neon new', function() {
   setup();
 
   it('should create a new project', function(done) {
-    let self = spawnable(this);
-    self.spawn(['new', 'my-app'])
-        .wait('This utility will walk you through creating the')
-        .wait('version').sendline('')
-        .wait('desc').sendline('My new app!')
-        .wait('node').sendline('')
-        .wait('git').sendline('')
-        .wait('author').sendline('')
-        .wait('email').sendline('')
-        .wait('license').sendline('')
-        .sendEof()
-        .run(err => {
-          if (err) throw err;
+    spawnNeonNew(this, 'my-app', {desc: 'My new app!'}, () => {
+      let pkg = JSON.parse(readFile(this.cwd, 'my-app/package.json'));
+      assert.propertyVal(pkg, 'name', 'my-app');
+      assert.propertyVal(pkg, 'version', '0.1.0');
+      assert.propertyVal(pkg, 'description', 'My new app!');
+      assert.propertyVal(pkg, 'license', 'MIT');
+      assert.nestedProperty(pkg, 'dependencies.neon-cli');
 
-          let pkg = JSON.parse(readFile(this.cwd, 'my-app/package.json'));
-          assert.propertyVal(pkg, 'name', 'my-app');
-          assert.propertyVal(pkg, 'version', '0.1.0');
-          assert.propertyVal(pkg, 'description', 'My new app!');
-          assert.propertyVal(pkg, 'license', 'MIT');
-          assert.nestedProperty(pkg, 'dependencies.neon-cli');
+      let cargo = TOML.parse(readFile(this.cwd, 'my-app/native/Cargo.toml'));
+      assert.nestedPropertyVal(cargo, 'package.name', 'my-app');
+      assert.nestedPropertyVal(cargo, 'package.version', '0.1.0');
+      assert.nestedPropertyVal(cargo, 'package.license', 'MIT');
+      assert.nestedPropertyVal(cargo, 'lib.name', 'my_app');
+      assert.nestedProperty(cargo, 'dependencies.neon');
 
-          let cargo = TOML.parse(readFile(this.cwd, 'my-app/native/Cargo.toml'));
-          assert.nestedPropertyVal(cargo, 'package.name', 'my-app');
-          assert.nestedPropertyVal(cargo, 'package.version', '0.1.0');
-          assert.nestedPropertyVal(cargo, 'package.license', 'MIT');
-          assert.nestedPropertyVal(cargo, 'lib.name', 'my_app');
-          assert.nestedProperty(cargo, 'dependencies.neon');
+      let indexjs = readFile(this.cwd, 'my-app/lib/index.js');
+      assert.include(indexjs, `require('../native')`);
 
-          let indexjs = readFile(this.cwd, 'my-app/lib/index.js');
-          assert.include(indexjs, `require('../native')`);
+      let librs = readFile(this.cwd, 'my-app/native/src/lib.rs');
+      assert.include(librs, `extern crate neon;`);
 
-          let librs = readFile(this.cwd, 'my-app/native/src/lib.rs');
-          assert.include(librs, `extern crate neon;`);
-
-          done();
-        });
+      done();
+    });
   });
 
   it('should create a new project as a scoped package', function(done) {
-    let self = spawnable(this);
-    self.spawn(['new', '@me/my-package'])
-        .wait('This utility will walk you through creating the')
-        .wait('version').sendline('')
-        .wait('desc').sendline('My new scoped package')
-        .wait('node').sendline('')
-        .wait('git').sendline('')
-        .wait('author').sendline('')
-        .wait('email').sendline('')
-        .wait('license').sendline('')
-        .sendEof()
-        .run(err => {
-          if (err) throw err;
+    spawnNeonNew(this, '@me/my-package', {}, () => {
+      let pkg = JSON.parse(readFile(this.cwd, 'my-package/package.json'));
+      assert.propertyVal(pkg, 'name', '@me/my-package');
 
-          let pkg = JSON.parse(readFile(this.cwd, 'my-package/package.json'));
-          assert.propertyVal(pkg, 'name', '@me/my-package');
+      let readme = readFile(this.cwd, 'my-package/README.md');
+      assert.match(readme, /@me\/my-package/);
 
-          let readme = readFile(this.cwd, 'my-package/README.md');
-          assert.match(readme, /@me\/my-package/);
+      let cargo = TOML.parse(readFile(this.cwd, 'my-package/native/Cargo.toml'));
+      assert.nestedPropertyVal(cargo, 'package.name', 'my-package');
+      assert.nestedPropertyVal(cargo, 'lib.name', 'my_package');
 
-          let cargo = TOML.parse(readFile(this.cwd, 'my-package/native/Cargo.toml'));
-          assert.nestedPropertyVal(cargo, 'package.name', 'my-package');
-          assert.nestedPropertyVal(cargo, 'lib.name', 'my_package');
-
-          done();
-        });
+      done();
+    });
   });
 
   it('should escape quotes in the generated package.json and Cargo.toml', function(done) {
-    let self = spawnable(this);
-    self.spawn(['new', 'my-app'])
-        .wait('This utility will walk you through creating the')
-        .wait('version').sendline('')
-        .wait('desc').sendline('Foo "bar"')
-        .wait('node').sendline('')
-        .wait('git').sendline('http://www.example.com/foo.git?bar="baz"')
-        .wait('author').sendline('Foo "Bar" Baz')
-        .wait('email').sendline('hughjass@example.com')
-        .wait('license').sendline('')
-        .sendEof()
-        .run(err => {
-          if (err) throw err;
+    let opts = {
+      desc: 'Foo "bar"',
+      author: 'Foo "Bar" Baz',
+      git: 'http://www.example.com/foo.git?bar="baz"',
+      email: 'haywoodjabuzoff@example.com'
+    };
 
-          let pkg = JSON.parse(readFile(this.cwd, 'my-app/package.json'));
-          assert.propertyVal(pkg, 'description', 'Foo "bar"');
-          assert.nestedPropertyVal(pkg, 'repository.url', 'http://www.example.com/foo.git?bar=%22baz%22');
-          assert.propertyVal(pkg, 'author', 'Foo "Bar" Baz <hughjass@example.com>');
+    spawnNeonNew(this, 'my-app', opts, () => {
+      let pkg = JSON.parse(readFile(this.cwd, 'my-app/package.json'));
+      assert.propertyVal(pkg, 'description', 'Foo "bar"');
+      assert.nestedPropertyVal(pkg, 'repository.url', 'http://www.example.com/foo.git?bar=%22baz%22');
+      assert.propertyVal(pkg, 'author', 'Foo "Bar" Baz <haywoodjabuzoff@example.com>');
 
-          let cargo = TOML.parse(readFile(this.cwd, 'my-app/native/Cargo.toml'));
-          assert.includeDeepMembers(cargo.package.authors, ['Foo "Bar" Baz <hughjass@example.com>'])
+      let cargo = TOML.parse(readFile(this.cwd, 'my-app/native/Cargo.toml'));
+      assert.includeDeepMembers(cargo.package.authors, ['Foo "Bar" Baz <haywoodjabuzoff@example.com>'])
 
-          done();
-        });
+      done();
+    });
   });
 });

--- a/test/cli/src/acceptance/new.ts
+++ b/test/cli/src/acceptance/new.ts
@@ -21,7 +21,14 @@ function spawnNeonNew(cx: Mocha.ITestCallbackContext, name: string, opts: SpawnN
 
   if (opts.neon) {
     args.push("--neon");
-    args.push(opts.neon);
+
+    if (process.platform === 'win32') {
+      // If the semver has a "^" operator, it needs to be escaped in Windows.
+      args.push(opts.neon.replace(/\^/g, "^^"));
+    } else {
+      // If the semver has a ">" operator, it needs to be escaped in Unix.
+      args.push(opts.neon.replace(/>/, "\\>"));
+    }
   }
 
   if (opts.features) {


### PR DESCRIPTION
Enables two new flags for `neon new`, both of which should become useful for development and experimental work:

- `neon new --neon=<version-or-path>`: specify a non-default version of Neon or path to a local Neon project directory on the filesystem
- `neon new --features=<neon-experimental-features-list>`: specify a space-separated list of experimental Neon features to enable

These should be useful for contributing or testing when we start developing N-API support, so that we can put the experimental support behind a feature flag until it stabilizes.