### PR TITLE
Workaround for Windows node-gyp bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ neon-runtime = { version = "=0.3.3", path = "crates/neon-runtime" }
 [features]
 default = ["legacy-runtime"]
 
+# Enable static tests. These can be fragile because of variations in Rust compiler
+# error message formatting from version to version, so they're disabled by default.
+enable-static-tests = []
+
 # Enable the default panic hook. Useful for debugging neon itself.
 default-panic-hook = []
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
 install:
   - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
   # Workaround until https://github.com/nodejs/node-gyp/issues/1933 is fixed.
-  - ps: if (($Env:NODEJS_VERSION -as [int]) -gt 10) { npm install -g npm@6.11.3 }
+  - npm install -g npm@6.11.3
   - npm config set msvs_version 2015
   - node -e "console.log(process.argv[0], process.arch, process.versions)"
   - curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,8 @@ environment:
 
 install:
   - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
+  # Workaround until https://github.com/nodejs/node-gyp/issues/1933 is fixed.
+  - ps: if (($Env:NODEJS_VERSION -as [int]) -gt 10) { npm install -g npm@6.11.3 }
   - npm config set msvs_version 2015
   - node -e "console.log(process.argv[0], process.arch, process.versions)"
   - curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,7 +431,7 @@ mod tests {
     fn static_test() { static_test_impl() }
 
     #[rustversion::beta]
-    #[not(cfg(feature = "enable-static-tests"))]
+    #[cfg(not(feature = "enable-static-tests"))]
     #[test]
     #[ignore]
     fn static_test() { static_test_impl() }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,14 @@ mod tests {
     // and any associated usability regressions before a new Rust version is shipped
     // but will have more stable results than Nightly.
     #[rustversion::beta]
+    #[cfg(feature = "enable-static-tests")]
     #[test]
+    fn static_test() { static_test_impl() }
+
+    #[rustversion::beta]
+    #[not(cfg(feature = "enable-static-tests"))]
+    #[test]
+    #[ignore]
     fn static_test() { static_test_impl() }
 
     #[rustversion::not(beta)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,10 @@ mod tests {
     fn static_test() { static_test_impl() }
 
     #[rustversion::not(beta)]
+    #[cfg(feature = "enable-static-tests")]
+    compile_error!("The `enable-static-tests` feature can only be enabled with the Rust beta toolchain.");
+
+    #[rustversion::not(beta)]
     #[test]
     #[ignore]
     fn static_test() { static_test_impl() }


### PR DESCRIPTION
See https://github.com/nodejs/node-gyp/issues/1933

This downgrades npm to the last version that didn't have the bug for Windows CI, to avoid hitting the bug. Once the above bug is fixed we can remove this workaround.