### PR TITLE
n-api: some warning cleanup

### DIFF
--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn set_return(_info: FunctionCallbackInfo, _value: Local) 
 
 }
 
-pub unsafe extern "C" fn get_isolate(info: FunctionCallbackInfo) -> Env { unimplemented!() }
+pub unsafe extern "C" fn get_isolate(_info: FunctionCallbackInfo) -> Env { unimplemented!() }
 
 // FIXME: Remove. This will never be implemented
 pub unsafe extern "C" fn current_isolate() -> Env { panic!("current_isolate won't be implemented in n-api") }

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -3,8 +3,7 @@
 use call::CCallback;
 use raw::{Env, Local};
 use std::os::raw::c_void;
-use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null;
 
 use nodejs_sys as napi;
 
@@ -27,7 +26,7 @@ pub unsafe extern "C" fn new_template(_out: &mut Local, _env: Env, _callback: CC
     unimplemented!()
 }
 
-pub unsafe extern "C" fn get_dynamic_callback(env: Env, data: *mut c_void) -> *mut c_void {
+pub unsafe extern "C" fn get_dynamic_callback(_env: Env, data: *mut c_void) -> *mut c_void {
     data
 }
 

--- a/crates/neon-runtime/src/napi/raw.rs
+++ b/crates/neon-runtime/src/napi/raw.rs
@@ -1,4 +1,3 @@
-use std::os::raw::c_void;
 use std::ptr;
 
 use nodejs_sys as napi;


### PR DESCRIPTION
A couple unused things crept in over the past few PRs to the N-API implementation.