### PR TITLE
Plain data objects

### DIFF
--- a/crates/neon-runtime/src/napi/array.rs
+++ b/crates/neon-runtime/src/napi/array.rs
@@ -7,6 +7,10 @@ use nodejs_sys as napi;
 pub unsafe extern "C" fn new(_out: &mut Local, _env: Env, _length: u32) { unimplemented!() }
 
 /// Gets the length of a `napi_value` containing a JavaScript Array.
+///
+/// # Panics
+/// This function panics if `array` is not an Array, or if a previous n-api call caused a pending
+/// exception.
 pub unsafe extern "C" fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
     assert_eq!(napi::napi_get_array_length(env, array, &mut len as *mut _), napi::napi_status::napi_ok);

--- a/crates/neon-runtime/src/napi/array.rs
+++ b/crates/neon-runtime/src/napi/array.rs
@@ -1,5 +1,14 @@
+//! Facilities for working with Array `napi_value`s.
+
 use raw::{Local, Env};
+
+use nodejs_sys as napi;
 
 pub unsafe extern "C" fn new(_out: &mut Local, _env: Env, _length: u32) { unimplemented!() }
 
-pub unsafe extern "C" fn len(_array: Local) -> u32 { unimplemented!() }
+/// Gets the length of a `napi_value` containing a JavaScript Array.
+pub unsafe extern "C" fn len(env: Env, array: Local) -> u32 {
+    let mut len = 0;
+    assert_eq!(napi::napi_get_array_length(env, array, &mut len as *mut _), napi::napi_status::napi_ok);
+    len
+}

