### PR TITLE
Mutable Task::perform()

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -23,7 +23,7 @@ pub trait Task: Send + Sized + 'static {
     type JsEvent: Value;
 
     /// Perform the task, producing either a successful `Output` or an unsuccessful `Error`. This method is executed in a background thread as part of libuv's built-in thread pool.
-    fn perform(&self) -> Result<Self::Output, Self::Error>;
+    fn perform(&mut self) -> Result<Self::Output, Self::Error>;
 
     /// Convert the result of the task to a JavaScript value to be passed to the asynchronous callback. This method is executed on the main thread at some point after the background task is completed.
     fn complete<'a>(self, cx: TaskContext<'a>, result: Result<Self::Output, Self::Error>) -> JsResult<Self::JsEvent>;
@@ -49,7 +49,7 @@ pub trait Task: Send + Sized + 'static {
 }
 
 unsafe extern "C" fn perform_task<T: Task>(task: *mut c_void) -> *mut c_void {
-    let task: Box<T> = Box::from_raw(mem::transmute(task));
+    let mut task: Box<T> = Box::from_raw(mem::transmute(task));
     let result = task.perform();
     Box::into_raw(task);
     mem::transmute(Box::into_raw(Box::new(result)))

--- a/test/dynamic/native/src/js/tasks.rs
+++ b/test/dynamic/native/src/js/tasks.rs
@@ -7,7 +7,7 @@ impl Task for SuccessTask {
     type Error = String;
     type JsEvent = JsNumber;
 
-    fn perform(&self) -> Result<Self::Output, Self::Error> {
+    fn perform(&mut self) -> Result<Self::Output, Self::Error> {
         Ok(17)
     }
 
@@ -29,7 +29,7 @@ impl Task for FailureTask {
     type Error = String;
     type JsEvent = JsNumber;
 
-    fn perform(&self) -> Result<Self::Output, Self::Error> {
+    fn perform(&mut self) -> Result<Self::Output, Self::Error> {
         Err(format!("I am a failing task"))
     }
 


### PR DESCRIPTION
Let's consider the following case:
```
pub struct AsyncTask<R, E> {
    pub payload: Box<dyn Fn() -> Result<R, E> + Send>,
}

impl<R, E> Task for AsyncTask<R, E> {
// --snip--

    fn perform(&self) -> Result<Self::Output, Self::Error> {
        (self.payload)()
    }

// --snip--
}
```

Let's assume we want to do the following:
```
pub fn foo(mut cx: FunctionContext) -> JsResult<JsUndefined> {
    let callback = $cx.argument::<JsFunction>(0)?;
    let path = $cx.argument::<JsString>(1)?.value();

    let payload = Box::new(move || -> Result<_, String> { Ok(path) });
    let task = AsyncTask { payload };
    task.schedule(callback);

    Ok($cx.undefined().upcast())
}
```

Rust will not compile this code because of this:
```
expected a closure that implements the `Fn` trait, but this closure only implements `FnOnce`

let payload = Box::new(move || -> Result<_, String> { Ok(path) });
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ---- closure is `FnOnce` because it moves the variable `path` out of its environment
                       |
                       this closure implements `FnOnce`, not `Fn`
```

So my question is how to **move arguments into the closure**? With the current neon code this is not possible.

My current solution is to wrap all arguments into an Option, then inside a closure I can take out the option and move it further. If there is None, then Task have been called twice, but this is not possible, right?

Unfortunately, Task::perform() should be mutable to allow calling an FnMut inside it. This pull request is for this case.