### PR TITLE
Singleton primitives

### DIFF
--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -17,7 +17,13 @@ pub unsafe extern "C" fn boolean(out: &mut Local, env: Env, b: bool) {
     napi::napi_get_boolean(env, b, out as *mut Local);
 }
 
-pub unsafe extern "C" fn boolean_value(_p: Local) -> bool { unimplemented!() }
+/// Get the boolean value out of a `Local` object. If the `Local` object does not contain a
+/// boolean, this function panics.
+pub unsafe extern "C" fn boolean_value(env: Env, p: Local) -> bool {
+    let mut value = false;
+    assert_eq!(napi::napi_get_value_bool(env, p, &mut value as *mut bool), napi::napi_status::napi_ok);
+    value
+}
 
 // DEPRECATE(0.2)
 pub unsafe extern "C" fn integer(_out: &mut Local, _isolate: Env, _x: i32) { unimplemented!() }

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -1,8 +1,16 @@
 use raw::{Local, Env};
 
-pub unsafe extern "C" fn undefined(_out: &mut Local) { unimplemented!() }
+use nodejs_sys as napi;
 
-pub unsafe extern "C" fn null(_out: &mut Local) { unimplemented!() }
+/// Mutates the `out` argument provided to refer to the global `undefined` object.
+pub unsafe extern "C" fn undefined(out: &mut Local, env: Env) {
+    napi::napi_get_undefined(env, out as *mut Local);
+}
+
+/// Mutates the `out` argument provided to refer to the global `null` object.
+pub unsafe extern "C" fn null(out: &mut Local, env: Env) {
+    napi::napi_get_null(env, out as *mut Local);
+}
 
 pub unsafe extern "C" fn boolean(_out: &mut Local, _b: bool) { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -12,7 +12,10 @@ pub unsafe extern "C" fn null(out: &mut Local, env: Env) {
     napi::napi_get_null(env, out as *mut Local);
 }
 
-pub unsafe extern "C" fn boolean(_out: &mut Local, _b: bool) { unimplemented!() }
+/// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
+pub unsafe extern "C" fn boolean(out: &mut Local, env: Env, b: bool) {
+    napi::napi_get_boolean(env, b, out as *mut Local);
+}
 
 pub unsafe extern "C" fn boolean_value(_p: Local) -> bool { unimplemented!() }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -68,7 +68,7 @@ extern "C" void Neon_Primitive_Null(v8::Local<v8::Primitive> *out, v8::Isolate *
   *out = Nan::Null();
 }
 
-extern "C" void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, bool b) {
+extern "C" void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, v8::Isolate *isolate, bool b) {
   *out = b ? Nan::True() : Nan::False();
 }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -60,11 +60,11 @@ extern "C" void *Neon_Object_GetIsolate(v8::Local<v8::Object> obj) {
   return obj->GetIsolate();
 }
 
-extern "C" void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out) {
+extern "C" void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out, v8::Isolate *isolate) {
   *out = Nan::Undefined();
 }
 
-extern "C" void Neon_Primitive_Null(v8::Local<v8::Primitive> *out) {
+extern "C" void Neon_Primitive_Null(v8::Local<v8::Primitive> *out, v8::Isolate *isolate) {
   *out = Nan::Null();
 }
 

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -23,8 +23,8 @@ extern "C" {
   void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);
 
   void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value);
-  void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out);
-  void Neon_Primitive_Null(v8::Local<v8::Primitive> *out);
+  void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out, v8::Isolate *isolate);
+  void Neon_Primitive_Null(v8::Local<v8::Primitive> *out, v8::Isolate *isolate);
   void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, bool b);
   bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p);
   bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -25,7 +25,7 @@ extern "C" {
   void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value);
   void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out, v8::Isolate *isolate);
   void Neon_Primitive_Null(v8::Local<v8::Primitive> *out, v8::Isolate *isolate);
