### PR TITLE
remove unnecessary macro from lib.rs template

### DIFF
--- a/cli/templates/Cargo.toml.hbs
+++ b/cli/templates/Cargo.toml.hbs
@@ -8,6 +8,7 @@ authors = ["{{project.author}}{{#if project.email}} <{{project.email}}>{{/if}}"]
 license = "{{project.license}}"
 {{/if}}
 build = "build.rs"
+edition = "2018"
 exclude = ["artifacts.json", "index.node"]
 
 [lib]

--- a/cli/templates/lib.rs.hbs
+++ b/cli/templates/lib.rs.hbs
@@ -1,5 +1,3 @@
-extern crate neon;
-
 use neon::prelude::*;
 
 fn hello(mut cx: FunctionContext) -> JsResult<JsString> {

--- a/cli/templates/lib.rs.hbs
+++ b/cli/templates/lib.rs.hbs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate neon;
 
 use neon::prelude::*;

--- a/test/cli/src/acceptance/new.ts
+++ b/test/cli/src/acceptance/new.ts
@@ -117,9 +117,6 @@ describe('neon new', function() {
       let indexjs = readFile(this.cwd, 'my-app/lib/index.js');
       assert.include(indexjs, `require('../native')`);
 
-      let librs = readFile(this.cwd, 'my-app/native/src/lib.rs');
-      assert.include(librs, `extern crate neon;`);
-
       done();
     });
   });


### PR DESCRIPTION
Creating a new neon project will always result in the following warnings:

```
warning: unused `#[macro_use]` import
 --> src/lib.rs:1:1
  |
1 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

    Finished dev [unoptimized + debuginfo] target(s) in 21.55s
```

To reproduce, run `neon new my-project` with `neon-cli@0.3.3`

Closes https://github.com/neon-bindings/neon/pull/447
Fixes https://github.com/neon-bindings/neon/issues/398