### PR TITLE
Function calls

### DIFF
--- a/crates/neon-runtime/src/nan/call.rs
+++ b/crates/neon-runtime/src/nan/call.rs
@@ -18,7 +18,7 @@ pub use neon_sys::Neon_Call_IsConstruct as is_construct;
 /// the function is bound to.
 pub use neon_sys::Neon_Call_This as this;
 
-/// Mutates the `out` argument provided to refer to the `v8::Local` handle value of the
+/// Mutates the `out` argument provided to refer to the pointer value of the
 /// `v8::FunctionCallbackInfo` `Data`.
 pub use neon_sys::Neon_Call_Data as data;
 

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -30,7 +30,17 @@ pub unsafe extern "C" fn current_isolate() -> Env { panic!("current_isolate won'
 
 pub unsafe extern "C" fn is_construct(_info: FunctionCallbackInfo) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn this(_info: FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
+    let status = napi::napi_get_cb_info(
+        env,
+        info,
+        null_mut(),
+        null_mut(),
+        out as *mut _,
+        null_mut(),
+    );
+    assert_eq!(status, napi::napi_status::napi_ok);
+}
 
 /// Mutates the `out` argument provided to refer to the associated data value of the
 /// `napi_callback_info`.
@@ -45,7 +55,6 @@ pub unsafe extern "C" fn data(env: Env, info: FunctionCallbackInfo, out: &mut *m
         null_mut(),
         &mut data as *mut _,
     );
-    println!("data() status = {:?} argc = {}", status, argc);
     if status == napi::napi_status::napi_ok {
         *out = data;
     }

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn is_construct(_info: FunctionCallbackInfo) -> bool { uni
 
 pub unsafe extern "C" fn this(_info: FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
 
-pub unsafe extern "C" fn data(_info: FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn data(_env: Env, _info: FunctionCallbackInfo, _out: &mut *mut c_void) { unimplemented!() }
 
 pub unsafe extern "C" fn len(_info: FunctionCallbackInfo) -> i32 { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn len(env: Env, info: FunctionCallbackInfo) -> i32 {
 /// Mutates the `out` argument provided to refer to the `napi_value` of the `i`th argument
 /// passed to the function.
 pub unsafe extern "C" fn get(env: Env, info: FunctionCallbackInfo, i: i32, out: &mut Local) {
-    // TODO make this not allocate
+    // TODO make this not allocate: https://github.com/neon-bindings/neon/issues/530
     // Instead, we can probably get all the arguments at once in `neon` itself?
     let mut args = vec![null_mut(); (i + 1) as usize];
     let mut num_args = args.len();

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -2,6 +2,8 @@ use std::os::raw::c_void;
 use std::ptr::null_mut;
 use raw::{FunctionCallbackInfo, Env, Local};
 
+use nodejs_sys as napi;
+
 #[repr(C)]
 pub struct CCallback {
     pub static_callback: *mut c_void,
@@ -17,19 +19,21 @@ impl Default for CCallback {
     }
 }
 
-pub unsafe extern "C" fn set_return(_info: &FunctionCallbackInfo, _value: Local) { unimplemented!() }
+pub unsafe extern "C" fn set_return(_info: FunctionCallbackInfo, _value: Local) {
 
-pub unsafe extern "C" fn get_isolate(_info: &FunctionCallbackInfo) -> Env { unimplemented!() }
+}
+
+pub unsafe extern "C" fn get_isolate(info: FunctionCallbackInfo) -> Env { unimplemented!() }
 
 // FIXME: Remove. This will never be implemented
 pub unsafe extern "C" fn current_isolate() -> Env { panic!("current_isolate won't be implemented in n-api") }
 
-pub unsafe extern "C" fn is_construct(_info: &FunctionCallbackInfo) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_construct(_info: FunctionCallbackInfo) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn this(_info: &FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn this(_info: FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
 
-pub unsafe extern "C" fn data(_info: &FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn data(_info: FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
 
-pub unsafe extern "C" fn len(_info: &FunctionCallbackInfo) -> i32 { unimplemented!() }
+pub unsafe extern "C" fn len(_info: FunctionCallbackInfo) -> i32 { unimplemented!() }
 
-pub unsafe extern "C" fn get(_info: &FunctionCallbackInfo, _i: i32, _out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn get(_info: FunctionCallbackInfo, _i: i32, _out: &mut Local) { unimplemented!() }

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -46,11 +46,10 @@ pub unsafe extern "C" fn this(env: Env, info: FunctionCallbackInfo, out: &mut Lo
 /// `napi_callback_info`.
 pub unsafe extern "C" fn data(env: Env, info: FunctionCallbackInfo, out: &mut *mut c_void) {
     let mut data = null_mut();
-    let mut argc = 0usize;
     let status = napi::napi_get_cb_info(
         env,
         info,
-        &mut argc as *mut _,
+        null_mut(),
         null_mut(),
         null_mut(),
         &mut data as *mut _,

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -32,7 +32,22 @@ pub unsafe extern "C" fn is_construct(_info: FunctionCallbackInfo) -> bool { uni
 
 pub unsafe extern "C" fn this(_info: FunctionCallbackInfo, _out: &mut Local) { unimplemented!() }
 
-pub unsafe extern "C" fn data(_env: Env, _info: FunctionCallbackInfo, _out: &mut *mut c_void) { unimplemented!() }
+pub unsafe extern "C" fn data(env: Env, info: FunctionCallbackInfo, out: &mut *mut c_void) {
+    let mut data = null_mut();
+    let mut argc = 0usize;
+    let status = napi::napi_get_cb_info(
+        env,
+        info,
+        &mut argc as *mut _,
+        null_mut(),
+        null_mut(),
+        &mut data as *mut _,
+    );
+    println!("data() status = {:?} argc = {}", status, argc);
+    if status == napi::napi_status::napi_ok {
+        *out = data;
+    }
+}
 
 pub unsafe extern "C" fn len(_info: FunctionCallbackInfo) -> i32 { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/class.rs
+++ b/crates/neon-runtime/src/napi/class.rs
@@ -26,11 +26,11 @@ pub unsafe extern "C" fn metadata_to_constructor(_out: &mut Local, _isolate: Env
 
 // FIXME: get rid of all the "kernel" nomenclature
 
-pub unsafe extern "C" fn get_allocate_kernel(_obj: Local) -> *mut c_void { unimplemented!() }
+pub unsafe extern "C" fn get_allocate_kernel(_data: *mut c_void) -> *mut c_void { unimplemented!() }
 
-pub unsafe extern "C" fn get_construct_kernel(_obj: Local) -> *mut c_void { unimplemented!() }
+pub unsafe extern "C" fn get_construct_kernel(_data: *mut c_void) -> *mut c_void { unimplemented!() }
 
-pub unsafe extern "C" fn get_call_kernel(_obj: Local) -> *mut c_void { unimplemented!() }
+pub unsafe extern "C" fn get_call_kernel(_data: *mut c_void) -> *mut c_void { unimplemented!() }
 
 pub unsafe extern "C" fn constructor(_out: &mut Local, _ft: Local) -> bool { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -3,13 +3,77 @@
 use call::CCallback;
 use raw::{Env, Local};
 use std::os::raw::c_void;
+use std::mem::MaybeUninit;
+use std::ptr::{null, null_mut};
 
-pub unsafe extern "C" fn new(_out: &mut Local, _env: Env, _callback: CCallback) -> bool { unimplemented!() }
+use nodejs_sys as napi;
 
-pub unsafe extern "C" fn new_template(_out: &mut Local, _env: Env, _callback: CCallback) -> bool { unimplemented!() }
+/// Mutates the `out` argument provided to refer to a newly created `v8::Function`. Returns
+/// `false` if the value couldn't be created.
+pub unsafe extern "C" fn new(out: &mut Local, env: Env, callback: CCallback) -> bool {
+    let status = napi::napi_create_function(
+        env,
+        null(),
+        0,
+        Some(std::mem::transmute(callback.static_callback)),
+        callback.dynamic_callback,
+        out as *mut Local,
+    );
 
-pub unsafe extern "C" fn get_dynamic_callback(_env: Env, _data: *mut c_void) -> *mut c_void { unimplemented!() }
+    status == napi::napi_status::napi_ok
+}
 
-pub unsafe extern "C" fn call(_out: &mut Local, _env: Env, _fun: Local, _this: Local, _argc: i32, _argv: *mut c_void) -> bool { unimplemented!() }
+pub unsafe extern "C" fn new_template(_out: &mut Local, _env: Env, _callback: CCallback) -> bool {
+    unimplemented!()
+}
 
-pub unsafe extern "C" fn construct(_out: &mut Local, _env: Env, _fun: Local, _argc: i32, _argv: *mut c_void) -> bool { unimplemented!() }
+pub unsafe extern "C" fn get_dynamic_callback(env: Env, data: *mut c_void) -> *mut c_void {
+    data
+    /*
+    let mut value = null_mut();
+
+    // debug stuff
+    {
+        let mut ty = napi::napi_valuetype::napi_null;
+        let r = napi::napi_typeof(env, obj, &mut ty as *mut _);
+        dbg!(r,ty);
+        let d = &mut [0u8; 64];
+        let l = crate::string::utf8_len(env, obj);
+        crate::string::data(env, d.as_mut_ptr(), l, obj);
+        dbg!(std::str::from_utf8(&d[..l as usize]));
+    }
+    // end debug stuff
+
+    let status = napi::napi_get_value_external(
+        env,
+        obj,
+        &mut value as *mut _,
+    );
+    println!("get_dynamic_callback() status = {:?}", status);
+    if status != napi::napi_status::napi_ok {
+        return null_mut();
+    }
+    value
+    */
+}
+
+pub unsafe extern "C" fn call(
+    _out: &mut Local,
+    _env: Env,
+    _fun: Local,
+    _this: Local,
+    _argc: i32,
+    _argv: *mut c_void,
+) -> bool {
+    unimplemented!()
+}
+
+pub unsafe extern "C" fn construct(
+    _out: &mut Local,
+    _env: Env,
+    _fun: Local,
+    _argc: i32,
+    _argv: *mut c_void,
+) -> bool {
+    unimplemented!()
+}

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -37,12 +37,8 @@ pub unsafe extern "C" fn call(out: &mut Local, env: Env, fun: Local, this: Local
     status == napi::napi_status::napi_ok
 }
 
-pub unsafe extern "C" fn construct(
-    _out: &mut Local,
-    _env: Env,
-    _fun: Local,
-    _argc: i32,
-    _argv: *mut c_void,
-) -> bool {
-    unimplemented!()
+pub unsafe extern "C" fn construct(out: &mut Local, env: Env, fun: Local, argc: i32, argv: *mut c_void) -> bool {
+    let status = napi::napi_new_instance(env, fun, argc as usize, argv as *const _, out as *mut _);
+
+    status == napi::napi_status::napi_ok
 }

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -2,12 +2,13 @@
 
 use call::CCallback;
 use raw::{Env, Local};
+use std::os::raw::c_void;
 
 pub unsafe extern "C" fn new(_out: &mut Local, _env: Env, _callback: CCallback) -> bool { unimplemented!() }
 
 pub unsafe extern "C" fn new_template(_out: &mut Local, _env: Env, _callback: CCallback) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn get_dynamic_callback(_obj: Local) -> *mut c_void { unimplemented!() }
+pub unsafe extern "C" fn get_dynamic_callback(_env: Env, _data: *mut c_void) -> *mut c_void { unimplemented!() }
 
 pub unsafe extern "C" fn call(_out: &mut Local, _env: Env, _fun: Local, _this: Local, _argc: i32, _argv: *mut c_void) -> bool { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -1,4 +1,5 @@
-use std::os::raw::c_void;
+//! Facilities for working with JS functions.
+
 use call::CCallback;
 use raw::{Env, Local};
 

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -31,15 +31,10 @@ pub unsafe extern "C" fn get_dynamic_callback(env: Env, data: *mut c_void) -> *m
     data
 }
 
-pub unsafe extern "C" fn call(
-    _out: &mut Local,
-    _env: Env,
-    _fun: Local,
-    _this: Local,
-    _argc: i32,
-    _argv: *mut c_void,
-) -> bool {
-    unimplemented!()
+pub unsafe extern "C" fn call(out: &mut Local, env: Env, fun: Local, this: Local, argc: i32, argv: *mut c_void) -> bool {
+    let status = napi::napi_call_function(env, this, fun, argc as usize, argv as *const _, out as *mut _);
+
+    status == napi::napi_status::napi_ok
 }
 
 pub unsafe extern "C" fn construct(

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -29,32 +29,6 @@ pub unsafe extern "C" fn new_template(_out: &mut Local, _env: Env, _callback: CC
 
 pub unsafe extern "C" fn get_dynamic_callback(env: Env, data: *mut c_void) -> *mut c_void {
     data
-    /*
-    let mut value = null_mut();
-
-    // debug stuff
-    {
-        let mut ty = napi::napi_valuetype::napi_null;
-        let r = napi::napi_typeof(env, obj, &mut ty as *mut _);
-        dbg!(r,ty);
-        let d = &mut [0u8; 64];
-        let l = crate::string::utf8_len(env, obj);
-        crate::string::data(env, d.as_mut_ptr(), l, obj);
-        dbg!(std::str::from_utf8(&d[..l as usize]));
-    }
-    // end debug stuff
-
-    let status = napi::napi_get_value_external(
-        env,
-        obj,
-        &mut value as *mut _,
-    );
-    println!("get_dynamic_callback() status = {:?}", status);
-    if status != napi::napi_status::napi_ok {
-        return null_mut();
-    }
-    value
-    */
 }
 
 pub unsafe extern "C" fn call(

--- a/crates/neon-runtime/src/napi/raw.rs
+++ b/crates/neon-runtime/src/napi/raw.rs
@@ -3,9 +3,9 @@ use std::ptr;
 
 use nodejs_sys as napi;
 
-pub type  Local = napi::napi_value;
+pub type Local = napi::napi_value;
 
-pub type FunctionCallbackInfo = c_void;
+pub type FunctionCallbackInfo = napi::napi_callback_info;
 
 pub type Env = napi::napi_env;
 

--- a/crates/neon-runtime/src/napi/scope.rs
+++ b/crates/neon-runtime/src/napi/scope.rs
@@ -69,4 +69,6 @@ pub unsafe extern "C" fn escapable_size() -> usize { unimplemented!() }
 
 pub unsafe extern "C" fn escapable_alignment() -> usize { unimplemented!() }
 
-pub unsafe extern "C" fn get_global(_env: Env, _out: &mut Local) { unimplemented!() }
+pub unsafe extern "C" fn get_global(env: Env, out: &mut Local) {
+    assert_eq!(napi::napi_get_global(env, out as *mut _), napi::napi_status::napi_ok);
+}

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -31,7 +31,9 @@ pub unsafe extern "C" fn is_string(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_string)
 }
 
-pub unsafe extern "C" fn is_object(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_object(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_object)
+}
 
 pub unsafe extern "C" fn is_array(_env: Env, _val: Local) -> bool { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -35,7 +35,9 @@ pub unsafe extern "C" fn is_object(_env: Env, _val: Local) -> bool { unimplement
 
 pub unsafe extern "C" fn is_array(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_function(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_function)
+}
 
 pub unsafe extern "C" fn is_error(_env: Env, _val: Local) -> bool { unimplemented!() }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -43,11 +43,11 @@ extern "C" void Neon_Call_Data(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8
   }
 }
 
-extern "C" int32_t Neon_Call_Length(v8::FunctionCallbackInfo<v8::Value> *info) {
+extern "C" int32_t Neon_Call_Length(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info) {
   return info->Length();
 }
 
-extern "C" void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out) {
+extern "C" void Neon_Call_Get(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out) {
   *out = (*info)[i];
 }
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -37,6 +37,8 @@ extern "C" void Neon_Call_Data(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8
   printf("Call_Data: v8 info implicit:\n");
   dump_implicit((void *)info);
   */
+
+  // Call data is stored wrapped in a v8::External by Neon_Fun_New et al, so we need to unwrap it before handing it back to Rust.
   v8::Local<v8::Value> external = info->Data();
   if (external->IsExternal()) {
     *out = external.As<v8::External>()->Value();

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -26,7 +26,7 @@ extern "C" bool Neon_Call_IsConstruct(v8::FunctionCallbackInfo<v8::Value> *info)
   return info->IsConstructCall();
 }
 
-extern "C" void Neon_Call_This(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out) {
+extern "C" void Neon_Call_This(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out) {
   *out = info->This();
 }
 

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -17,7 +17,7 @@ extern "C" {
   void *Neon_Call_GetIsolate(v8::FunctionCallbackInfo<v8::Value> *info);
   void *Neon_Call_CurrentIsolate();
   bool Neon_Call_IsConstruct(v8::FunctionCallbackInfo<v8::Value> *info);
-  void Neon_Call_This(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out);
+  void Neon_Call_This(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out);
   void Neon_Call_Data(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, void **out);
   int32_t Neon_Call_Length(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_Get(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -19,8 +19,8 @@ extern "C" {
   bool Neon_Call_IsConstruct(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_This(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out);
   void Neon_Call_Data(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, void **out);
-  int32_t Neon_Call_Length(v8::FunctionCallbackInfo<v8::Value> *info);
-  void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);
+  int32_t Neon_Call_Length(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info);
+  void Neon_Call_Get(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);
 
   void Neon_Primitive_Number(v8::Local<v8::Number> *out, v8::Isolate *isolate, double value);
   void Neon_Primitive_Undefined(v8::Local<v8::Primitive> *out, v8::Isolate *isolate);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -18,7 +18,7 @@ extern "C" {
   void *Neon_Call_CurrentIsolate();
   bool Neon_Call_IsConstruct(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_This(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Object> *out);
-  void Neon_Call_Data(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Value> *out);
+  void Neon_Call_Data(v8::Isolate *isolate, v8::FunctionCallbackInfo<v8::Value> *info, void **out);
   int32_t Neon_Call_Length(v8::FunctionCallbackInfo<v8::Value> *info);
   void Neon_Call_Get(v8::FunctionCallbackInfo<v8::Value> *info, int32_t i, v8::Local<v8::Value> *out);
 
@@ -75,7 +75,7 @@ extern "C" {
 
   bool Neon_Fun_New(v8::Local<v8::Function> *out, v8::Isolate *isolate, callback_t callback);
   bool Neon_Fun_Template_New(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, callback_t callback);
-  void *Neon_Fun_GetDynamicCallback(v8::Local<v8::External> obj);
+  void *Neon_Fun_GetDynamicCallback(v8::Isolate *isolate, void *obj);
   bool Neon_Fun_Call(v8::Local<v8::Value> *out, v8::Isolate *isolate, v8::Local<v8::Function> fun, v8::Local<v8::Value> self, int32_t argc, v8::Local<v8::Value> argv[]);
   bool Neon_Fun_Construct(v8::Local<v8::Object> *out, v8::Isolate *isolate, v8::Local<v8::Function> fun, int32_t argc, v8::Local<v8::Value> argv[]);
 
@@ -95,9 +95,9 @@ extern "C" {
                               callback_t call,
                               Neon_DropCallback drop);
   // FIXME: get rid of all the "kernel" nomenclature
-  void *Neon_Class_GetCallKernel(v8::Local<v8::External> wrapper);
-  void *Neon_Class_GetConstructKernel(v8::Local<v8::External> wrapper);
-  void *Neon_Class_GetAllocateKernel(v8::Local<v8::External> wrapper);
+  void *Neon_Class_GetCallKernel(void *wrapper);
+  void *Neon_Class_GetConstructKernel(void *wrapper);
+  void *Neon_Class_GetAllocateKernel(void *wrapper);
   bool Neon_Class_Constructor(v8::Local<v8::Function> *out, v8::Local<v8::FunctionTemplate> ft);
   bool Neon_Class_HasInstance(void *metadata, v8::Local<v8::Value> v);
   bool Neon_Class_SetName(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -99,8 +99,8 @@ extern "C" {
     pub fn Neon_Call_IsConstruct(info: FunctionCallbackInfo) -> bool;
     pub fn Neon_Call_This(info: FunctionCallbackInfo, out: &mut Local);
     pub fn Neon_Call_Data(isolate: Isolate, info: FunctionCallbackInfo, out: &mut *mut c_void);
-    pub fn Neon_Call_Length(info: FunctionCallbackInfo) -> i32;
-    pub fn Neon_Call_Get(info: FunctionCallbackInfo, i: i32, out: &mut Local);
+    pub fn Neon_Call_Length(isolate: Isolate, info: FunctionCallbackInfo) -> i32;
+    pub fn Neon_Call_Get(isolate: Isolate, info: FunctionCallbackInfo, i: i32, out: &mut Local);
 
     pub fn Neon_Class_GetClassMap(isolate: Isolate) -> *mut c_void;
     pub fn Neon_Class_SetClassMap(isolate: Isolate, map: *mut c_void, free_map: *mut c_void);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -98,7 +98,7 @@ extern "C" {
     pub fn Neon_Call_CurrentIsolate() -> Isolate;
     pub fn Neon_Call_IsConstruct(info: FunctionCallbackInfo) -> bool;
     pub fn Neon_Call_This(info: FunctionCallbackInfo, out: &mut Local);
-    pub fn Neon_Call_Data(isolate: Isolate, info: FunctionCallbackInfo, out: &mut Local);
+    pub fn Neon_Call_Data(isolate: Isolate, info: FunctionCallbackInfo, out: &mut *mut c_void);
     pub fn Neon_Call_Length(info: FunctionCallbackInfo) -> i32;
     pub fn Neon_Call_Get(info: FunctionCallbackInfo, i: i32, out: &mut Local);
 
@@ -115,9 +115,9 @@ extern "C" {
     pub fn Neon_Class_ThrowThisError(isolate: Isolate, metadata: *mut c_void);
     pub fn Neon_Class_AddMethod(isolate: Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32, method: Local) -> bool;
     pub fn Neon_Class_MetadataToConstructor(out: &mut Local, isolate: Isolate, metadata: *mut c_void) -> bool;
-    pub fn Neon_Class_GetAllocateKernel(obj: Local) -> *mut c_void;
-    pub fn Neon_Class_GetConstructKernel(obj: Local) -> *mut c_void;
-    pub fn Neon_Class_GetCallKernel(obj: Local) -> *mut c_void;
+    pub fn Neon_Class_GetAllocateKernel(data: *mut c_void) -> *mut c_void;
+    pub fn Neon_Class_GetConstructKernel(data: *mut c_void) -> *mut c_void;
+    pub fn Neon_Class_GetCallKernel(data: *mut c_void) -> *mut c_void;
     pub fn Neon_Class_Constructor(out: &mut Local, ft: Local) -> bool;
     pub fn Neon_Class_HasInstance(metadata: *mut c_void, v: Local) -> bool;
     pub fn Neon_Class_GetInstanceInternals(obj: Local) -> *mut c_void;
@@ -133,7 +133,7 @@ extern "C" {
 
     pub fn Neon_Fun_New(out: &mut Local, isolate: Isolate, callback: CCallback) -> bool;
     pub fn Neon_Fun_Template_New(out: &mut Local, isolate: Isolate, callback: CCallback) -> bool;
-    pub fn Neon_Fun_GetDynamicCallback(obj: Local) -> *mut c_void;
+    pub fn Neon_Fun_GetDynamicCallback(isolate: Isolate, data: *mut c_void) -> *mut c_void;
     pub fn Neon_Fun_Call(out: &mut Local, isolate: Isolate, fun: Local, this: Local, argc: i32, argv: *mut c_void) -> bool;
     pub fn Neon_Fun_Construct(out: &mut Local, isolate: Isolate, fun: Local, argc: i32, argv: *mut c_void) -> bool;
 

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -16,7 +16,7 @@ pub struct Local {
 ///
 /// It contains the arguments used to invoke the function, the isolate reference, the `this` object
 /// the function is bound to and a mechanism to return a value to the caller.
-pub type FunctionCallbackInfo = c_void;
+pub type FunctionCallbackInfo = *const c_void;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -93,14 +93,14 @@ extern "C" {
     pub fn Neon_Buffer_Uninitialized(out: &mut Local, size: u32) -> bool;
     pub fn Neon_Buffer_Data<'a, 'b>(base_out: &'a mut *mut c_void, obj: Local) -> usize;
 
-    pub fn Neon_Call_SetReturn(info: &FunctionCallbackInfo, value: Local);
-    pub fn Neon_Call_GetIsolate(info: &FunctionCallbackInfo) -> Isolate;
+    pub fn Neon_Call_SetReturn(info: FunctionCallbackInfo, value: Local);
+    pub fn Neon_Call_GetIsolate(info: FunctionCallbackInfo) -> Isolate;
     pub fn Neon_Call_CurrentIsolate() -> Isolate;
-    pub fn Neon_Call_IsConstruct(info: &FunctionCallbackInfo) -> bool;
-    pub fn Neon_Call_This(info: &FunctionCallbackInfo, out: &mut Local);
-    pub fn Neon_Call_Data(info: &FunctionCallbackInfo, out: &mut Local);
-    pub fn Neon_Call_Length(info: &FunctionCallbackInfo) -> i32;
-    pub fn Neon_Call_Get(info: &FunctionCallbackInfo, i: i32, out: &mut Local);
+    pub fn Neon_Call_IsConstruct(info: FunctionCallbackInfo) -> bool;
+    pub fn Neon_Call_This(info: FunctionCallbackInfo, out: &mut Local);
+    pub fn Neon_Call_Data(isolate: Isolate, info: FunctionCallbackInfo, out: &mut Local);
+    pub fn Neon_Call_Length(info: FunctionCallbackInfo) -> i32;
+    pub fn Neon_Call_Get(info: FunctionCallbackInfo, i: i32, out: &mut Local);
 
     pub fn Neon_Class_GetClassMap(isolate: Isolate) -> *mut c_void;
     pub fn Neon_Class_SetClassMap(isolate: Isolate, map: *mut c_void, free_map: *mut c_void);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -97,7 +97,7 @@ extern "C" {
     pub fn Neon_Call_GetIsolate(info: FunctionCallbackInfo) -> Isolate;
     pub fn Neon_Call_CurrentIsolate() -> Isolate;
     pub fn Neon_Call_IsConstruct(info: FunctionCallbackInfo) -> bool;
-    pub fn Neon_Call_This(info: FunctionCallbackInfo, out: &mut Local);
+    pub fn Neon_Call_This(isolate: Isolate, info: FunctionCallbackInfo, out: &mut Local);
     pub fn Neon_Call_Data(isolate: Isolate, info: FunctionCallbackInfo, out: &mut *mut c_void);
     pub fn Neon_Call_Length(isolate: Isolate, info: FunctionCallbackInfo) -> i32;
     pub fn Neon_Call_Get(isolate: Isolate, info: FunctionCallbackInfo, i: i32, out: &mut Local);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -35,8 +35,8 @@ impl CallbackInfo {
         }
     }
 
-    pub unsafe fn with_cx<T: This, U, F: for<'a> FnOnce(CallContext<'a, T>) -> U>(&self, f: F) -> U {
-        CallContext::<T>::with(self, f)
+    pub unsafe fn with_cx<T: This, U, F: for<'a> FnOnce(CallContext<'a, T>) -> U>(&self, env: Env, f: F) -> U {
+        CallContext::<T>::with(env, self, f)
     }
 
     pub fn set_return<'a, 'b, T: Value>(&'a self, value: Handle<'b, T>) {
@@ -456,8 +456,7 @@ impl<'a, T: This> CallContext<'a, T> {
     /// Indicates whether the function was called via the JavaScript `[[Call]]` or `[[Construct]]` semantics.
     pub fn kind(&self) -> CallKind { self.info.kind() }
 
-    pub(crate) fn with<U, F: for<'b> FnOnce(CallContext<'b, T>) -> U>(info: &'a CallbackInfo, f: F) -> U {
-        let env = Env::current();
+    pub(crate) fn with<U, F: for<'b> FnOnce(CallContext<'b, T>) -> U>(env: Env, info: &'a CallbackInfo, f: F) -> U {
         Scope::with(env, |scope| {
             f(CallContext {
                 scope,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -20,6 +20,7 @@ use object::{Object, This};
 use object::class::Class;
 use result::{NeonResult, JsResult, Throw};
 use self::internal::{ContextInternal, Scope, ScopeMetadata};
+use std::os::raw::c_void;
 
 #[repr(C)]
 pub(crate) struct CallbackInfo {
@@ -30,7 +31,7 @@ impl CallbackInfo {
     pub fn data<'a>(&self) -> Handle<'a, JsValue> {
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::call::data(&self.info, &mut local);
+            neon_runtime::call::data(self.info, &mut local);
             Handle::new_internal(JsValue::from_raw(local))
         }
     }
@@ -41,7 +42,7 @@ impl CallbackInfo {
 
     pub fn set_return<'a, 'b, T: Value>(&'a self, value: Handle<'b, T>) {
         unsafe {
-            neon_runtime::call::set_return(&self.info, value.to_raw())
+            neon_runtime::call::set_return(self.info, value.to_raw())
         }
     }
 
@@ -55,7 +56,7 @@ impl CallbackInfo {
 
     pub fn len(&self) -> i32 {
         unsafe {
-            neon_runtime::call::len(&self.info)
+            neon_runtime::call::len(self.info)
         }
     }
 
@@ -65,7 +66,7 @@ impl CallbackInfo {
         }
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::call::get(&self.info, i, &mut local);
+            neon_runtime::call::get(self.info, i, &mut local);
             Some(Handle::new_internal(JsValue::from_raw(local)))
         }
     }
@@ -76,7 +77,7 @@ impl CallbackInfo {
         }
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::call::get(&self.info, i, &mut local);
+            neon_runtime::call::get(self.info, i, &mut local);
             Ok(Handle::new_internal(JsValue::from_raw(local)))
         }
     }
@@ -84,7 +85,7 @@ impl CallbackInfo {
     pub fn this<'b, V: Context<'b>>(&self, _: &mut V) -> raw::Local {
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::call::this(std::mem::transmute(&self.info), &mut local);
+            neon_runtime::call::this(std::mem::transmute(self.info), &mut local);
             local
         }
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -28,11 +28,11 @@ pub(crate) struct CallbackInfo {
 }
 
 impl CallbackInfo {
-    pub fn data<'a>(&self) -> Handle<'a, JsValue> {
+    pub fn data<'a>(&self, env: Env) -> *mut c_void {
         unsafe {
-            let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::call::data(self.info, &mut local);
-            Handle::new_internal(JsValue::from_raw(local))
+            let mut raw_data: *mut c_void = std::mem::zeroed();
+            neon_runtime::call::data(env.to_raw(), self.info, &mut raw_data);
+            raw_data
         }
     }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -82,10 +82,11 @@ impl CallbackInfo {
         }
     }
 
-    pub fn this<'b, V: Context<'b>>(&self, _: &mut V) -> raw::Local {
+    pub fn this<'b, C: Context<'b>>(&self, cx: &mut C) -> raw::Local {
+        let env = cx.env();
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            neon_runtime::call::this(std::mem::transmute(self.info), &mut local);
+            neon_runtime::call::this(env.to_raw(), std::mem::transmute(self.info), &mut local);
             local
         }
     }

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -15,7 +15,7 @@ use types::error::convert_panics;
 pub struct MethodCallback<T: Class>(pub fn(CallContext<T>) -> JsResult<JsValue>);
 
 impl<T: Class> Callback<()> for MethodCallback<T> {
-    extern "C" fn invoke(env: Env, info: &CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: CallbackInfo) {
         unsafe {
             info.with_cx::<T, _, _>(env, |mut cx| {
                 let data = info.data();
@@ -65,7 +65,7 @@ impl ConstructorCallCallback {
 }
 
 impl Callback<()> for ConstructorCallCallback {
-    extern "C" fn invoke(env: Env, info: &CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: CallbackInfo) {
         unsafe {
             info.with_cx(env, |cx| {
                 let data = info.data();
@@ -87,7 +87,7 @@ impl Callback<()> for ConstructorCallCallback {
 pub struct AllocateCallback<T: Class>(pub fn(CallContext<JsUndefined>) -> NeonResult<T::Internals>);
 
 impl<T: Class> Callback<*mut c_void> for AllocateCallback<T> {
-    extern "C" fn invoke(env: Env, info: &CallbackInfo) -> *mut c_void {
+    extern "C" fn invoke(env: Env, info: CallbackInfo) -> *mut c_void {
         unsafe {
             info.with_cx(env, |cx| {
                 let data = info.data();
@@ -112,7 +112,7 @@ impl<T: Class> Callback<*mut c_void> for AllocateCallback<T> {
 pub struct ConstructCallback<T: Class>(pub fn(CallContext<T>) -> NeonResult<Option<Handle<JsObject>>>);
 
 impl<T: Class> Callback<bool> for ConstructCallback<T> {
-    extern "C" fn invoke(env: Env, info: &CallbackInfo) -> bool {
+    extern "C" fn invoke(env: Env, info: CallbackInfo) -> bool {
         unsafe {
             info.with_cx(env, |cx| {
                 let data = info.data();

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -15,7 +15,7 @@ use types::error::convert_panics;
 pub struct MethodCallback<T: Class>(pub fn(CallContext<T>) -> JsResult<JsValue>);
 
 impl<T: Class> Callback<()> for MethodCallback<T> {
-    extern "C" fn invoke(env: Env, info: CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) {
         unsafe {
             info.with_cx::<T, _, _>(env, |mut cx| {
                 let data = info.data(cx.env());
@@ -65,7 +65,7 @@ impl ConstructorCallCallback {
 }
 
 impl Callback<()> for ConstructorCallCallback {
-    extern "C" fn invoke(env: Env, info: CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) {
         unsafe {
             info.with_cx(env, |cx| {
                 let data = info.data(cx.env());
@@ -87,7 +87,7 @@ impl Callback<()> for ConstructorCallCallback {
 pub struct AllocateCallback<T: Class>(pub fn(CallContext<JsUndefined>) -> NeonResult<T::Internals>);
 
 impl<T: Class> Callback<*mut c_void> for AllocateCallback<T> {
-    extern "C" fn invoke(env: Env, info: CallbackInfo) -> *mut c_void {
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) -> *mut c_void {
         unsafe {
             info.with_cx(env, |cx| {
                 let data = info.data(cx.env());
@@ -112,7 +112,7 @@ impl<T: Class> Callback<*mut c_void> for AllocateCallback<T> {
 pub struct ConstructCallback<T: Class>(pub fn(CallContext<T>) -> NeonResult<Option<Handle<JsObject>>>);
 
 impl<T: Class> Callback<bool> for ConstructCallback<T> {
-    extern "C" fn invoke(env: Env, info: CallbackInfo) -> bool {
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) -> bool {
         unsafe {
             info.with_cx(env, |cx| {
                 let data = info.data(cx.env());

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -269,13 +269,13 @@ pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
     /// Extracts the computed Rust function and invokes it. The Neon runtime
     /// ensures that the computed function is provided as the extra data field,
     /// wrapped as a V8 External, in the `CallbackInfo` argument.
-    extern "C" fn invoke(env: Env, info: CallbackInfo) -> T;
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) -> T;
 
     /// See `invoke`. This is used by the non-n-api implementation, so that every impl for this
     /// trait doesn't need to provide two versions of `invoke`.
     #[cfg(feature = "legacy-runtime")]
     #[doc(hidden)]
-    extern "C" fn invoke_compat(info: CallbackInfo) -> T {
+    extern "C" fn invoke_compat(info: CallbackInfo<'_>) -> T {
         Self::invoke(Env::current(), info)
     }
 

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -269,13 +269,13 @@ pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
     /// Extracts the computed Rust function and invokes it. The Neon runtime
     /// ensures that the computed function is provided as the extra data field,
     /// wrapped as a V8 External, in the `CallbackInfo` argument.
-    extern "C" fn invoke(env: Env, info: &CallbackInfo) -> T;
+    extern "C" fn invoke(env: Env, info: CallbackInfo) -> T;
 
     /// See `invoke`. This is used by the non-n-api implementation, so that every impl for this
     /// trait doesn't need to provide two versions of `invoke`.
     #[cfg(feature = "legacy-runtime")]
     #[doc(hidden)]
-    extern "C" fn invoke_compat(info: &CallbackInfo) -> T {
+    extern "C" fn invoke_compat(info: CallbackInfo) -> T {
         Self::invoke(Env::current(), info)
     }
 

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -35,9 +35,9 @@ impl<T: Value> Callback<()> for FunctionCallback<T> {
     extern "C" fn invoke(env: Env, info: CallbackInfo) {
         unsafe {
             info.with_cx::<JsObject, _, _>(env, |cx| {
-                let data = info.data();
+                let data = info.data(env);
                 let dynamic_callback: fn(FunctionContext) -> JsResult<T> =
-                    mem::transmute(neon_runtime::fun::get_dynamic_callback(data.to_raw()));
+                    mem::transmute(neon_runtime::fun::get_dynamic_callback(env.to_raw(), data));
                 if let Ok(value) = convert_panics(|| { dynamic_callback(cx) }) {
                     info.set_return(value);
                 }

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -32,7 +32,7 @@ pub trait ValueInternal: Managed + 'static {
 pub struct FunctionCallback<T: Value>(pub fn(FunctionContext) -> JsResult<T>);
 
 impl<T: Value> Callback<()> for FunctionCallback<T> {
-    extern "C" fn invoke(env: Env, info: &CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: CallbackInfo) {
         unsafe {
             info.with_cx::<JsObject, _, _>(env, |cx| {
                 let data = info.data();

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -32,9 +32,9 @@ pub trait ValueInternal: Managed + 'static {
 pub struct FunctionCallback<T: Value>(pub fn(FunctionContext) -> JsResult<T>);
 
 impl<T: Value> Callback<()> for FunctionCallback<T> {
-    extern "C" fn invoke(info: &CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: &CallbackInfo) {
         unsafe {
-            info.with_cx::<JsObject, _, _>(|cx| {
+            info.with_cx::<JsObject, _, _>(env, |cx| {
                 let data = info.data();
                 let dynamic_callback: fn(FunctionContext) -> JsResult<T> =
                     mem::transmute(neon_runtime::fun::get_dynamic_callback(data.to_raw()));

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -62,8 +62,13 @@ impl<T: Value> Callback<raw::Local> for FunctionCallback<T> {
                 if let Ok(value) = convert_panics(|| { dynamic_callback(cx) }) {
                     value.to_raw()
                 } else {
-                    // TODO this should probably not be null
-                    std::ptr::null_mut()
+                    // What should we return if the function panicked?
+                    //
+                    // `ptr::null_mut()` may work, but we should have a test to verify that, which
+                    // can be created after [#505][0]. For now, let's not guess!
+                    //
+                    // [0]: https://github.com/neon-bindings/neon/pull/505.
+                    unimplemented!("cannot return from function after a panic")
                 }
             })
         }

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -33,7 +33,7 @@ pub struct FunctionCallback<T: Value>(pub fn(FunctionContext) -> JsResult<T>);
 
 #[cfg(feature = "legacy-runtime")]
 impl<T: Value> Callback<()> for FunctionCallback<T> {
-    extern "C" fn invoke(env: Env, info: CallbackInfo) {
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) {
         unsafe {
             info.with_cx::<JsObject, _, _>(env, |cx| {
                 let data = info.data(env);
@@ -53,7 +53,7 @@ impl<T: Value> Callback<()> for FunctionCallback<T> {
 
 #[cfg(feature = "napi-runtime")]
 impl<T: Value> Callback<raw::Local> for FunctionCallback<T> {
-    extern "C" fn invoke(env: Env, info: CallbackInfo) -> raw::Local {
+    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) -> raw::Local {
         unsafe {
             info.with_cx::<JsObject, _, _>(env, |cx| {
                 let data = info.data(env);

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -11,7 +11,7 @@ describe('JsFunction', function() {
   });
 
   // The n-api runtime cannot yet call JS functions.
-  it.skip('call a JsFunction built in JS that implements x => x + 1', function () {
+  it('call a JsFunction built in JS that implements x => x + 1', function () {
     assert.equal(addon.call_js_function(function(x) { return x + 1 }), 17);
   });
 

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -22,12 +22,12 @@ describe('JsFunction', function() {
     addon.check_string_and_number("string", 42);
   });
 
-  // The n-api runtime doesn't yet handle panics.
+  // The N-API runtime doesn't yet handle panics.
   it.skip('converts a Rust panic to a throw in a function', function() {
     assert.throws(function() { addon.panic() }, Error, /^internal error in Neon module: zomg$/);
   });
 
-  // The n-api runtime doesn't yet handle panics.
+  // The N-API runtime doesn't yet handle panics.
   it.skip('lets panic override a throw', function() {
     assert.throws(function() { addon.panic_after_throw() }, Error, /^internal error in Neon module: this should override the RangeError$/);
   });
@@ -73,19 +73,19 @@ describe('JsFunction', function() {
     assert.equal(addon.is_argument_zero_some.call(null, ['a', 'b']), true);
   });
 
-  // The n-api runtime cannot yet throw errors.
+  // The N-API runtime cannot yet throw errors.
   it.skip('correctly casts an argument via cx.arguments', function() {
     assert.equal(addon.require_argument_zero_string('foobar'), 'foobar');
     assert.throws(function() { addon.require_argument_zero_string(new Date()) }, TypeError);
     assert.throws(function() { addon.require_argument_zero_string(17) }, TypeError);
   });
 
-  // The n-api runtime does not support scoped computation yet.
+  // The N-API runtime does not support scoped computation yet.
   it.skip('executes a scoped computation', function() {
     assert.equal(addon.execute_scoped(), 99);
   });
 
-  // The n-api runtime does not support scoped computation yet.
+  // The N-API runtime does not support scoped computation yet.
   it.skip('computes a value in a scoped computation', function() {
     assert.equal(addon.compute_scoped(), 99);
   });

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -55,7 +55,7 @@ describe('JsFunction', function() {
   });
 
   // The n-api runtime cannot yet access `this`.
-  it.skip('can manipulate an object `this` binding', function() {
+  it('can manipulate an object `this` binding', function() {
     var o = { modified: false };
     addon.require_object_this.call(o);
     assert.equal(o.modified, true);

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -16,7 +16,7 @@ describe('JsFunction', function() {
   });
 
   // The n-api runtime cannot yet call JS functions.
-  it.skip('new a JsFunction', function () {
+  it('new a JsFunction', function () {
     assert.equal(addon.construct_js_function(Date), 1970);
   });
 

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -10,12 +10,10 @@ describe('JsFunction', function() {
     assert.equal(addon.return_js_function()(41), 42);
   });
 
-  // The n-api runtime cannot yet call JS functions.
   it('call a JsFunction built in JS that implements x => x + 1', function () {
     assert.equal(addon.call_js_function(function(x) { return x + 1 }), 17);
   });
 
-  // The n-api runtime cannot yet call JS functions.
   it('new a JsFunction', function () {
     assert.equal(addon.construct_js_function(Date), 1970);
   });

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -1,0 +1,97 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('JsFunction', function() {
+  it('return a JsFunction built in Rust', function () {
+    assert.isFunction(addon.return_js_function());
+  });
+
+  it('return a JsFunction built in Rust that implements x => x + 1', function () {
+    assert.equal(addon.return_js_function()(41), 42);
+  });
+
+  // The n-api runtime cannot yet call JS functions.
+  it.skip('call a JsFunction built in JS that implements x => x + 1', function () {
+    assert.equal(addon.call_js_function(function(x) { return x + 1 }), 17);
+  });
+
+  // The n-api runtime cannot yet call JS functions.
+  it.skip('new a JsFunction', function () {
+    assert.equal(addon.construct_js_function(Date), 1970);
+  });
+
+  it('got two parameters, a string and a number', function() {
+    addon.check_string_and_number("string", 42);
+  });
+
+  // The n-api runtime doesn't yet handle panics.
+  it.skip('converts a Rust panic to a throw in a function', function() {
+    assert.throws(function() { addon.panic() }, Error, /^internal error in Neon module: zomg$/);
+  });
+
+  // The n-api runtime doesn't yet handle panics.
+  it.skip('lets panic override a throw', function() {
+    assert.throws(function() { addon.panic_after_throw() }, Error, /^internal error in Neon module: this should override the RangeError$/);
+  });
+
+  it('computes the right number of arguments', function() {
+    assert.equal(addon.num_arguments(), 0);
+    assert.equal(addon.num_arguments('a'), 1);
+    assert.equal(addon.num_arguments('a', 'b'), 2);
+    assert.equal(addon.num_arguments('a', 'b', 'c'), 3);
+    assert.equal(addon.num_arguments('a', 'b', 'c', 'd'), 4);
+  });
+
+  // The n-api runtime cannot yet access `this`.
+  it.skip('gets the right `this`-value', function() {
+    var o = { iamobject: 'i am object' };
+    assert.equal(addon.return_this.call(o), o);
+
+    var d = new Date();
+    assert.equal(addon.return_this.call(d), d);
+
+    var n = 19;
+    assert.notStrictEqual(addon.return_this.call(n), n);
+  });
+
+  // The n-api runtime cannot yet access `this`.
+  it.skip('can manipulate an object `this` binding', function() {
+    var o = { modified: false };
+    addon.require_object_this.call(o);
+    assert.equal(o.modified, true);
+    // Doesn't throw because of implicit primitive wrapping:
+    addon.require_object_this.call(42);
+  });
+
+  // The n-api runtime cannot yet access `this`.
+  it.skip('implicitly gets global', function() {
+    var global = (new Function("return this"))();
+    assert.equal(addon.return_this.call(undefined), global);
+  });
+
+  it('exposes an argument via arguments_opt iff it is there', function() {
+    assert.equal(addon.is_argument_zero_some(), false);
+    assert.equal(addon.is_argument_zero_some('a'), true);
+    assert.equal(addon.is_argument_zero_some('a', 'b'), true);
+    assert.equal(addon.is_argument_zero_some.call(null), false);
+    assert.equal(addon.is_argument_zero_some.call(null, ['a']), true);
+    assert.equal(addon.is_argument_zero_some.call(null, ['a', 'b']), true);
+  });
+
+  // The n-api runtime cannot yet throw errors.
+  it.skip('correctly casts an argument via cx.arguments', function() {
+    assert.equal(addon.require_argument_zero_string('foobar'), 'foobar');
+    assert.throws(function() { addon.require_argument_zero_string(new Date()) }, TypeError);
+    assert.throws(function() { addon.require_argument_zero_string(17) }, TypeError);
+  });
+
+  // The n-api runtime does not support scoped computation yet.
+  it.skip('executes a scoped computation', function() {
+    assert.equal(addon.execute_scoped(), 99);
+  });
+
+  // The n-api runtime does not support scoped computation yet.
+  it.skip('computes a value in a scoped computation', function() {
+    assert.equal(addon.compute_scoped(), 99);
+  });
+});

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -42,8 +42,7 @@ describe('JsFunction', function() {
     assert.equal(addon.num_arguments('a', 'b', 'c', 'd'), 4);
   });
 
-  // The n-api runtime cannot yet access `this`.
-  it.skip('gets the right `this`-value', function() {
+  it('gets the right `this`-value', function() {
     var o = { iamobject: 'i am object' };
     assert.equal(addon.return_this.call(o), o);
 
@@ -54,7 +53,6 @@ describe('JsFunction', function() {
     assert.notStrictEqual(addon.return_this.call(n), n);
   });
 
-  // The n-api runtime cannot yet access `this`.
   it('can manipulate an object `this` binding', function() {
     var o = { modified: false };
     addon.require_object_this.call(o);
@@ -63,8 +61,7 @@ describe('JsFunction', function() {
     addon.require_object_this.call(42);
   });
 
-  // The n-api runtime cannot yet access `this`.
-  it.skip('implicitly gets global', function() {
+  it('implicitly gets global', function() {
     var global = (new Function("return this"))();
     assert.equal(addon.return_this.call(undefined), global);
   });

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -29,6 +29,6 @@ describe('hello', function() {
   });
 
   it('should export a Rust function', function () {
-    assert.strictEqual(addon.return_js_function(2), 3.0);
+    assert.strictEqual(addon.add1(2), 3.0);
   })
 });

--- a/test/napi/lib/hello.js
+++ b/test/napi/lib/hello.js
@@ -27,4 +27,8 @@ describe('hello', function() {
       whatever: true
     });
   });
+
+  it('should export a Rust function', function () {
+    assert.strictEqual(addon.return_js_function(2), 3.0);
+  })
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -140,7 +140,7 @@ describe('JsObject', function() {
     assert.equal(b.readUInt32LE(12), 66012);
   });
 
-  it('reads the names of own properties', function() {
+  it('returns only own properties from get_own_property_names', function() {
     var superObject = {
       a: 1
     };
@@ -152,5 +152,17 @@ describe('JsObject', function() {
       addon.get_own_property_names(childObject),
       Object.getOwnPropertyNames(childObject)
     );
+  });
+
+  it('does not return Symbols from get_own_property_names', function() {
+    var object = {};
+    object['this should be a thing'] = 0;
+    object[Symbol('this should not be a thing')] = 1;
+
+    assert.deepEqual(
+      addon.get_own_property_names(object),
+      Object.getOwnPropertyNames(object)
+    );
+    assert.equal(addon.get_own_property_names(object).length, 1);
   });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -22,7 +22,7 @@ describe('JsObject', function() {
     assert.deepEqual({number: 9000, string: 'hello node'}, addon.return_js_object_with_mixed_content());
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('gets a 16-byte, zeroed ArrayBuffer', function() {
     var b = addon.return_array_buffer();
     assert.equal(b.byteLength, 16);
@@ -32,7 +32,7 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 0);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly reads an ArrayBuffer using the lock API', function() {
     var b = new ArrayBuffer(16);
     var a = new Uint32Array(b);
@@ -46,7 +46,7 @@ describe('JsObject', function() {
     assert.equal(addon.read_array_buffer_with_lock(b, 3), 88888888);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly reads an ArrayBuffer using the borrow API', function() {
     var b = new ArrayBuffer(16);
     var a = new Uint32Array(b);
@@ -60,7 +60,7 @@ describe('JsObject', function() {
     assert.equal(addon.read_array_buffer_with_borrow(b, 3), 89898989);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly writes to an ArrayBuffer using the lock API', function() {
     var b = new ArrayBuffer(16);
     addon.write_array_buffer_with_lock(b, 0, 999);
@@ -73,7 +73,7 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 99991111);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly writes to an ArrayBuffer using the borrow_mut API', function() {
     var b = new ArrayBuffer(16);
     addon.write_array_buffer_with_borrow_mut(b, 0, 434);
@@ -86,7 +86,7 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 400100);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly reads a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(147,    0);
@@ -99,7 +99,7 @@ describe('JsObject', function() {
     assert.equal(addon.read_buffer_with_lock(b, 3), 189189);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly reads a Buffer using the borrow API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(149,      0);
@@ -112,7 +112,7 @@ describe('JsObject', function() {
     assert.equal(addon.read_buffer_with_borrow(b, 3), 22914478);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly writes to a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.fill(0);
@@ -126,7 +126,7 @@ describe('JsObject', function() {
     assert.equal(b.readUInt32LE(12), 421600);
   });
 
-  // ArrayBuffers are not yet implemented in the n-api runtime.
+  // ArrayBuffers are not yet implemented in the N-API runtime.
   it.skip('correctly writes to a Buffer using the borrow_mut API', function() {
     var b = Buffer.allocUnsafe(16);
     b.fill(0);

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -139,4 +139,18 @@ describe('JsObject', function() {
     addon.write_buffer_with_borrow_mut(b, 3, 66012);
     assert.equal(b.readUInt32LE(12), 66012);
   });
+
+  it('reads the names of own properties', function() {
+    var superObject = {
+      a: 1
+    };
+
+    var childObject = Object.create(superObject);
+    childObject.b = 2;
+
+    assert.deepEqual(
+      addon.get_own_property_names(childObject),
+      Object.getOwnPropertyNames(childObject)
+    );
+  });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -1,0 +1,142 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('JsObject', function() {
+  it('return the v8::Global object', function () {
+      assert(global === addon.return_js_global_object());
+  });
+
+  it('return a JsObject built in Rust', function () {
+    assert.deepEqual({}, addon.return_js_object());
+  });
+
+  it('return a JsObject with a number key value pair', function () {
+    assert.deepEqual({number: 9000}, addon.return_js_object_with_number());
+  });
+
+  it('return a JsObject with an string key value pair', function () {
+    assert.deepEqual({string: "hello node"}, addon.return_js_object_with_string());
+  });
+
+  it('return a JsObject with mixed content key value pairs', function () {
+    assert.deepEqual({number: 9000, string: 'hello node'}, addon.return_js_object_with_mixed_content());
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('gets a 16-byte, zeroed ArrayBuffer', function() {
+    var b = addon.return_array_buffer();
+    assert.equal(b.byteLength, 16);
+    assert.equal((new Uint32Array(b))[0], 0);
+    assert.equal((new Uint32Array(b))[1], 0);
+    assert.equal((new Uint32Array(b))[2], 0);
+    assert.equal((new Uint32Array(b))[3], 0);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly reads an ArrayBuffer using the lock API', function() {
+    var b = new ArrayBuffer(16);
+    var a = new Uint32Array(b);
+    a[0] = 47;
+    a[1] = 133;
+    a[2] = 9;
+    a[3] = 88888888;
+    assert.equal(addon.read_array_buffer_with_lock(b, 0), 47);
+    assert.equal(addon.read_array_buffer_with_lock(b, 1), 133);
+    assert.equal(addon.read_array_buffer_with_lock(b, 2), 9);
+    assert.equal(addon.read_array_buffer_with_lock(b, 3), 88888888);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly reads an ArrayBuffer using the borrow API', function() {
+    var b = new ArrayBuffer(16);
+    var a = new Uint32Array(b);
+    a[0] = 49;
+    a[1] = 135;
+    a[2] = 11;
+    a[3] = 89898989;
+    assert.equal(addon.read_array_buffer_with_borrow(b, 0), 49);
+    assert.equal(addon.read_array_buffer_with_borrow(b, 1), 135);
+    assert.equal(addon.read_array_buffer_with_borrow(b, 2), 11);
+    assert.equal(addon.read_array_buffer_with_borrow(b, 3), 89898989);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly writes to an ArrayBuffer using the lock API', function() {
+    var b = new ArrayBuffer(16);
+    addon.write_array_buffer_with_lock(b, 0, 999);
+    assert.equal((new Uint32Array(b))[0], 999);
+    addon.write_array_buffer_with_lock(b, 1, 111);
+    assert.equal((new Uint32Array(b))[1], 111);
+    addon.write_array_buffer_with_lock(b, 2, 121212);
+    assert.equal((new Uint32Array(b))[2], 121212);
+    addon.write_array_buffer_with_lock(b, 3, 99991111);
+    assert.equal((new Uint32Array(b))[3], 99991111);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly writes to an ArrayBuffer using the borrow_mut API', function() {
+    var b = new ArrayBuffer(16);
+    addon.write_array_buffer_with_borrow_mut(b, 0, 434);
+    assert.equal((new Uint32Array(b))[0], 434);
+    addon.write_array_buffer_with_borrow_mut(b, 1, 100);
+    assert.equal((new Uint32Array(b))[1], 100);
+    addon.write_array_buffer_with_borrow_mut(b, 2, 22);
+    assert.equal((new Uint32Array(b))[2], 22);
+    addon.write_array_buffer_with_borrow_mut(b, 3, 400100);
+    assert.equal((new Uint32Array(b))[3], 400100);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly reads a Buffer using the lock API', function() {
+    var b = Buffer.allocUnsafe(16);
+    b.writeUInt32LE(147,    0);
+    b.writeUInt32LE(1133,   4);
+    b.writeUInt32LE(109,    8);
+    b.writeUInt32LE(189189, 12);
+    assert.equal(addon.read_buffer_with_lock(b, 0), 147);
+    assert.equal(addon.read_buffer_with_lock(b, 1), 1133);
+    assert.equal(addon.read_buffer_with_lock(b, 2), 109);
+    assert.equal(addon.read_buffer_with_lock(b, 3), 189189);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly reads a Buffer using the borrow API', function() {
+    var b = Buffer.allocUnsafe(16);
+    b.writeUInt32LE(149,      0);
+    b.writeUInt32LE(2244,     4);
+    b.writeUInt32LE(707,      8);
+    b.writeUInt32LE(22914478, 12);
+    assert.equal(addon.read_buffer_with_borrow(b, 0), 149);
+    assert.equal(addon.read_buffer_with_borrow(b, 1), 2244);
+    assert.equal(addon.read_buffer_with_borrow(b, 2), 707);
+    assert.equal(addon.read_buffer_with_borrow(b, 3), 22914478);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly writes to a Buffer using the lock API', function() {
+    var b = Buffer.allocUnsafe(16);
+    b.fill(0);
+    addon.write_buffer_with_lock(b, 0, 6);
+    assert.equal(b.readUInt32LE(0), 6);
+    addon.write_buffer_with_lock(b, 1, 6000001);
+    assert.equal(b.readUInt32LE(4), 6000001);
+    addon.write_buffer_with_lock(b, 2, 4500);
+    assert.equal(b.readUInt32LE(8), 4500);
+    addon.write_buffer_with_lock(b, 3, 421600);
+    assert.equal(b.readUInt32LE(12), 421600);
+  });
+
+  // ArrayBuffers are not yet implemented in the n-api runtime.
+  it.skip('correctly writes to a Buffer using the borrow_mut API', function() {
+    var b = Buffer.allocUnsafe(16);
+    b.fill(0);
+    addon.write_buffer_with_borrow_mut(b, 0, 16);
+    assert.equal(b.readUInt32LE(0), 16);
+    addon.write_buffer_with_borrow_mut(b, 1, 16000001);
+    assert.equal(b.readUInt32LE(4), 16000001);
+    addon.write_buffer_with_borrow_mut(b, 2, 232);
+    assert.equal(b.readUInt32LE(8), 232);
+    addon.write_buffer_with_borrow_mut(b, 3, 66012);
+    assert.equal(b.readUInt32LE(12), 66012);
+  });
+});

--- a/test/napi/native/src/js/functions.rs
+++ b/test/napi/native/src/js/functions.rs
@@ -1,0 +1,103 @@
+use neon::prelude::*;
+use neon::object::This;
+
+fn add1(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let x = cx.argument::<JsNumber>(0)?.value(&mut cx);
+    Ok(cx.number(x + 1.0))
+}
+
+pub fn return_js_function(mut cx: FunctionContext) -> JsResult<JsFunction> {
+    JsFunction::new(&mut cx, add1)
+}
+
+pub fn call_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let f = cx.argument::<JsFunction>(0)?;
+    let args: Vec<Handle<JsNumber>> = vec![cx.number(16.0)];
+    let null = cx.null();
+    f.call(&mut cx, null, args)?.downcast::<JsNumber, _>(&mut cx).or_throw(&mut cx)
+}
+
+pub fn construct_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let f = cx.argument::<JsFunction>(0)?;
+    let zero = cx.number(0.0);
+    let o = f.construct(&mut cx, vec![zero])?;
+    let get_utc_full_year_method = o.get(&mut cx, "getUTCFullYear")?.downcast::<JsFunction, _>(&mut cx).or_throw(&mut cx)?;
+    let args: Vec<Handle<JsValue>> = vec![];
+    get_utc_full_year_method.call(&mut cx, o.upcast::<JsValue>(), args)?.downcast::<JsNumber, _>(&mut cx).or_throw(&mut cx)
+}
+
+trait CheckArgument<'a> {
+    fn check_argument<V: Value>(&mut self, i: i32) -> JsResult<'a, V>;
+}
+
+impl<'a, T: This> CheckArgument<'a> for CallContext<'a, T> {
+    fn check_argument<V: Value>(&mut self, i: i32) -> JsResult<'a, V> {
+        self.argument::<V>(i)
+    }
+}
+
+pub fn check_string_and_number(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    cx.check_argument::<JsString>(0)?;
+    cx.check_argument::<JsNumber>(1)?;
+    Ok(cx.undefined())
+}
+
+pub fn panic(_: FunctionContext) -> JsResult<JsUndefined> {
+    panic!("zomg")
+}
+
+pub fn panic_after_throw(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    cx.throw_range_error::<_, ()>("entering throw state with a RangeError").unwrap_err();
+    panic!("this should override the RangeError")
+}
+
+pub fn num_arguments(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let n = cx.len();
+    Ok(cx.number(n))
+}
+
+pub fn return_this(mut cx: FunctionContext) -> JsResult<JsValue> {
+    Ok(cx.this().upcast())
+}
+
+pub fn require_object_this(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let this = cx.this();
+    let this = this.downcast::<JsObject, _>(&mut cx).or_throw(&mut cx)?;
+    let t = cx.boolean(true);
+    this.set(&mut cx, "modified", t)?;
+    Ok(cx.undefined())
+}
+
+pub fn is_argument_zero_some(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let b = cx.argument_opt(0).is_some();
+    Ok(cx.boolean(b))
+}
+
+pub fn require_argument_zero_string(mut cx: FunctionContext) -> JsResult<JsString> {
+    let s = cx.argument(0)?;
+    Ok(s)
+}
+
+pub fn execute_scoped(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let mut i = 0;
+    for _ in 1..100 {
+        cx.execute_scoped(|mut cx| {
+            let n = cx.number(1);
+            i += n.value(&mut cx) as i32;
+        });
+    }
+    Ok(cx.number(i))
+}
+
+pub fn compute_scoped(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let mut i = cx.number(0);
+    for _ in 1..100 {
+        i = cx.compute_scoped(|mut cx| {
+            let n = cx.number(1);
+            let left = i.value(&mut cx) as i32;
+            let right = n.value(&mut cx) as i32;
+            Ok(cx.number(left + right))
+        })?;
+    }
+    Ok(i)
+}

--- a/test/napi/native/src/js/objects.rs
+++ b/test/napi/native/src/js/objects.rs
@@ -1,0 +1,117 @@
+use neon::prelude::*;
+
+pub fn return_js_global_object(mut cx: FunctionContext) -> JsResult<JsObject> {
+    Ok(cx.global())
+}
+
+pub fn return_js_object(mut cx: FunctionContext) -> JsResult<JsObject> {
+    Ok(cx.empty_object())
+}
+
+pub fn return_js_object_with_mixed_content(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let js_object: Handle<JsObject> = cx.empty_object();
+    let n = cx.number(9000.0);
+    js_object.set(&mut cx, "number", n)?;
+    let s = cx.string("hello node");
+    js_object.set(&mut cx, "string", s)?;
+    Ok(js_object)
+}
+
+pub fn return_js_object_with_number(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let js_object: Handle<JsObject> = cx.empty_object();
+    let n = cx.number(9000.0);
+    js_object.set(&mut cx, "number", n)?;
+    Ok(js_object)
+}
+
+pub fn return_js_object_with_string(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let js_object: Handle<JsObject> = cx.empty_object();
+    let s = cx.string("hello node");
+    js_object.set(&mut cx, "string", s)?;
+    Ok(js_object)
+}
+
+pub fn return_array_buffer(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
+    let b: Handle<JsArrayBuffer> = cx.array_buffer(16)?;
+    Ok(b)
+}
+
+pub fn read_array_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let b: Handle<JsArrayBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = {
+        let guard = cx.lock();
+        let data = b.borrow(&guard);
+        let slice = data.as_slice::<u32>();
+        slice[i]
+    };
+    Ok(cx.number(x))
+}
+
+pub fn read_array_buffer_with_borrow(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let b: Handle<JsArrayBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = cx.borrow(&b, |data| { data.as_slice::<u32>()[i] });
+    Ok(cx.number(x))
+}
+
+pub fn write_array_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mut b: Handle<JsArrayBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = cx.argument::<JsNumber>(2)?.value(&mut cx) as u32;
+    {
+        let guard = cx.lock();
+        let data = b.borrow_mut(&guard);
+        let slice = data.as_mut_slice::<u32>();
+        slice[i] = x;
+    }
+    Ok(cx.undefined())
+}
+
+pub fn write_array_buffer_with_borrow_mut(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mut b: Handle<JsArrayBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = cx.argument::<JsNumber>(2)?.value(&mut cx) as u32;
+    cx.borrow_mut(&mut b, |data| { data.as_mut_slice::<u32>()[i] = x; });
+    Ok(cx.undefined())
+}
+
+pub fn read_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let b: Handle<JsBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = {
+        let guard = cx.lock();
+        let data = b.borrow(&guard);
+        let slice = data.as_slice::<u32>();
+        slice[i]
+    };
+    Ok(cx.number(x))
+}
+
+pub fn read_buffer_with_borrow(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let b: Handle<JsBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = cx.borrow(&b, |data| { data.as_slice::<u32>()[i] });
+    Ok(cx.number(x))
+}
+
+pub fn write_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mut b: Handle<JsBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = cx.argument::<JsNumber>(2)?.value(&mut cx) as u32;
+    {
+        let guard = cx.lock();
+        let data = b.borrow_mut(&guard);
+        let slice = data.as_mut_slice::<u32>();
+        slice[i] = x;
+    }
+    Ok(cx.undefined())
+}
+
+pub fn write_buffer_with_borrow_mut(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mut b: Handle<JsBuffer> = cx.argument(0)?;
+    let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;
+    let x = cx.argument::<JsNumber>(2)?.value(&mut cx) as u32;
+    cx.borrow_mut(&mut b, |data| { data.as_mut_slice::<u32>()[i] = x; });
+    Ok(cx.undefined())
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -1,5 +1,11 @@
 use neon::prelude::*;
 
+mod js {
+    pub mod functions;
+}
+
+use js::functions::*;
+
 register_module!(|mut cx| {
     let greeting = cx.string("Hello, World!");
     let greeting_copy = greeting.value(&mut cx);
@@ -74,6 +80,21 @@ register_module!(|mut cx| {
     }
 
     cx.export_function("add1", add1)?;
+
+    cx.export_function("return_js_function", return_js_function)?;
+    cx.export_function("call_js_function", call_js_function)?;
+    cx.export_function("construct_js_function", construct_js_function)?;
+    cx.export_function("num_arguments", num_arguments)?;
+    cx.export_function("return_this", return_this)?;
+    cx.export_function("require_object_this", require_object_this)?;
+    cx.export_function("is_argument_zero_some", is_argument_zero_some)?;
+    cx.export_function("require_argument_zero_string", require_argument_zero_string)?;
+    cx.export_function("check_string_and_number", check_string_and_number)?;
+    cx.export_function("execute_scoped", execute_scoped)?;
+    cx.export_function("compute_scoped", compute_scoped)?;
+
+    cx.export_function("panic", panic)?;
+    cx.export_function("panic_after_throw", panic_after_throw)?;
 
     Ok(())
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -104,5 +104,12 @@ register_module!(|mut cx| {
     cx.export_function("panic", panic)?;
     cx.export_function("panic_after_throw", panic_after_throw)?;
 
+    fn call_get_own_property_names(mut cx: FunctionContext) -> JsResult<JsArray> {
+        let object = cx.argument::<JsObject>(0)?;
+        object.get_own_property_names(&mut cx)
+    }
+
+    cx.export_function("get_own_property_names", call_get_own_property_names)?;
+
     Ok(())
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -68,5 +68,16 @@ register_module!(|mut cx| {
 
     cx.export_value("rustCreated", rust_created)?;
 
+    fn add1(mut cx: FunctionContext) -> JsResult<JsNumber> {
+        let x = cx.argument::<JsNumber>(0)?.value(&mut cx);
+        Ok(cx.number(x + 1.0))
+    }
+
+    fn return_js_function(mut cx: FunctionContext) -> JsResult<JsFunction> {
+        JsFunction::new(&mut cx, add1)
+    }
+
+    cx.export_function("return_js_function", return_js_function)?;
+
     Ok(())
 });

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -2,9 +2,11 @@ use neon::prelude::*;
 
 mod js {
     pub mod functions;
+    pub mod objects;
 }
 
 use js::functions::*;
+use js::objects::*;
 
 register_module!(|mut cx| {
     let greeting = cx.string("Hello, World!");
@@ -92,6 +94,12 @@ register_module!(|mut cx| {
     cx.export_function("check_string_and_number", check_string_and_number)?;
     cx.export_function("execute_scoped", execute_scoped)?;
     cx.export_function("compute_scoped", compute_scoped)?;
+
+    cx.export_function("return_js_global_object", return_js_global_object)?;
+    cx.export_function("return_js_object", return_js_object)?;
+    cx.export_function("return_js_object_with_number", return_js_object_with_number)?;
+    cx.export_function("return_js_object_with_string", return_js_object_with_string)?;
+    cx.export_function("return_js_object_with_mixed_content", return_js_object_with_mixed_content)?;
 
     cx.export_function("panic", panic)?;
     cx.export_function("panic_after_throw", panic_after_throw)?;

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -73,11 +73,7 @@ register_module!(|mut cx| {
         Ok(cx.number(x + 1.0))
     }
 
-    fn return_js_function(mut cx: FunctionContext) -> JsResult<JsFunction> {
-        JsFunction::new(&mut cx, add1)
-    }
-
-    cx.export_function("return_js_function", return_js_function)?;
+    cx.export_function("add1", add1)?;
 
     Ok(())
 });


### PR DESCRIPTION
Implements most simple function calls between Rust and JS code. (no thread-safe callbacks yet!) Builds on https://github.com/neon-bindings/neon/pull/493.

With function calls, we can start porting tests from the legacy runtime to n-api. I ported tests for objects and functions here.

There are some notable differences between NAN and n-api in how they deal with functions.
- With n-api, the "data" pointer can be just a pointer, and n-api handles wrapping it inside a `v8::External` value. n-api also _unwraps_ it for you when you ask for the data pointer. To align the two runtimes, I moved the unwrapping of the `v8::External` for the NAN runtime into `neon-sys`. Functions that were used to get data out from the `v8::External` value now take void pointers. `get_dynamic_callback()` is now a no-op but I left it in so the data format can be changed later.
- With NAN, you have to call `SetReturn()` to set the return value for a function call. With n-api, you can return an `napi_value` from your functions instead. The n-api runtime gets its own `Callback` impl and `neon_runtime::call::set_return` is unused.
  - [x] When there is no return value, I'm returning a nullptr, but this should maybe be an `undefined` `napi_value`.

The `FunctionCallbackInfo` structure was one that could only be used as a reference. n-api has an opaque `napi_callback_info` type alias for a pointer, which could not be used in this way. I changed `FunctionCallbackInfo` to be a pointer instead.
- [x] Need to confirm what this means for lifetimes—perhaps it should be a `FunctionCallbackInfo<'a>`, so we can't store it for longer than the actual function call lasts?