-  void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, bool b);
+  void Neon_Primitive_Boolean(v8::Local<v8::Boolean> *out, v8::Isolate *isolate, bool b);
   bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p);
   bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p);
 

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -155,7 +155,7 @@ extern "C" {
 
     pub fn Neon_Primitive_Undefined(out: &mut Local, isolate: Isolate);
     pub fn Neon_Primitive_Null(out: &mut Local, isolate: Isolate);
-    pub fn Neon_Primitive_Boolean(out: &mut Local, b: bool);
+    pub fn Neon_Primitive_Boolean(out: &mut Local, isolate: Isolate, b: bool);
     pub fn Neon_Primitive_BooleanValue(p: Local) -> bool;
     pub fn Neon_Primitive_Integer(out: &mut Local, isolate: Isolate, x: i32);
     pub fn Neon_Primitive_IsUint32(p: Local) -> bool;

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -153,8 +153,8 @@ extern "C" {
     pub fn Neon_Object_Get(out: &mut Local, object: Local, key: Local) -> bool;
     pub fn Neon_Object_Set(out: &mut bool, object: Local, key: Local, val: Local) -> bool;
 
-    pub fn Neon_Primitive_Undefined(out: &mut Local);
-    pub fn Neon_Primitive_Null(out: &mut Local);
+    pub fn Neon_Primitive_Undefined(out: &mut Local, isolate: Isolate);
+    pub fn Neon_Primitive_Null(out: &mut Local, isolate: Isolate);
     pub fn Neon_Primitive_Boolean(out: &mut Local, b: bool);
     pub fn Neon_Primitive_BooleanValue(p: Local) -> bool;
     pub fn Neon_Primitive_Integer(out: &mut Local, isolate: Isolate, x: i32);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -251,13 +251,27 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     /// Convenience method for creating a `JsNull` value.
+    #[cfg(feature = "legacy-runtime")]
     fn null(&mut self) -> Handle<'a, JsNull> {
         JsNull::new()
     }
 
+    /// Convenience method for creating a `JsNull` value.
+    #[cfg(feature = "napi-runtime")]
+    fn null(&mut self) -> Handle<'a, JsNull> {
+        JsNull::new(self)
+    }
+
     /// Convenience method for creating a `JsUndefined` value.
+    #[cfg(feature = "legacy-runtime")]
     fn undefined(&mut self) -> Handle<'a, JsUndefined> {
         JsUndefined::new()
+    }
+
+    /// Convenience method for creating a `JsUndefined` value.
+    #[cfg(feature = "napi-runtime")]
+    fn undefined(&mut self) -> Handle<'a, JsUndefined> {
+        JsUndefined::new(self)
     }
 
     /// Convenience method for creating an empty `JsObject` value.
@@ -476,8 +490,15 @@ impl<'a, T: This> CallContext<'a, T> {
     }
 
     /// Produces a handle to the `this`-binding.
+    #[cfg(feature = "legacy-runtime")]
     pub fn this(&mut self) -> Handle<'a, T> {
         Handle::new_internal(T::as_this(self.info.this(self)))
+    }
+
+    /// Produces a handle to the `this`-binding.
+    #[cfg(feature = "napi-runtime")]
+    pub fn this(&mut self, env: Env) -> Handle<'a, T> {
+        Handle::new_internal(T::as_this(env, self.info.this(self)))
     }
 }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -490,15 +490,13 @@ impl<'a, T: This> CallContext<'a, T> {
     }
 
     /// Produces a handle to the `this`-binding.
-    #[cfg(feature = "legacy-runtime")]
     pub fn this(&mut self) -> Handle<'a, T> {
-        Handle::new_internal(T::as_this(self.info.this(self)))
-    }
+        #[cfg(feature = "legacy-runtime")]
+        let this = T::as_this(self.info.this(self));
+        #[cfg(feature = "napi-runtime")]
+        let this = T::as_this(self.env(), self.info.this(self));
 
-    /// Produces a handle to the `this`-binding.
-    #[cfg(feature = "napi-runtime")]
-    pub fn this(&mut self, env: Env) -> Handle<'a, T> {
-        Handle::new_internal(T::as_this(env, self.info.this(self)))
+        Handle::new_internal(this)
     }
 }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -251,27 +251,19 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     /// Convenience method for creating a `JsNull` value.
-    #[cfg(feature = "legacy-runtime")]
     fn null(&mut self) -> Handle<'a, JsNull> {
-        JsNull::new()
-    }
-
-    /// Convenience method for creating a `JsNull` value.
-    #[cfg(feature = "napi-runtime")]
-    fn null(&mut self) -> Handle<'a, JsNull> {
-        JsNull::new(self)
+        #[cfg(feature = "legacy-runtime")]
+        return JsNull::new();
+        #[cfg(feature = "napi-runtime")]
+        return JsNull::new(self);
     }
 
     /// Convenience method for creating a `JsUndefined` value.