--- a/crates/neon-runtime/src/napi/convert.rs
+++ b/crates/neon-runtime/src/napi/convert.rs
@@ -1,5 +1,11 @@
-use raw::Local;
+use nodejs_sys as napi;
+
+use raw::{Env, Local};
 
 pub unsafe extern "C" fn to_object(_out: &mut Local, _value: &Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn to_string(_out: &mut Local, _value: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn to_string(out: &mut Local, env: Env, value: Local) -> bool {
+    let status = napi::napi_coerce_to_string(env, value, out as *mut _);
+
+    status == napi::napi_status::napi_ok
+}

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -23,7 +23,12 @@ pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, ind
     status == napi::napi_status::napi_ok
 }
 
-pub unsafe extern "C" fn set_index(_out: &mut bool, _object: Local, _index: u32, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn set_index(out: &mut bool, env: Env, object: Local, index: u32, val: Local) -> bool {
+    let status = napi::napi_set_element(env, object, index, val);
+    *out = status == napi::napi_status::napi_ok;
+
+    *out
+}
 
 pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, key: *const u8, len: i32) -> bool {
     let mut key_val = MaybeUninit::uninit();

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -8,8 +8,13 @@ pub unsafe extern "C" fn new(out: &mut Local, env: Env) {
     napi::napi_create_object(env, out as *mut Local);
 }
 
-pub unsafe extern "C" fn get_own_property_names(_out: &mut Local, _object: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
+    let status = napi::napi_get_property_names(env, object, out as *mut Local);
 
+    status == napi::napi_status::napi_ok
+}
+
+// Unused.
 pub unsafe extern "C" fn get_isolate(_obj: Local) -> Env { unimplemented!() }
 
 pub unsafe extern "C" fn get_index(_out: &mut Local, _object: Local, _index: u32) -> bool { unimplemented!() }

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -16,7 +16,32 @@ pub unsafe extern "C" fn get_index(_out: &mut Local, _object: Local, _index: u32
 
 pub unsafe extern "C" fn set_index(_out: &mut bool, _object: Local, _index: u32, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn get_string(_out: &mut Local, _object: Local, _key: *const u8, _len: i32) -> bool { unimplemented!() }
+pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, key: *const u8, len: i32) -> bool {
+    let mut key_val = MaybeUninit::uninit();
+
+    // Not using `crate::string::new()` because it requires a _reference_ to a Local,
+    // while we only have uninitialized memory.
+    if napi::napi_create_string_utf8(
+        env,
+        key as *const i8,
+        len as usize,
+        key_val.as_mut_ptr(),
+    ) != napi::napi_status::napi_ok {
+        return false;
+    }
+
+    // Not using napi_get_named_property() because the `key` may not be null terminated.
+    if napi::napi_get_property(
+        env,
+        object,
+        key_val.assume_init(),
+        out as *mut Local,
+    ) != napi::napi_status::napi_ok {
+        return false;
+    }
+
+    true
+}
 
 pub unsafe extern "C" fn set_string(
     env: Env,
@@ -53,10 +78,15 @@ pub unsafe extern "C" fn set_string(
     true
 }
 
-pub unsafe extern "C" fn get(_out: &mut Local, _object: Local, _key: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool {
+    let status = napi::napi_get_property(env, object, key, out as *mut Local);
+
+    status == napi::napi_status::napi_ok
+}
 
 pub unsafe extern "C" fn set(out: &mut bool, env: Env, object: Local, key: Local, val: Local) -> bool {
     let status = napi::napi_set_property(env, object, key, val);
     *out = status == napi::napi_status::napi_ok;
-    return *out;
+
+    *out
 }

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -15,35 +15,69 @@ pub unsafe extern "C" fn new(out: &mut Local, env: Env) {
 /// Mutates the `out` argument to refer to a `napi_value` containing the own property names of the
 /// `object` as a JavaScript Array.
 pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
-    let status = napi::napi_get_property_names(env, object, out as *mut _);
-
-    if status != napi::napi_status::napi_ok {
+    // Node.js 13+ have `napi_get_all_property_names`, which does the conversion right and allows
+    // us to ask for only own properties or prototype properties or anything we like.
+    // Unfortunately, earlier versions do not support that method, so we have to implement it
+    // manually.
+    //
+    // So we use a temporary array for the raw names:
+    let mut raw_names = MaybeUninit::uninit();
+    if napi::napi_get_property_names(env, object, raw_names.as_mut_ptr()) != napi::napi_status::napi_ok {
+        return false;
+    }
+    // And a "fixed" array for the actual return value:
+    let mut fixed_names = MaybeUninit::uninit();
+    if napi::napi_create_array(env, fixed_names.as_mut_ptr()) != napi::napi_status::napi_ok {
         return false;
     }
 
-    // Before https://github.com/nodejs/node/pull/27524, `napi_get_property_names` would return
-    // numbers for numeric indices instead of strings.
-    let len = array::len(env, *out);
-    for index in 0..len {
-        let mut element: Local = std::mem::zeroed();
+    let raw_names = raw_names.assume_init();
+    let mut fixed_names = fixed_names.assume_init();
+
+    *out = fixed_names;
+
+    let raw_len = array::len(env, raw_names);
+    let mut fixed_len = 0;
+    for index in 0..raw_len {
+        let mut property_name: Local = std::mem::zeroed();
+
         // In general, getters may cause arbitrary JS code to be run, but this is a newly created
         // Array from an official internal API so it doesn't do anything strange.
-        if !get_index(&mut element, env, *out, index) {
+        if !get_index(&mut property_name, env, raw_names, index) {
             continue;
         }
-        if tag::is_string(env, element) {
-            continue;
-        }
-        let mut stringified: Local = std::mem::zeroed();
-        // If we can't convert to a string, something went wrong.
-        if !convert::to_string(&mut stringified, env, element) {
+
+        let mut is_own_property = false;
+        // May return a non-OK status if `key` is not a string or a Symbol, but here it is always
+        // a string.
+        if napi::napi_has_own_property(env, object, property_name, &mut is_own_property as *mut _) != napi::napi_status::napi_ok {
             return false;
         }
+
+        if !is_own_property {
+            continue;
+        }
+
+        // Before https://github.com/nodejs/node/pull/27524, `napi_get_property_names` would return
+        // numbers for numeric indices instead of strings.
+        // Make sure we always return strings.
+        let property_name = if !tag::is_string(env, property_name) {
+            let mut stringified: Local = std::mem::zeroed();
+            // If we can't convert to a string, something went wrong.
+            if !convert::to_string(&mut stringified, env, property_name) {
+                return false;
+            }
+            stringified
+        } else {
+            property_name
+        };
+
         let mut dummy = false;
         // If we can't convert assign to this array, something went wrong.
-        if !set_index(&mut dummy, env, *out, index, stringified) {
+        if !set_index(&mut dummy, env, fixed_names, fixed_len, property_name) {
             return false;
         }
+        fixed_len += 1;
     }
 
     true

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, objec
     }
 
     let raw_names = raw_names.assume_init();
-    let mut fixed_names = fixed_names.assume_init();
+    let fixed_names = fixed_names.assume_init();
 
     *out = fixed_names;
 
@@ -44,17 +44,6 @@ pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, objec
         // In general, getters may cause arbitrary JS code to be run, but this is a newly created
         // Array from an official internal API so it doesn't do anything strange.
         if !get_index(&mut property_name, env, raw_names, index) {
-            continue;
-        }
-
-        let mut is_own_property = false;
-        // May return a non-OK status if `key` is not a string or a Symbol, but here it is always
-        // a string.
-        if napi::napi_has_own_property(env, object, property_name, &mut is_own_property as *mut _) != napi::napi_status::napi_ok {
-            return false;
-        }
-
-        if !is_own_property {
             continue;
         }
 
@@ -71,6 +60,17 @@ pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, objec
         } else {
             property_name
         };
+
+        let mut is_own_property = false;
+        // May return a non-OK status if `key` is not a string or a Symbol, but here it is always
+        // a string.
+        if napi::napi_has_own_property(env, object, property_name, &mut is_own_property as *mut _) != napi::napi_status::napi_ok {
+            return false;
+        }
+
+        if !is_own_property {
+            continue;
+        }
 
         let mut dummy = false;
         // If we can't convert assign to this array, something went wrong.

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -4,7 +4,9 @@ use nodejs_sys as napi;
 
 use raw::{Env, Local};
 
-pub unsafe extern "C" fn new(_out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn new(out: &mut Local, env: Env) {
+    napi::napi_create_object(env, out as *mut Local);
+}
 
 pub unsafe extern "C" fn get_own_property_names(_out: &mut Local, _object: Local) -> bool { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -4,10 +4,13 @@ use nodejs_sys as napi;
 
 use raw::{Env, Local};
 
+/// Mutates the `out` argument to refer to a `napi_value` containing a newly created JavaScript Object.
 pub unsafe extern "C" fn new(out: &mut Local, env: Env) {
     napi::napi_create_object(env, out as *mut _);
 }
 
+/// Mutates the `out` argument to refer to a `napi_value` containing the own property names of the
+/// `object` as a JavaScript Array.
 pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
     let status = napi::napi_get_property_names(env, object, out as *mut _);
 
@@ -19,6 +22,7 @@ pub unsafe extern "C" fn get_isolate(_obj: Local) -> Env {
     unimplemented!()
 }
 
+/// Mutate the `out` argument to refer to the value at `index` in the given `object`. Returns `false` if the value couldn't be retrieved.
 pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, index: u32) -> bool {
     let status = napi::napi_get_element(env, object, index, out as *mut _);
 
@@ -39,6 +43,7 @@ pub unsafe extern "C" fn set_index(out: &mut bool, env: Env, object: Local, inde
     *out
 }
 
+/// Mutate the `out` argument to refer to the value at a named `key` in the given `object`. Returns `false` if the value couldn't be retrieved.
 pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, key: *const u8, len: i32) -> bool {
     let mut key_val = MaybeUninit::uninit();
 
@@ -88,6 +93,8 @@ pub unsafe extern "C" fn set_string(env: Env, out: &mut bool, object: Local, key
     true
 }
 
+/// Mutates `out` to refer to the value of the property of `object` named by the `key` value.
+/// Returns false if the value couldn't be retrieved.
 pub unsafe extern "C" fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool {
     let status = napi::napi_get_property(env, object, key, out as *mut _);
 

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -15,7 +15,9 @@ pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, objec
 }
 
 // Unused.
-pub unsafe extern "C" fn get_isolate(_obj: Local) -> Env { unimplemented!() }
+pub unsafe extern "C" fn get_isolate(_obj: Local) -> Env {
+    unimplemented!()
+}
 
 pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, index: u32) -> bool {
     let status = napi::napi_get_element(env, object, index, out as *mut _);
@@ -23,6 +25,13 @@ pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, ind
     status == napi::napi_status::napi_ok
 }
 
+/// Sets the key value of a `napi_value` at the `index` provided. Returns `true` if the set
+/// succeeded.
+///
+/// The `out` parameter and the return value contain the same information for historical reasons,
+/// see [discussion].
+///
+/// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
 pub unsafe extern "C" fn set_index(out: &mut bool, env: Env, object: Local, index: u32, val: Local) -> bool {
     let status = napi::napi_set_element(env, object, index, val);
     *out = status == napi::napi_status::napi_ok;
@@ -35,56 +44,43 @@ pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, ke
 
     // Not using `crate::string::new()` because it requires a _reference_ to a Local,
     // while we only have uninitialized memory.
-    if napi::napi_create_string_utf8(
-        env,
-        key as *const i8,
-        len as usize,
-        key_val.as_mut_ptr(),
-    ) != napi::napi_status::napi_ok {
+    if napi::napi_create_string_utf8(env, key as *const i8, len as usize, key_val.as_mut_ptr())
+        != napi::napi_status::napi_ok
+    {
         return false;
     }
 
     // Not using napi_get_named_property() because the `key` may not be null terminated.
-    if napi::napi_get_property(
-        env,
-        object,
-        key_val.assume_init(),
-        out as *mut _,
-    ) != napi::napi_status::napi_ok {
+    if napi::napi_get_property(env, object, key_val.assume_init(), out as *mut _)
+        != napi::napi_status::napi_ok
+    {
         return false;
     }
 
     true
 }
 
-pub unsafe extern "C" fn set_string(
-    env: Env,
-    out: &mut bool,
-    object: Local,
-    key: *const u8,
-    len: i32,
-    val: Local,
-) -> bool {
+/// Sets the key value of a `napi_value` at a named key. Returns `true` if the set succeeded.
+///
+/// The `out` parameter and the return value contain the same information for historical reasons,
+/// see [discussion].
+///
+/// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
+pub unsafe extern "C" fn set_string(env: Env, out: &mut bool, object: Local, key: *const u8, len: i32, val: Local) -> bool {
     let mut key_val = MaybeUninit::uninit();
 
     *out = true;
 
-    if napi::napi_create_string_utf8(
-        env,
-        key as *const i8,
-        len as usize,
-        key_val.as_mut_ptr(),
-    ) != napi::napi_status::napi_ok {
+    if napi::napi_create_string_utf8(env, key as *const i8, len as usize, key_val.as_mut_ptr())
+        != napi::napi_status::napi_ok
+    {
         *out = false;
         return false;
     }
 
-    if napi::napi_set_property(
-        env,
-        object,
-        key_val.assume_init(),
-        val,
-    ) != napi::napi_status::napi_ok {
+    if napi::napi_set_property(env, object, key_val.assume_init(), val)
+        != napi::napi_status::napi_ok
+    {
         *out = false;
         return false;
     }
@@ -98,6 +94,12 @@ pub unsafe extern "C" fn get(out: &mut Local, env: Env, object: Local, key: Loca
     status == napi::napi_status::napi_ok
 }
 
+/// Sets the property value of an `napi_value` object, named by another `napi_value` `key`. Returns `true` if the set succeeded.
+///
+/// The `out` parameter and the return value contain the same information for historical reasons,
+/// see [discussion].
+///
+/// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
 pub unsafe extern "C" fn set(out: &mut bool, env: Env, object: Local, key: Local, val: Local) -> bool {
     let status = napi::napi_set_property(env, object, key, val);
     *out = status == napi::napi_status::napi_ok;

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -5,11 +5,11 @@ use nodejs_sys as napi;
 use raw::{Env, Local};
 
 pub unsafe extern "C" fn new(out: &mut Local, env: Env) {
-    napi::napi_create_object(env, out as *mut Local);
+    napi::napi_create_object(env, out as *mut _);
 }
 
 pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
-    let status = napi::napi_get_property_names(env, object, out as *mut Local);
+    let status = napi::napi_get_property_names(env, object, out as *mut _);
 
     status == napi::napi_status::napi_ok
 }
@@ -17,7 +17,11 @@ pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, objec
 // Unused.
 pub unsafe extern "C" fn get_isolate(_obj: Local) -> Env { unimplemented!() }
 
-pub unsafe extern "C" fn get_index(_out: &mut Local, _object: Local, _index: u32) -> bool { unimplemented!() }
+pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, index: u32) -> bool {
+    let status = napi::napi_get_element(env, object, index, out as *mut _);
+
+    status == napi::napi_status::napi_ok
+}
 
 pub unsafe extern "C" fn set_index(_out: &mut bool, _object: Local, _index: u32, _val: Local) -> bool { unimplemented!() }
 
@@ -40,7 +44,7 @@ pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, ke
         env,
         object,
         key_val.assume_init(),
-        out as *mut Local,
+        out as *mut _,
     ) != napi::napi_status::napi_ok {
         return false;
     }
@@ -84,7 +88,7 @@ pub unsafe extern "C" fn set_string(
 }
 
 pub unsafe extern "C" fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool {
-    let status = napi::napi_get_property(env, object, key, out as *mut Local);
+    let status = napi::napi_get_property(env, object, key, out as *mut _);
 
     status == napi::napi_status::napi_ok
 }

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -55,4 +55,8 @@ pub unsafe extern "C" fn set_string(
 
 pub unsafe extern "C" fn get(_out: &mut Local, _object: Local, _key: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn set(_out: &mut bool, _object: Local, _key: Local, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn set(out: &mut bool, env: Env, object: Local, key: Local, val: Local) -> bool {
+    let status = napi::napi_set_property(env, object, key, val);
+    *out = status == napi::napi_status::napi_ok;
+    return *out;
+}

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -1,23 +1,38 @@
-use raw::Local;
+use raw::{Env, Local};
 
-pub unsafe extern "C" fn is_undefined(_val: Local) -> bool { unimplemented!() }
+use nodejs_sys as napi;
 
-pub unsafe extern "C" fn is_null(_val: Local) -> bool { unimplemented!() }
+unsafe fn is_type(env: Env, val: Local, expect: napi::napi_valuetype) -> bool {
+    let mut actual = napi::napi_valuetype::napi_undefined;
+    if napi::napi_typeof(env, val, &mut actual as *mut _) == napi::napi_status::napi_ok {
+        actual == expect
+    } else {
+        false
+    }
+}
 
-pub unsafe extern "C" fn is_number(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_undefined(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_boolean(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_null(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_string(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_number(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_number)
+}
 
-pub unsafe extern "C" fn is_object(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_boolean(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_boolean)
+}
 
-pub unsafe extern "C" fn is_array(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_string(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_function(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_object(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_error(_val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_array(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_buffer(_obj: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_function(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_arraybuffer(_obj: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_error(_env: Env, _val: Local) -> bool { unimplemented!() }
+
+pub unsafe extern "C" fn is_buffer(_env: Env, _obj: Local) -> bool { unimplemented!() }
+
+pub unsafe extern "C" fn is_arraybuffer(_env: Env, _obj: Local) -> bool { unimplemented!() }

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -23,7 +23,9 @@ pub unsafe extern "C" fn is_boolean(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_boolean)
 }
 
-pub unsafe extern "C" fn is_string(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_string(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_string)
+}
 
 pub unsafe extern "C" fn is_object(_env: Env, _val: Local) -> bool { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -2,6 +2,7 @@ use raw::{Env, Local};
 
 use nodejs_sys as napi;
 
+/// Return true if an `napi_value` `val` has the expected value type.
 unsafe fn is_type(env: Env, val: Local, expect: napi::napi_valuetype) -> bool {
     let mut actual = napi::napi_valuetype::napi_undefined;
     if napi::napi_typeof(env, val, &mut actual as *mut _) == napi::napi_status::napi_ok {
@@ -15,14 +16,17 @@ pub unsafe extern "C" fn is_undefined(_env: Env, _val: Local) -> bool { unimplem
 
 pub unsafe extern "C" fn is_null(_env: Env, _val: Local) -> bool { unimplemented!() }
 
+/// Is `val` a JavaScript number?
 pub unsafe extern "C" fn is_number(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_number)
 }
 
+/// Is `val` a JavaScript boolean?
 pub unsafe extern "C" fn is_boolean(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_boolean)
 }
 
+/// Is `val` a JavaScript string?
 pub unsafe extern "C" fn is_string(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_string)
 }

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -205,7 +205,7 @@ extern "C" size_t Neon_Buffer_Data(void **base_out, v8::Local<v8::Object> obj) {
   return node::Buffer::Length(obj);
 }
 
-extern "C" bool Neon_Tag_IsBuffer(v8::Local<v8::Value> obj) {
+extern "C" bool Neon_Tag_IsBuffer(v8::Isolate *isolate, v8::Local<v8::Value> obj) {
   return node::Buffer::HasInstance(obj);
 }
 
@@ -222,7 +222,7 @@ extern "C" size_t Neon_ArrayBuffer_Data(void **base_out, v8::Local<v8::ArrayBuff
 }
 
 
-extern "C" bool Neon_Tag_IsArrayBuffer(v8::Local<v8::Value> value) {
+extern "C" bool Neon_Tag_IsArrayBuffer(v8::Isolate *isolate, v8::Local<v8::Value> value) {
   return value->IsArrayBuffer();
 }
 
@@ -447,39 +447,39 @@ extern "C" bool Neon_Fun_Construct(v8::Local<v8::Object> *out, v8::Isolate *isol
   return maybe_result.ToLocal(out);
 }
 
-extern "C" bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsUndefined(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsUndefined();
 }
 
-extern "C" bool Neon_Tag_IsNull(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsNull(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsNull();
 }
 
-extern "C" bool Neon_Tag_IsNumber(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsNumber(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsNumber();
 }
 
-extern "C" bool Neon_Tag_IsBoolean(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsBoolean(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsBoolean();
 }
 
-extern "C" bool Neon_Tag_IsString(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsString(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsString();
 }
 
-extern "C" bool Neon_Tag_IsObject(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsObject(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsObject();
 }
 
-extern "C" bool Neon_Tag_IsArray(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsArray(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsArray();
 }
 
-extern "C" bool Neon_Tag_IsFunction(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsFunction(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsFunction();
 }
 
-extern "C" bool Neon_Tag_IsError(v8::Local<v8::Value> val) {
+extern "C" bool Neon_Tag_IsError(v8::Isolate *isolate, v8::Local<v8::Value> val) {
   return val->IsNativeError();
 }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -173,7 +173,7 @@ extern "C" size_t Neon_String_Data(char *out, size_t len, v8::Local<v8::Value> s
   return Nan::DecodeWrite(out, len, str, Nan::UTF8);
 }
 
-extern "C" bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Local<v8::Value> value) {
+extern "C" bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Isolate *isolate, v8::Local<v8::Value> value) {
   Nan::MaybeLocal<v8::String> maybe = Nan::To<v8::String>(value);
   return maybe.ToLocal(out);
 }

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -48,7 +48,7 @@ extern "C" void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t
   *out = (*info)[i];
 }
 
-extern "C" void Neon_Object_New(v8::Local<v8::Object> *out) {
+extern "C" void Neon_Object_New(v8::Local<v8::Object> *out, v8::Isolate *isolate) {
   *out = Nan::New<v8::Object>();
 }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -52,7 +52,7 @@ extern "C" void Neon_Object_New(v8::Local<v8::Object> *out, v8::Isolate *isolate
   *out = Nan::New<v8::Object>();
 }
 
-extern "C" bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Local<v8::Object> obj) {
+extern "C" bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Isolate *isolate, v8::Local<v8::Object> obj) {
   Nan::MaybeLocal<v8::Array> maybe = Nan::GetOwnPropertyNames(obj);
   return maybe.ToLocal(out);
 }

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -152,7 +152,7 @@ extern "C" void Neon_Array_New(v8::Local<v8::Array> *out, v8::Isolate *isolate, 
   *out = v8::Array::New(isolate, length);
 }
 
-extern "C" uint32_t Neon_Array_Length(v8::Local<v8::Array> array) {
+extern "C" uint32_t Neon_Array_Length(v8::Isolate *isolate, v8::Local<v8::Array> array) {
   return array->Length();
 }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -139,6 +139,7 @@ extern "C" bool Neon_Object_Get(v8::Local<v8::Value> *out, v8::Local<v8::Object>
 }
 
 extern "C" bool Neon_Object_Set(bool *out, v8::Local<v8::Object> obj, v8::Local<v8::Value> key, v8::Local<v8::Value> val) {
+  // Only returns `Just(true)` or `Empty()`.
   Nan::Maybe<bool> maybe = Nan::Set(obj, key, val);
   if (maybe.IsJust()) {
     *out = maybe.FromJust();

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -109,17 +109,17 @@ extern "C" {
 
   uint32_t Neon_Module_GetVersion();
 
-  bool Neon_Tag_IsUndefined(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsNull(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsBoolean(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsNumber(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsString(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsObject(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsArray(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsFunction(v8::Local<v8::Value> val);
-  bool Neon_Tag_IsBuffer(v8::Local<v8::Value> obj);
-  bool Neon_Tag_IsArrayBuffer(v8::Local<v8::Value> obj);
-  bool Neon_Tag_IsError(v8::Local<v8::Value> val);
+  bool Neon_Tag_IsUndefined(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsNull(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsBoolean(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsNumber(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsString(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsObject(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsArray(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsFunction(v8::Isolate *isolate, v8::Local<v8::Value> val);
+  bool Neon_Tag_IsBuffer(v8::Isolate *isolate, v8::Local<v8::Value> obj);
+  bool Neon_Tag_IsArrayBuffer(v8::Isolate *isolate, v8::Local<v8::Value> obj);
+  bool Neon_Tag_IsError(v8::Isolate *isolate, v8::Local<v8::Value> val);
 
   void Neon_Error_NewError(v8::Local<v8::Value> *out, v8::Local<v8::String> msg);
   void Neon_Error_NewTypeError(v8::Local<v8::Value> *out, v8::Local<v8::String> msg);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -46,7 +46,7 @@ extern "C" {
   int32_t Neon_String_Utf8Length(v8::Local<v8::String> str);
   size_t Neon_String_Data(char *out, size_t len, v8::Local<v8::Value> str);
 
-  bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Local<v8::Value> value);
+  bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Isolate *isolate, v8::Local<v8::Value> value);
   bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::Value> *value);
 
   bool Neon_Buffer_New(v8::Local<v8::Object> *out, uint32_t size);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -29,7 +29,7 @@ extern "C" {
   bool Neon_Primitive_IsUint32(v8::Local<v8::Primitive> p);
   bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p);
 
-  void Neon_Object_New(v8::Local<v8::Object> *out);
+  void Neon_Object_New(v8::Local<v8::Object> *out, v8::Isolate *isolate);
   bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Local<v8::Object> obj);
   void *Neon_Object_GetIsolate(v8::Local<v8::Object> obj);
   bool Neon_Object_Get_Index(v8::Local<v8::Value> *out, v8::Local<v8::Object> object, uint32_t index);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -30,7 +30,7 @@ extern "C" {
   bool Neon_Primitive_IsInt32(v8::Local<v8::Primitive> p);
 
   void Neon_Object_New(v8::Local<v8::Object> *out, v8::Isolate *isolate);
-  bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Local<v8::Object> obj);
+  bool Neon_Object_GetOwnPropertyNames(v8::Local<v8::Array> *out, v8::Isolate *isolate, v8::Local<v8::Object> obj);
   void *Neon_Object_GetIsolate(v8::Local<v8::Object> obj);
   bool Neon_Object_Get_Index(v8::Local<v8::Value> *out, v8::Local<v8::Object> object, uint32_t index);
   bool Neon_Object_Set_Index(bool *out, v8::Local<v8::Object> object, uint32_t index, v8::Local<v8::Value> val);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -40,7 +40,7 @@ extern "C" {
   bool Neon_Object_Set(bool *out, v8::Local<v8::Object> obj, v8::Local<v8::Value> key, v8::Local<v8::Value> val);
 
   void Neon_Array_New(v8::Local<v8::Array> *out, v8::Isolate *isolate, uint32_t length);
-  uint32_t Neon_Array_Length(v8::Local<v8::Array> array);
+  uint32_t Neon_Array_Length(v8::Isolate *isolate, v8::Local<v8::Array> array);
 
   bool Neon_String_New(v8::Local<v8::String> *out, v8::Isolate *isolate, const uint8_t *data, int32_t len);
   int32_t Neon_String_Utf8Length(v8::Local<v8::String> str);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -144,7 +144,7 @@ extern "C" {
     pub fn Neon_Module_GetVersion() -> i32;
 
     pub fn Neon_Object_New(out: &mut Local, isolate: Isolate);
-    pub fn Neon_Object_GetOwnPropertyNames(out: &mut Local, object: Local) -> bool;
+    pub fn Neon_Object_GetOwnPropertyNames(out: &mut Local, isolate: Isolate, object: Local) -> bool;
     pub fn Neon_Object_GetIsolate(obj: Local) -> Isolate;
     pub fn Neon_Object_Get_Index(out: &mut Local, object: Local, index: u32) -> bool;
     pub fn Neon_Object_Set_Index(out: &mut bool, object: Local, index: u32, val: Local) -> bool;

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -181,17 +181,17 @@ extern "C" {
     pub fn Neon_String_Utf8Length(str: Local) -> isize;
     pub fn Neon_String_Data(out: *mut u8, len: isize, str: Local) -> isize;
 
-    pub fn Neon_Tag_IsUndefined(val: Local) -> bool;
-    pub fn Neon_Tag_IsNull(val: Local) -> bool;
-    pub fn Neon_Tag_IsNumber(val: Local) -> bool;
-    pub fn Neon_Tag_IsBoolean(val: Local) -> bool;
-    pub fn Neon_Tag_IsString(val: Local) -> bool;
-    pub fn Neon_Tag_IsObject(val: Local) -> bool;
-    pub fn Neon_Tag_IsArray(val: Local) -> bool;
-    pub fn Neon_Tag_IsFunction(val: Local) -> bool;
-    pub fn Neon_Tag_IsError(val: Local) -> bool;
-    pub fn Neon_Tag_IsBuffer(obj: Local) -> bool;
-    pub fn Neon_Tag_IsArrayBuffer(obj: Local) -> bool;
+    pub fn Neon_Tag_IsUndefined(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsNull(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsNumber(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsBoolean(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsString(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsObject(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsArray(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsFunction(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsError(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsBuffer(isolate: Isolate, obj: Local) -> bool;
+    pub fn Neon_Tag_IsArrayBuffer(isolate: Isolate, obj: Local) -> bool;
 
     pub fn Neon_Task_Schedule(task: *mut c_void,
                               perform: unsafe extern fn(*mut c_void) -> *mut c_void,

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -84,7 +84,7 @@ pub struct InheritedHandleScope;
 extern "C" {
 
     pub fn Neon_Array_New(out: &mut Local, isolate: Isolate, length: u32);
-    pub fn Neon_Array_Length(array: Local) -> u32;
+    pub fn Neon_Array_Length(isolate: Isolate, array: Local) -> u32;
 
     pub fn Neon_ArrayBuffer_New(out: &mut Local, isolate: Isolate, size: u32) -> bool;
     pub fn Neon_ArrayBuffer_Data<'a, 'b>(base_out: &'a mut *mut c_void, obj: Local) -> usize;

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -143,7 +143,7 @@ extern "C" {
     pub fn Neon_Module_ExecCallback(callback: CCallback, exports: Local, vm: *mut c_void);
     pub fn Neon_Module_GetVersion() -> i32;
 
-    pub fn Neon_Object_New(out: &mut Local);
+    pub fn Neon_Object_New(out: &mut Local, isolate: Isolate);
     pub fn Neon_Object_GetOwnPropertyNames(out: &mut Local, object: Local) -> bool;
     pub fn Neon_Object_GetIsolate(obj: Local) -> Isolate;
     pub fn Neon_Object_Get_Index(out: &mut Local, object: Local, index: u32) -> bool;

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -123,7 +123,7 @@ extern "C" {
     pub fn Neon_Class_GetInstanceInternals(obj: Local) -> *mut c_void;
 
     pub fn Neon_Convert_ToObject(out: &mut Local, value: &Local) -> bool;
-    pub fn Neon_Convert_ToString(out: &mut Local, value: Local) -> bool;
+    pub fn Neon_Convert_ToString(out: &mut Local, isolate: Isolate, value: Local) -> bool;
 
     pub fn Neon_Error_Throw(val: Local);
     pub fn Neon_Error_NewError(out: &mut Local, msg: Local);

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -10,6 +10,7 @@ use neon_runtime;
 use neon_runtime::raw;
 use types::Value;
 use context::Context;
+#[cfg(feature = "legacy-runtime")]
 use context::internal::Env;
 use result::{JsResult, JsResultExt};
 use self::internal::SuperType;

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -10,6 +10,7 @@ use neon_runtime;
 use neon_runtime::raw;
 use types::Value;
 use context::Context;
+use context::internal::Env;
 use result::{JsResult, JsResultExt};
 use self::internal::SuperType;
 
@@ -102,6 +103,7 @@ impl<'a, T: Value> Handle<'a, T> {
         Handle::new_internal(SuperType::upcast_internal(self.value))
     }
 
+    #[cfg(feature = "legacy-runtime")]
     /// Tests whether this value is an instance of the given type.
     /// 
     /// # Example:
@@ -117,25 +119,77 @@ impl<'a, T: Value> Handle<'a, T> {
     /// # }
     /// ```
     pub fn is_a<U: Value>(&self) -> bool {
-        U::is_typeof(self.value)
+        U::is_typeof(Env::current(), self.value)
     }
 
+    #[cfg(feature = "napi-runtime")]
+    /// Tests whether this value is an instance of the given type.
+    /// 
+    /// # Example:
+    /// 
+    /// ```no_run
+    /// # use neon::prelude::*;
+    /// # fn my_neon_function(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    /// let v: Handle<JsValue> = cx.number(17).upcast(&mut cx);
+    /// v.is_a::<JsString>(&mut cx); // false
+    /// v.is_a::<JsNumber>(&mut cx); // true
+    /// v.is_a::<JsValue>(&mut cx);  // true
+    /// # Ok(cx.undefined())
+    /// # }
+    /// ```
+    pub fn is_a<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> bool {
+        U::is_typeof(cx.env(), self.value)
+    }
+
+    /// Tests whether this value is an instance of the given type.
+    ///
+    /// Works with both the legacy and the N-API runtime with the same signature. This allows other
+    /// parts of the codebase to care less about which version we're in.
+    pub(crate) fn is_a_compat<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> bool {
+        #[cfg(feature = "legacy-runtime")]
+        return self.is_a::<U>();
+        #[cfg(feature = "napi-runtime")]
+        return self.is_a::<U, C>(cx);
+    }
+
+    #[cfg(feature = "legacy-runtime")]
     /// Attempts to downcast a handle to another type, which may fail. A failure
     /// to downcast **does not** throw a JavaScript exception, so it's OK to
     /// continue interacting with the JS engine if this method produces an `Err`
     /// result.
     pub fn downcast<U: Value>(&self) -> DowncastResult<'a, T, U> {
-        match U::downcast(self.value) {
+        match U::downcast(Env::current(), self.value) {
             Some(v) => Ok(Handle::new_internal(v)),
             None => Err(DowncastError::new())
         }
     }
 
+    #[cfg(feature = "napi-runtime")]
+    /// Attempts to downcast a handle to another type, which may fail. A failure
+    /// to downcast **does not** throw a JavaScript exception, so it's OK to
+    /// continue interacting with the JS engine if this method produces an `Err`
+    /// result.
+    pub fn downcast<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> DowncastResult<'a, T, U> {
+        match U::downcast(cx.env(), self.value) {
+            Some(v) => Ok(Handle::new_internal(v)),
+            None => Err(DowncastError::new())
+        }
+    }
+
+    #[cfg(feature = "legacy-runtime")]
     /// Attempts to downcast a handle to another type, raising a JavaScript `TypeError`
     /// exception on failure. This method is a convenient shorthand, equivalent to
     /// `self.downcast::<U>().or_throw::<C>(cx)`.
     pub fn downcast_or_throw<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> JsResult<'a, U> {
         self.downcast().or_throw(cx)
+    }
+
+    #[cfg(feature = "napi-runtime")]
+    /// Attempts to downcast a handle to another type, raising a JavaScript `TypeError`
+    /// exception on failure. This method is a convenient shorthand, equivalent to
+    /// `self.downcast::<U>().or_throw::<C>(cx)`.
+    pub fn downcast_or_throw<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> JsResult<'a, U> {
+        self.downcast(cx).or_throw(cx)
     }
 
 }

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -141,17 +141,6 @@ impl<'a, T: Value> Handle<'a, T> {
         U::is_typeof(cx.env(), self.value)
     }
 
-    /// Tests whether this value is an instance of the given type.
-    ///
-    /// Works with both the legacy and the N-API runtime with the same signature. This allows other
-    /// parts of the codebase to care less about which version we're in.
-    pub(crate) fn is_a_compat<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> bool {
-        #[cfg(feature = "legacy-runtime")]
-        return self.is_a::<U>();
-        #[cfg(feature = "napi-runtime")]
-        return self.is_a::<U, C>(cx);
-    }
-
     #[cfg(feature = "legacy-runtime")]
     /// Attempts to downcast a handle to another type, which may fail. A failure
     /// to downcast **does not** throw a JavaScript exception, so it's OK to

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -20,7 +20,12 @@ impl<T: Class> Callback<()> for MethodCallback<T> {
             info.with_cx::<T, _, _>(|mut cx| {
                 let data = info.data();
                 let this: Handle<JsValue> = Handle::new_internal(JsValue::from_raw(info.this(&mut cx)));
-                let is_a_t = this.is_a_compat::<T, _>(&mut cx);
+
+                #[cfg(feature = "legacy-runtime")]
+                let is_a_t = this.is_a::<T>();
+                #[cfg(feature = "napi-runtime")]
+                let is_a_t = this.is_a::<T, _>(&mut cx);
+
                 if !is_a_t {
                     if let Ok(metadata) = T::metadata(&mut cx) {
                         neon_runtime::class::throw_this_error(mem::transmute(cx.env()), metadata.pointer);

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -20,7 +20,8 @@ impl<T: Class> Callback<()> for MethodCallback<T> {
             info.with_cx::<T, _, _>(|mut cx| {
                 let data = info.data();
                 let this: Handle<JsValue> = Handle::new_internal(JsValue::from_raw(info.this(&mut cx)));
-                if !this.is_a::<T>() {
+                let is_a_t = this.is_a_compat::<T, _>(&mut cx);
+                if !is_a_t {
                     if let Ok(metadata) = T::metadata(&mut cx) {
                         neon_runtime::class::throw_this_error(mem::transmute(cx.env()), metadata.pointer);
                     }

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -220,11 +220,8 @@ impl<T: Class> ValueInternal for T {
         }
     }
 
-    fn is_typeof<Other: Value>(value: Other) -> bool {
-        let mut isolate: Env = unsafe {
-            mem::transmute(neon_runtime::call::current_isolate())
-        };
-        let map = isolate.class_map();
+    fn is_typeof<Other: Value>(mut env: Env, value: Other) -> bool {
+        let map = env.class_map();
         match map.get(&TypeId::of::<T>()) {
             None => false,
             Some(ref metadata) => unsafe {

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -121,12 +121,12 @@ mod traits {
 
         unsafe fn set_from<'c, C: Context<'c>>(
             self,
-            _cx: &mut C,
+            cx: &mut C,
             out: &mut bool,
             obj: raw::Local,
             val: raw::Local,
         ) -> bool {
-            neon_runtime::object::set_index(out, obj, self, val)
+            neon_runtime::object::set_index(out, cx.env().to_raw(), obj, self, val)
         }
     }
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -130,11 +130,13 @@ mod traits {
     impl<'a, K: Value> PropertyKey for Handle<'a, K> {
         unsafe fn get_from<'c, C: Context<'c>>(
             self,
-            _cx: &mut C,
+            cx: &mut C,
             out: &mut raw::Local,
             obj: raw::Local
         ) -> bool {
-            neon_runtime::object::get(out, obj, self.to_raw())
+            let env = cx.env().to_raw();
+
+            neon_runtime::object::get(out, env, obj, self.to_raw())
         }
 
         unsafe fn set_from<'c, C: Context<'c>>(
@@ -144,19 +146,23 @@ mod traits {
             obj: raw::Local,
             val: raw::Local,
         ) -> bool {
-            neon_runtime::object::set(out, cx.env().to_raw(), obj, self.to_raw(), val)
+            let env = cx.env().to_raw();
+
+            neon_runtime::object::set(out, env, obj, self.to_raw(), val)
         }
     }
 
     impl<'a> PropertyKey for &'a str {
         unsafe fn get_from<'c, C: Context<'c>>(
             self,
-            _cx: &mut C,
+            cx: &mut C,
             out: &mut raw::Local,
             obj: raw::Local
         ) -> bool {
             let (ptr, len) = Utf8::from(self).into_small_unwrap().lower();
-            neon_runtime::object::get_string(out, obj, ptr, len)
+            let env = cx.env().to_raw();
+
+            neon_runtime::object::get_string(env, out, obj, ptr, len)
         }
 
         unsafe fn set_from<'c, C: Context<'c>>(

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -58,8 +58,11 @@ mod traits {
             build(|out| { unsafe { key.get_from(out, self.to_raw()) } })
         }
 
-        fn get_own_property_names<'a, C: Context<'a>>(self, _: &mut C) -> JsResult<'a, JsArray> {
-            build(|out| { unsafe { neon_runtime::object::get_own_property_names(out, self.to_raw()) } })
+        fn get_own_property_names<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsArray> {
+            let env = cx.env();
+            build(|out| {
+                unsafe { neon_runtime::object::get_own_property_names(out, env.to_raw(), self.to_raw()) }
+            })
         }
 
         fn set<'a, C: Context<'a>, K: PropertyKey, W: Value>(self, _: &mut C, key: K, val: Handle<W>) -> NeonResult<bool> {
@@ -185,8 +188,12 @@ mod traits {
             build(|out| { unsafe { key.get_from(cx, out, self.to_raw()) } })
         }
 
-        fn get_own_property_names<'a, C: Context<'a>>(self, _: &mut C) -> JsResult<'a, JsArray> {
-            build(|out| { unsafe { neon_runtime::object::get_own_property_names(out, self.to_raw()) } })
+        fn get_own_property_names<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsArray> {
+            let env = cx.env();
+
+            build(|out| {
+                unsafe { neon_runtime::object::get_own_property_names(out, env.to_raw(), self.to_raw()) }
+            })
         }
 
         fn set<'a, C: Context<'a>, K: PropertyKey, W: Value>(self, cx: &mut C, key: K, val: Handle<W>) -> NeonResult<bool> {

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -139,12 +139,12 @@ mod traits {
 
         unsafe fn set_from<'c, C: Context<'c>>(
             self,
-            _cx: &mut C,
+            cx: &mut C,
             out: &mut bool,
             obj: raw::Local,
             val: raw::Local,
         ) -> bool {
-            neon_runtime::object::set(out, obj, self.to_raw(), val)
+            neon_runtime::object::set(out, cx.env().to_raw(), obj, self.to_raw(), val)
         }
     }
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -112,11 +112,11 @@ mod traits {
     impl PropertyKey for u32 {
         unsafe fn get_from<'c, C: Context<'c>>(
             self,
-            _cx: &mut C,
+            cx: &mut C,
             out: &mut raw::Local,
             obj: raw::Local
         ) -> bool {
-            neon_runtime::object::get_index(out, obj, self)
+            neon_runtime::object::get_index(out, cx.env().to_raw(), obj, self)
         }
 
         unsafe fn set_from<'c, C: Context<'c>>(

--- a/src/types/binary.rs
+++ b/src/types/binary.rs
@@ -5,6 +5,7 @@ use std::mem::{self, MaybeUninit};
 use std::os::raw::c_void;
 use std::slice;
 use context::{Context, Lock};
+use context::internal::Env;
 use borrow::{Borrow, BorrowMut, Ref, RefMut, LoanError};
 use borrow::internal::Pointer;
 use handle::Managed;
@@ -42,8 +43,8 @@ impl Managed for JsBuffer {
 impl ValueInternal for JsBuffer {
     fn name() -> String { "Buffer".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_buffer(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_buffer(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -74,8 +75,8 @@ impl Managed for JsArrayBuffer {
 impl ValueInternal for JsArrayBuffer {
     fn name() -> String { "ArrayBuffer".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_arraybuffer(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_arraybuffer(env.to_raw(), other.to_raw()) }
     }
 }
 

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -6,6 +6,7 @@ use neon_runtime;
 use neon_runtime::raw;
 
 use context::Context;
+use context::internal::Env;
 use result::{NeonResult, Throw};
 use types::{Value, Object, Handle, Managed, build};
 use types::internal::ValueInternal;
@@ -25,8 +26,8 @@ impl Managed for JsError {
 impl ValueInternal for JsError {
     fn name() -> String { "Error".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_error(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_error(env.to_raw(), other.to_raw()) }
     }
 }
 

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -3,6 +3,7 @@ use std::os::raw::c_void;
 use neon_runtime;
 use neon_runtime::raw;
 use context::{CallbackInfo, FunctionContext};
+use context::internal::Env;
 use types::error::convert_panics;
 use types::{JsObject, Handle, Managed};
 use result::JsResult;
@@ -12,10 +13,10 @@ use super::Value;
 pub trait ValueInternal: Managed + 'static {
     fn name() -> String;
 
-    fn is_typeof<Other: Value>(other: Other) -> bool;
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool;
 
-    fn downcast<Other: Value>(other: Other) -> Option<Self> {
-        if Self::is_typeof(other) {
+    fn downcast<Other: Value>(env: Env, other: Other) -> Option<Self> {
+        if Self::is_typeof(env, other) {
             Some(Self::from_raw(other.to_raw()))
         } else {
             None

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -75,7 +75,7 @@ impl Managed for JsValue {
 impl ValueInternal for JsValue {
     fn name() -> String { "any".to_string() }
 
-    fn is_typeof<Other: Value>(_: Other) -> bool {
+    fn is_typeof<Other: Value>(_env: Env, _other: Other) -> bool {
         true
     }
 }
@@ -154,8 +154,8 @@ unsafe impl This for JsUndefined {
 impl ValueInternal for JsUndefined {
     fn name() -> String { "undefined".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_undefined(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_undefined(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -195,8 +195,8 @@ impl Managed for JsNull {
 impl ValueInternal for JsNull {
     fn name() -> String { "null".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_null(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_null(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -245,8 +245,8 @@ impl Managed for JsBoolean {
 impl ValueInternal for JsBoolean {
     fn name() -> String { "boolean".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_boolean(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_boolean(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -288,8 +288,8 @@ impl Managed for JsString {
 impl ValueInternal for JsString {
     fn name() -> String { "string".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_string(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_string(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -411,8 +411,8 @@ impl Managed for JsNumber {
 impl ValueInternal for JsNumber {
     fn name() -> String { "number".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_number(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_number(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -444,8 +444,8 @@ unsafe impl This for JsObject {
 impl ValueInternal for JsObject {
     fn name() -> String { "object".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_object(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_object(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -522,8 +522,8 @@ impl Managed for JsArray {
 impl ValueInternal for JsArray {
     fn name() -> String { "Array".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_array(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_array(env.to_raw(), other.to_raw()) }
     }
 }
 
@@ -615,7 +615,7 @@ impl<T: Object> Managed for JsFunction<T> {
 impl<T: Object> ValueInternal for JsFunction<T> {
     fn name() -> String { "function".to_string() }
 
-    fn is_typeof<Other: Value>(other: Other) -> bool {
-        unsafe { neon_runtime::tag::is_function(other.to_raw()) }
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_function(env.to_raw(), other.to_raw()) }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -50,8 +50,11 @@ impl<T: Object> SuperType<T> for JsObject {
 
 /// The trait shared by all JavaScript values.
 pub trait Value: ValueInternal {
-    fn to_string<'a, C: Context<'a>>(self, _: &mut C) -> JsResult<'a, JsString> {
-        build(|out| { unsafe { neon_runtime::convert::to_string(out, self.to_raw()) } })
+    fn to_string<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsString> {
+        let env = cx.env();
+        build(|out| {
+            unsafe { neon_runtime::convert::to_string(out, env.to_raw(), self.to_raw()) }
+        })
     }
 
     fn as_value<'a, C: Context<'a>>(self, _: &mut C) -> Handle<'a, JsValue> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -452,12 +452,14 @@ impl ValueInternal for JsObject {
 impl Object for JsObject { }
 
 impl JsObject {
-    pub fn new<'a, C: Context<'a>>(_: &mut C) -> Handle<'a, JsObject> {
-        JsObject::new_internal()
+    pub fn new<'a, C: Context<'a>>(c: &mut C) -> Handle<'a, JsObject> {
+        JsObject::new_internal(c.env())
     }
 
-    pub(crate) fn new_internal<'a>() -> Handle<'a, JsObject> {
-        JsObject::build(|out| { unsafe { neon_runtime::object::new(out) } })
+    pub(crate) fn new_internal<'a>(env: Env) -> Handle<'a, JsObject> {
+        JsObject::build(|out| {
+            unsafe { neon_runtime::object::new(out, env.to_raw()) }
+        })
     }
 
     pub(crate) fn build<'a, F: FnOnce(&mut raw::Local)>(init: F) -> Handle<'a, JsObject> {

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -25,6 +25,6 @@ describe('hello', function() {
       0: 1,
       a: 1,
       whatever: true
-    })
+    });
   });
 });

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -22,6 +22,7 @@ describe('hello', function() {
 
   it('should be able to create JS objects in rust', function () {
     assert.deepEqual(addon.rustCreated, {
+      0: 1,
       a: 1,
       whatever: true
     })

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -19,4 +19,11 @@ describe('hello', function() {
     assert.strictEqual(addon.one, 1);
     assert.strictEqual(addon.two, 2.1);
   });
+
+  it('should be able to create JS objects in rust', function () {
+    assert.deepEqual(addon.rustCreated, {
+      a: 1,
+      whatever: true
+    })
+  });
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -52,7 +52,7 @@ register_module!(|mut cx| {
     let property_names = rust_created.get_own_property_names(&mut cx)?
         .to_vec(&mut cx)?
         .into_iter()
-        .map(|value| value.to_string(&mut cx).unwrap().value(&mut cx))
+        .map(|value| value.downcast::<JsString, _>(&mut cx).unwrap().value(&mut cx))
         .collect::<Vec<_>>();
     assert_eq!(property_names, &["a", "whatever"]);
 

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -33,7 +33,10 @@ register_module!(|mut cx| {
     let rust_created = cx.empty_object();
     {
         let a = cx.number(1);
+        // set at name
         rust_created.set(&mut cx, "a", a)?;
+        // set at index
+        rust_created.set(&mut cx, 0, a)?;
     }
     {
         let whatever = cx.boolean(true);
@@ -42,6 +45,10 @@ register_module!(|mut cx| {
 
     assert_eq!({
         let v: Handle<JsNumber> = rust_created.get(&mut cx, "a")?.downcast_or_throw(&mut cx)?;
+        v.value(&mut cx)
+    }, 1.0f64);
+    assert_eq!({
+        let v: Handle<JsNumber> = rust_created.get(&mut cx, 0)?.downcast_or_throw(&mut cx)?;
         v.value(&mut cx)
     }, 1.0f64);
     assert_eq!({
@@ -54,7 +61,7 @@ register_module!(|mut cx| {
         .into_iter()
         .map(|value| value.downcast::<JsString, _>(&mut cx).unwrap().value(&mut cx))
         .collect::<Vec<_>>();
-    assert_eq!(property_names, &["a", "whatever"]);
+    assert_eq!(property_names, &["0", "a", "whatever"]);
 
     cx.export_value("rustCreated", rust_created)?;
 

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -49,6 +49,13 @@ register_module!(|mut cx| {
         v.value(&mut cx)
     }, true);
 
+    let property_names = rust_created.get_own_property_names(&mut cx)?
+        .to_vec(&mut cx)?
+        .into_iter()
+        .map(|value| value.to_string(&mut cx).unwrap().value(&mut cx))
+        .collect::<Vec<_>>();
+    assert_eq!(property_names, &["a", "whatever"]);
+
     cx.export_value("rustCreated", rust_created)?;
 
     Ok(())

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -59,8 +59,11 @@ register_module!(|mut cx| {
     let property_names = rust_created.get_own_property_names(&mut cx)?
         .to_vec(&mut cx)?
         .into_iter()
-        .map(|value| value.downcast::<JsString, _>(&mut cx).unwrap().value(&mut cx))
-        .collect::<Vec<_>>();
+        .map(|value| {
+            let string: Handle<JsString> = value.downcast_or_throw(&mut cx)?;
+            Ok(string.value(&mut cx))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     assert_eq!(property_names, &["0", "a", "whatever"]);
 
     cx.export_value("rustCreated", rust_created)?;

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -29,5 +29,18 @@ register_module!(|mut cx| {
     cx.export_value("one", one)?;
     cx.export_value("two", two)?;
 
+    // Plain objects.
+    let mut rust_created = cx.empty_object();
+    {
+        let a = cx.number(1);
+        rust_created.set(&mut cx, "a", a);
+    }
+    {
+        let whatever = cx.boolean(true);
+        rust_created.set(&mut cx, "whatever", whatever);
+    }
+
+    cx.export_value("rustCreated", rust_created);
+
     Ok(())
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -30,17 +30,17 @@ register_module!(|mut cx| {
     cx.export_value("two", two)?;
 
     // Plain objects.
-    let mut rust_created = cx.empty_object();
+    let rust_created = cx.empty_object();
     {
         let a = cx.number(1);
-        rust_created.set(&mut cx, "a", a);
+        rust_created.set(&mut cx, "a", a)?;
     }
     {
         let whatever = cx.boolean(true);
-        rust_created.set(&mut cx, "whatever", whatever);
+        rust_created.set(&mut cx, "whatever", whatever)?;
     }
 
-    cx.export_value("rustCreated", rust_created);
+    cx.export_value("rustCreated", rust_created)?;
 
     Ok(())
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -40,6 +40,15 @@ register_module!(|mut cx| {
         rust_created.set(&mut cx, "whatever", whatever)?;
     }
 
+    assert_eq!({
+        let v: Handle<JsNumber> = rust_created.get(&mut cx, "a")?.downcast_or_throw(&mut cx)?;
+        v.value(&mut cx)
+    }, 1.0f64);
+    assert_eq!({
+        let v: Handle<JsBoolean> = rust_created.get(&mut cx, "whatever")?.downcast_or_throw(&mut cx)?;
+        v.value(&mut cx)
+    }, true);
+
     cx.export_value("rustCreated", rust_created)?;
 
     Ok(())


### PR DESCRIPTION
Implements these 'plain object' operations:
- creating an empty object
- getting and setting properties, named properties, index properties
- listing properties

And the required tag checks to make that work, and the required array methods to make `get_own_property_names` usable.

Most of it is quite straightforward, just calling napi functions. The remaining changes are about passing `Env` values to functions that need it under n-api, but did not need it under nan. The test for the object code uses downcasting, and the downcasting and typecheck code did not previously receive a reference to the `Env`. The `js_array.len()` function also did not receive a reference to the `Env`, but needs one to eventually call the napi function.

For the `js_array.len()` function, which is used by other methods on the impl, I added a private `len_inner()` function with a consistent API to save some feature flag checks. It could be removed if the nan implementation is removed later.