### PR TITLE
Static tests in Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,8 +406,6 @@ mod tests {
 
         log("static_test");
 
-        // Temporarily disabled in Windows; blocked on https://github.com/dtolnay/trybuild/issues/30
-        #[cfg(not(windows))]
         run("cargo test --release", &project_root().join("test").join("static"));
     }
 

--- a/test/static/Cargo.toml
+++ b/test/static/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT/Apache-2.0"
 neon = { path = "../../" }
 
 [dev-dependencies]
-trybuild = "1.0.14"
+trybuild = "1.0.15"


### PR DESCRIPTION
Now that https://github.com/dtolnay/trybuild/pull/32 has been merged and trybuild 1.0.15 has been published, we can re-enable the static tests in Windows CI.