-    #[cfg(feature = "legacy-runtime")]
     fn undefined(&mut self) -> Handle<'a, JsUndefined> {
-        JsUndefined::new()
-    }
-
-    /// Convenience method for creating a `JsUndefined` value.
-    #[cfg(feature = "napi-runtime")]
-    fn undefined(&mut self) -> Handle<'a, JsUndefined> {
-        JsUndefined::new(self)
+        #[cfg(feature = "legacy-runtime")]
+        return JsUndefined::new();
+        #[cfg(feature = "napi-runtime")]
+        return JsUndefined::new(self);
     }
 
     /// Convenience method for creating an empty `JsObject` value.

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -119,7 +119,13 @@ pub trait Class: Managed + Any {
 }
 
 unsafe impl<T: Class> This for T {
+    #[cfg(feature = "legacy-runtime")]
     fn as_this(h: raw::Local) -> Self {
+        Self::from_raw(h)
+    }
+
+    #[cfg(feature = "napi-runtime")]
+    fn as_this(_env: Env, h: raw::Local) -> Self {
         Self::from_raw(h)
     }
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -2,16 +2,13 @@
 
 pub(crate) mod class;
 
-use neon_runtime::raw;
-use handle::Managed;
-
 pub use self::class::{Class, ClassDescriptor};
 pub use self::traits::*;
 
 #[cfg(feature = "legacy-runtime")]
 mod traits {
     use neon_runtime::raw;
-    use handle::Handle;
+    use handle::{Handle, Managed};
     use types::{Value, JsValue, JsArray, build};
     use types::utf8::Utf8;
     use context::Context;
@@ -74,15 +71,21 @@ mod traits {
             }
         }
     }
+
+    /// The trait of types that can be a function's `this` binding.
+    pub unsafe trait This: Managed {
+        fn as_this(h: raw::Local) -> Self;
+    }
 }
 
 #[cfg(feature = "napi-runtime")]
 mod traits {
     use neon_runtime::raw;
-    use handle::Handle;
+    use handle::{Handle, Managed};
     use types::{Value, JsValue, JsArray, build};
     use types::utf8::Utf8;
     use context::Context;
+    use context::internal::Env;
     use result::{NeonResult, JsResult, Throw};
 
     /// A property key in a JavaScript object.
@@ -189,9 +192,9 @@ mod traits {
             }
         }
     }
-}
 
