### PR TITLE
Fix ERR_CHILD_PROCESS_STDIO_MAXBUFFER error

### DIFF
--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -27,7 +27,8 @@ export default class Project {
   static async create(root: string, options: Partial<ProjectOptions> = {}): Promise<Project> {
     let { crate = 'native' } = options;
     const { stdout } = await execFile("cargo", ["metadata", "--format-version=1"], {
-      cwd: path.join(root, crate)
+      cwd: path.join(root, crate),
+      maxBuffer: 1024 * 1024
     });
     const targetDirectory: string = JSON.parse(stdout).target_directory;
 

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -26,9 +26,8 @@ export default class Project {
 
   static async create(root: string, options: Partial<ProjectOptions> = {}): Promise<Project> {
     let { crate = 'native' } = options;
-    const { stdout } = await execFile("cargo", ["metadata", "--format-version=1"], {
-      cwd: path.join(root, crate),
-      maxBuffer: 1024 * 1024
+    const { stdout } = await execFile("cargo", ["metadata", "--format-version=1", "--no-deps"], {
+      cwd: path.join(root, crate)
     });
     const targetDirectory: string = JSON.parse(stdout).target_directory;
 


### PR DESCRIPTION
After upgrading to 0.3.2 I started to get following error:
```
$ neon build --release
neon ERR! stdout maxBuffer length exceeded

RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length exceeded
    at Socket.onChildStdout (child_process.js:348:14)
    at Socket.emit (events.js:189:13)
    at addChunk (_stream_readable.js:284:12)
    at readableAddChunk (_stream_readable.js:261:13)
    at Socket.Readable.push (_stream_readable.js:220:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:94:17)
```

I use NodeJS 10 LTS which has only 200kb, and it seems to be not enough. NodeJS 12 has 1Mb by default, and it works fine on another machine.

PR increases the buffer to 1Mb and fixes error for my case