### PR TITLE
Read architecture from node-gyp correctly

### DIFF
--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -89,12 +89,12 @@ mod build {
         cmd
     }
 
-    // The node-gyp output includes platform information in a string
+    // The node-gyp build output includes platform information in a string
     // that looks like:
     //
-    //     gyp info using node@8.3.0 | win32 | x64
+    //     gyp verb architecture ia32
     fn parse_node_arch(node_gyp_output: &str) -> String {
-        let version_regex = Regex::new(r"node@(?P<version>\d+\.\d+\.\d+)\s+\|\s+(?P<platform>\w+)\s+\|\s(?P<arch>ia32|x64)").unwrap();
+        let version_regex = Regex::new(r"gyp verb architecture (?P<arch>ia32|x64)").unwrap();
         let captures = version_regex.captures(&node_gyp_output).unwrap();
         String::from(&captures["arch"])
     }
@@ -164,18 +164,19 @@ mod build {
         }
 
         if cfg!(windows) {
-            let node_gyp_output = String::from_utf8_lossy(&output.stderr);
-            println!("cargo:node_arch={}", parse_node_arch(&node_gyp_output));
             println!("cargo:node_root_dir={}", parse_node_root_dir(&node_gyp_output));
             println!("cargo:node_lib_file={}", parse_node_lib_file(&node_gyp_output));
         }
 
         // Run `node-gyp build`.
-        npm(native_dir)
+        let build_output = npm(native_dir)
             .args(&["run", if debug() { "build-debug" } else { "build-release" }])
-            .status()
+            .output()
             .ok()
             .expect("Failed to run \"node-gyp build\" for neon-sys!");
+
+        let node_gyp_build_output = String::from_utf8_lossy(&build_output.stderr);
+        println!("cargo:node_arch={}", parse_node_arch(&node_gyp_build_output));
     }
 
     // Link the built object file into a static library.

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -164,6 +164,7 @@ mod build {
         }
 
         if cfg!(windows) {
+            let node_gyp_output = String::from_utf8_lossy(&output.stderr);
             println!("cargo:node_root_dir={}", parse_node_root_dir(&node_gyp_output));
             println!("cargo:node_lib_file={}", parse_node_lib_file(&node_gyp_output));
         }

--- a/crates/neon-sys/native/package.json
+++ b/crates/neon-sys/native/package.json
@@ -4,8 +4,8 @@
     "preinstall": "echo 'Skipping node-gyp installation as part of npm install.'",
     "configure-release": "node-gyp configure --verbose",
     "configure-debug": "node-gyp configure --verbose --debug",
-    "build-release": "node-gyp build",
-    "build-debug": "node-gyp build --debug"
+    "build-release": "node-gyp build --verbose",
+    "build-debug": "node-gyp build --verbose --debug"
   },
   "dependencies": {
     "bindings": "1.2.1",


### PR DESCRIPTION
Reads the target architecture from the output of `node-gyp build` which prints the target architecture rather than the 'using' string that `node-gyp` prints (which is the platform it's running on).

This allows neon projects to build on platforms where the host's node binary is of a different architecture to the target architecture (eg. on Windows when building for x86 on an x64 host, even if using native x86 toolchains).

Fixes https://github.com/neon-bindings/neon/issues/490