-/// The trait of types that can be a function's `this` binding.
-pub unsafe trait This: Managed {
-    fn as_this(h: raw::Local) -> Self;
+    /// The trait of types that can be a function's `this` binding.
+    pub unsafe trait This: Managed {
+        fn as_this(env: Env, h: raw::Local) -> Self;
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -218,9 +218,18 @@ impl JsBoolean {
         }
     }
 
+    #[cfg(feature = "legacy-runtime")]
     pub fn value(self) -> bool {
         unsafe {
             neon_runtime::primitive::boolean_value(self.to_raw())
+        }
+    }
+
+    #[cfg(feature = "napi-runtime")]
+    pub fn value<'a, C: Context<'a>>(self, cx: &mut C) -> bool {
+        let env = cx.env().to_raw();
+        unsafe {
+            neon_runtime::primitive::boolean_value(env, self.to_raw())
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -539,8 +539,8 @@ impl JsFunction {
               U: Value
     {
         build(|out| {
+            let env = cx.env().to_raw();
             unsafe {
-                let env = std::mem::transmute(cx.env().to_raw());
                 let callback = FunctionCallback(f).into_c_callback();
                 neon_runtime::fun::new(out, env, callback)
             }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -206,14 +206,14 @@ impl ValueInternal for JsNull {
 pub struct JsBoolean(raw::Local);
 
 impl JsBoolean {
-    pub fn new<'a, C: Context<'a>>(_: &mut C, b: bool) -> Handle<'a, JsBoolean> {
-        JsBoolean::new_internal(b)
+    pub fn new<'a, C: Context<'a>>(cx: &mut C, b: bool) -> Handle<'a, JsBoolean> {
+        JsBoolean::new_internal(cx.env(), b)
     }
 
-    pub(crate) fn new_internal<'a>(b: bool) -> Handle<'a, JsBoolean> {
+    pub(crate) fn new_internal<'a>(env: Env, b: bool) -> Handle<'a, JsBoolean> {
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::primitive::boolean(&mut local, b);
+            neon_runtime::primitive::boolean(&mut local, env.to_raw(), b);
             Handle::new_internal(JsBoolean(local))
         }
     }

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -10,5 +10,7 @@ describe('hello', function() {
   it('should export global singletons for JS primitives', function () {
     assert.equal(addon.undefined, undefined);
     assert.equal(addon.null, null);
+    assert.equal(addon.true, true);
+    assert.equal(addon.false, false);
   });
 });

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -3,15 +3,15 @@ var assert = require('chai').assert;
 
 describe('hello', function() {
   it('should export a greeting', function () {
-    assert.equal(addon.greeting, "Hello, World!");
-    assert.equal(addon.greeting, addon.greetingCopy);
+    assert.strictEqual(addon.greeting, "Hello, World!");
+    assert.strictEqual(addon.greeting, addon.greetingCopy);
   });
 
   it('should export global singletons for JS primitives', function () {
-    assert.equal(addon.undefined, undefined);
+    assert.strictEqual(addon.undefined, undefined);
     assert.ok(addon.hasOwnProperty('undefined'));
-    assert.equal(addon.null, null);
-    assert.equal(addon.true, true);
-    assert.equal(addon.false, false);
+    assert.strictEqual(addon.null, null);
+    assert.strictEqual(addon.true, true);
+    assert.strictEqual(addon.false, false);
   });
 });

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -6,4 +6,9 @@ describe('hello', function() {
     assert.equal(addon.greeting, "Hello, World!");
     assert.equal(addon.greeting, addon.greetingCopy);
   });
+
+  it('should export global singletons for JS primitives', function () {
+    assert.equal(addon.undefined, undefined);
+    assert.equal(addon.null, null);
+  });
 });

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -9,6 +9,7 @@ describe('hello', function() {
 
   it('should export global singletons for JS primitives', function () {
     assert.equal(addon.undefined, undefined);
+    assert.ok(addon.hasOwnProperty('undefined'));
     assert.equal(addon.null, null);
     assert.equal(addon.true, true);
     assert.equal(addon.false, false);

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -13,6 +13,10 @@ register_module!(|mut cx| {
     let null = cx.null();
     let b_true = cx.boolean(true);
     let b_false = cx.boolean(false);
+
+    assert_eq!(b_true.value(&mut cx), true);
+    assert_eq!(b_false.value(&mut cx), false);
+
     cx.export_value("undefined", undefined)?;
     cx.export_value("null", null)?;
     cx.export_value("true", b_true)?;

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -8,5 +8,11 @@ register_module!(|mut cx| {
     cx.export_value("greeting", greeting)?;
     cx.export_value("greetingCopy", greeting_copy)?;
 
+    // Global singletons.
+    let undefined = cx.undefined();
+    let null = cx.null();
+    cx.export_value("undefined", undefined)?;
+    cx.export_value("null", null)?;
+
     Ok(())
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -11,8 +11,12 @@ register_module!(|mut cx| {
     // Global singletons.
     let undefined = cx.undefined();
     let null = cx.null();
+    let b_true = cx.boolean(true);
+    let b_false = cx.boolean(false);
     cx.export_value("undefined", undefined)?;
     cx.export_value("null", null)?;
+    cx.export_value("true", b_true)?;
+    cx.export_value("false", b_false)?;
 
     Ok(())
 });


### PR DESCRIPTION
Implements `cx.null()`, `cx.undefined()`, and `cx.boolean(b: bool)` for the n-api runtime.

n-api requires the `napi_env` value to be passed in to the `napi_get_*` functions. This patch passes the `raw::Env` to the neon-runtime functions like `neon_runtime::primitive::null`. For the legacy runtime, I've added some dummy `Isolate*` parameters in neon-sys, so we don't automatically need feature flags everywhere `neon_runtime` is used. I assume this should be fine, since `neon_runtime` is not public API(?).

A `This::as_this` trait method implementation was creating a `JsUndefined` value, so that trait was updated to receive the `Env` value as well in the n-api runtime.

(I initially tried to avoid all the feature flag switching it requires with a second trait `ThisCompat` that would have an `impl <T: ThisCompat> This for T {}` to unify the API, but that blanket implementation was not possible without exporting `ThisCompat`, so I decided against it. There were not _that_ many places that `This::as_this` was implemented/used anyway :smile: )