### PR TITLE
n-api: ArrayBuffers and Buffers

### DIFF
--- a/crates/neon-runtime/src/napi/arraybuffer.rs
+++ b/crates/neon-runtime/src/napi/arraybuffer.rs
@@ -10,6 +10,11 @@ pub unsafe extern "C" fn new(out: &mut Local, env: Env, size: u32) -> bool {
     status == napi::napi_status::napi_ok
 }
 
-pub unsafe extern "C" fn data<'a, 'b>(_base_out: &'a mut *mut c_void, _obj: Local) -> usize {
-    unimplemented!()
+pub unsafe extern "C" fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
+    let mut size = 0;
+    assert_eq!(
+        napi::napi_get_arraybuffer_info(env, obj, base_out as *mut _, &mut size as *mut _),
+        napi::napi_status::napi_ok,
+    );
+    size
 }

--- a/crates/neon-runtime/src/napi/arraybuffer.rs
+++ b/crates/neon-runtime/src/napi/arraybuffer.rs
@@ -1,6 +1,15 @@
-use raw::Local;
+use raw::{Env, Local};
 use std::os::raw::c_void;
+use std::ptr::null_mut;
 
-pub unsafe extern "C" fn new(_out: &mut Local, _isolate: *mut c_void, _size: u32) -> bool { unimplemented!() }
+use nodejs_sys as napi;
 
-pub unsafe extern "C" fn data<'a, 'b>(_base_out: &'a mut *mut c_void, _obj: Local) -> usize { unimplemented!() }
+pub unsafe extern "C" fn new(out: &mut Local, env: Env, size: u32) -> bool {
+    let status = napi::napi_create_arraybuffer(env, size as usize, null_mut(), out as *mut _);
+
+    status == napi::napi_status::napi_ok
+}
+
+pub unsafe extern "C" fn data<'a, 'b>(_base_out: &'a mut *mut c_void, _obj: Local) -> usize {
+    unimplemented!()
+}

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -1,9 +1,21 @@
 use raw::{Env, Local};
 use std::os::raw::c_void;
+use std::ptr::null_mut;
 
 use nodejs_sys as napi;
 
-pub unsafe extern "C" fn new(_out: &mut Local, _size: u32) -> bool { unimplemented!() }
+pub unsafe extern "C" fn new(env: Env, out: &mut Local, size: u32) -> bool {
+    let status = napi::napi_create_buffer(env, size as usize, null_mut(), out as *mut _);
+
+    if status == napi::napi_status::napi_ok {
+        let mut bytes = null_mut();
+        let size = data(env, &mut bytes, *out);
+        std::ptr::write_bytes(bytes, 0, size);
+        true
+    } else {
+        false
+    }
+}
 
 pub unsafe extern "C" fn uninitialized(_out: &mut Local, _size: u32) -> bool { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -5,12 +5,12 @@ use std::ptr::null_mut;
 use nodejs_sys as napi;
 
 pub unsafe extern "C" fn new(env: Env, out: &mut Local, size: u32) -> bool {
-    let status = napi::napi_create_buffer(env, size as usize, null_mut(), out as *mut _);
-
+    let mut bytes = null_mut();
+    let status = napi::napi_create_buffer(env, size as usize, &mut bytes as *mut _, out as *mut _);
     if status == napi::napi_status::napi_ok {
-        let mut bytes = null_mut();
-        let size = data(env, &mut bytes, *out);
-        std::ptr::write_bytes(bytes as *mut u8, 0, size);
+        // zero-initialize it. If performance is critical, JsBuffer::uninitialized can be used
+        // instead.
+        std::ptr::write_bytes(bytes, 0, size as usize);
         true
     } else {
         false

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -1,8 +1,17 @@
-use raw::Local;
+use raw::{Env, Local};
 use std::os::raw::c_void;
+
+use nodejs_sys as napi;
 
 pub unsafe extern "C" fn new(_out: &mut Local, _size: u32) -> bool { unimplemented!() }
 
 pub unsafe extern "C" fn uninitialized(_out: &mut Local, _size: u32) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn data<'a, 'b>(_base_out: &'a mut *mut c_void, _obj: Local) -> usize { unimplemented!() }
+pub unsafe extern "C" fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
+    let mut size = 0;
+    assert_eq!(
+        napi::napi_get_buffer_info(env, obj, base_out as *mut _, &mut size as *mut _),
+        napi::napi_status::napi_ok,
+    );
+    size
+}

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -10,7 +10,7 @@ pub unsafe extern "C" fn new(env: Env, out: &mut Local, size: u32) -> bool {
     if status == napi::napi_status::napi_ok {
         let mut bytes = null_mut();
         let size = data(env, &mut bytes, *out);
-        std::ptr::write_bytes(bytes, 0, size);
+        std::ptr::write_bytes(bytes as *mut u8, 0, size);
         true
     } else {
         false

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -45,4 +45,9 @@ pub unsafe extern "C" fn is_error(_env: Env, _val: Local) -> bool { unimplemente
 
 pub unsafe extern "C" fn is_buffer(_env: Env, _obj: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_arraybuffer(_env: Env, _obj: Local) -> bool { unimplemented!() }
+/// Is `val` an ArrayBuffer instance?
+pub unsafe extern "C" fn is_arraybuffer(env: Env, val: Local) -> bool {
+    let mut result = false;
+    assert_eq!(napi::napi_is_arraybuffer(env, val, &mut result as *mut _), napi::napi_status::napi_ok);
+    result
+}

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -43,7 +43,12 @@ pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {
 
 pub unsafe extern "C" fn is_error(_env: Env, _val: Local) -> bool { unimplemented!() }
 
-pub unsafe extern "C" fn is_buffer(_env: Env, _obj: Local) -> bool { unimplemented!() }
+/// Is `val` a Node.js Buffer instance?
+pub unsafe extern "C" fn is_buffer(env: Env, val: Local) -> bool {
+    let mut result = false;
+    assert_eq!(napi::napi_is_buffer(env, val, &mut result as *mut _), napi::napi_status::napi_ok);
+    result
+}
 
 /// Is `val` an ArrayBuffer instance?
 pub unsafe extern "C" fn is_arraybuffer(env: Env, val: Local) -> bool {

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -219,7 +219,7 @@ extern "C" bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolat
   return true;
 }
 
-extern "C" size_t Neon_ArrayBuffer_Data(void **base_out, v8::Local<v8::ArrayBuffer> buffer) {
+extern "C" size_t Neon_ArrayBuffer_Data(v8::Isolate *isolate, void **base_out, v8::Local<v8::ArrayBuffer> buffer) {
   v8::ArrayBuffer::Contents contents = buffer->GetContents();
   *base_out = contents.Data();
 

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -188,7 +188,7 @@ extern "C" bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::
   return maybe.ToLocal(out);
 }
 
-extern "C" bool Neon_Buffer_New(v8::Local<v8::Object> *out, uint32_t size) {
+extern "C" bool Neon_Buffer_New(v8::Isolate *isolate, v8::Local<v8::Object> *out, uint32_t size) {
   Nan::MaybeLocal<v8::Object> maybe = Nan::NewBuffer(size);
   if (!maybe.ToLocal(out)) {
     return false;

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -204,7 +204,7 @@ extern "C" bool Neon_Buffer_Uninitialized(v8::Local<v8::Object> *out, uint32_t s
   return maybe.ToLocal(out);
 }
 
-extern "C" size_t Neon_Buffer_Data(void **base_out, v8::Local<v8::Object> obj) {
+extern "C" size_t Neon_Buffer_Data(v8::Isolate *isolate, void **base_out, v8::Local<v8::Object> obj) {
   *base_out = node::Buffer::Data(obj);
 
   return node::Buffer::Length(obj);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -50,7 +50,7 @@ extern "C" {
   bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::Value> *value);
 
   bool Neon_Buffer_New(v8::Local<v8::Object> *out, uint32_t size);
-  size_t Neon_Buffer_Data(void **base_out, v8::Local<v8::Object> obj);
+  size_t Neon_Buffer_Data(v8::Isolate *isolate, void **base_out, v8::Local<v8::Object> obj);
 
   bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
   bool Neon_ArrayBuffer_Uninitialized(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -49,7 +49,7 @@ extern "C" {
   bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Isolate *isolate, v8::Local<v8::Value> value);
   bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::Value> *value);
 
-  bool Neon_Buffer_New(v8::Local<v8::Object> *out, uint32_t size);
+  bool Neon_Buffer_New(v8::Isolate *isolate, v8::Local<v8::Object> *out, uint32_t size);
   size_t Neon_Buffer_Data(v8::Isolate *isolate, void **base_out, v8::Local<v8::Object> obj);
 
   bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -54,7 +54,7 @@ extern "C" {
 
   bool Neon_ArrayBuffer_New(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
   bool Neon_ArrayBuffer_Uninitialized(v8::Local<v8::ArrayBuffer> *out, v8::Isolate *isolate, uint32_t size);
-  size_t Neon_ArrayBuffer_Data(void **base_out, v8::Local<v8::ArrayBuffer> buffer);
+  size_t Neon_ArrayBuffer_Data(v8::Isolate *isolate, void **base_out, v8::Local<v8::ArrayBuffer> buffer);
 
   typedef void(*Neon_ChainedScopeCallback)(void *, void *, void *, void *);
   typedef void(*Neon_NestedScopeCallback)(void *, void *, void *);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -91,7 +91,7 @@ extern "C" {
 
     pub fn Neon_Buffer_New(out: &mut Local, size: u32) -> bool;
     pub fn Neon_Buffer_Uninitialized(out: &mut Local, size: u32) -> bool;
-    pub fn Neon_Buffer_Data<'a, 'b>(base_out: &'a mut *mut c_void, obj: Local) -> usize;
+    pub fn Neon_Buffer_Data<'a, 'b>(isolate: Isolate, base_out: &'a mut *mut c_void, obj: Local) -> usize;
 
     pub fn Neon_Call_SetReturn(info: FunctionCallbackInfo, value: Local);
     pub fn Neon_Call_GetIsolate(info: FunctionCallbackInfo) -> Isolate;

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -89,7 +89,7 @@ extern "C" {
     pub fn Neon_ArrayBuffer_New(out: &mut Local, isolate: Isolate, size: u32) -> bool;
     pub fn Neon_ArrayBuffer_Data<'a, 'b>(isolate: Isolate, base_out: &'a mut *mut c_void, obj: Local) -> usize;
 
-    pub fn Neon_Buffer_New(out: &mut Local, size: u32) -> bool;
+    pub fn Neon_Buffer_New(isolate: Isolate, out: &mut Local, size: u32) -> bool;
     pub fn Neon_Buffer_Uninitialized(out: &mut Local, size: u32) -> bool;
     pub fn Neon_Buffer_Data<'a, 'b>(isolate: Isolate, base_out: &'a mut *mut c_void, obj: Local) -> usize;
 

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -87,7 +87,7 @@ extern "C" {
     pub fn Neon_Array_Length(isolate: Isolate, array: Local) -> u32;
 
     pub fn Neon_ArrayBuffer_New(out: &mut Local, isolate: Isolate, size: u32) -> bool;
-    pub fn Neon_ArrayBuffer_Data<'a, 'b>(base_out: &'a mut *mut c_void, obj: Local) -> usize;
+    pub fn Neon_ArrayBuffer_Data<'a, 'b>(isolate: Isolate, base_out: &'a mut *mut c_void, obj: Local) -> usize;
 
     pub fn Neon_Buffer_New(out: &mut Local, size: u32) -> bool;
     pub fn Neon_Buffer_Uninitialized(out: &mut Local, size: u32) -> bool;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -124,7 +124,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// Lock the JavaScript engine, returning an RAII guard that keeps the lock active as long as the guard is alive.
     /// 
     /// If this is not the currently active context (for example, if it was used to spawn a scoped context with `execute_scoped` or `compute_scoped`), this method will panic.
-    fn lock<'c>(&'c self) -> Lock<'c> {
+    fn lock(&self) -> Lock<'_> {
         self.check_active();
         Lock::new(self.env())
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -105,14 +105,16 @@ pub enum CallKind {
 /// Types of JS values that support the `Borrow` and `BorrowMut` traits can be inspected while the engine is locked by passing a reference to a `Lock` to their methods.
 pub struct Lock<'a> {
     pub(crate) ledger: RefCell<Ledger>,
+    pub(crate) env: Env,
     phantom: PhantomData<&'a ()>
 }
 
 impl<'a> Lock<'a> {
-    fn new() -> Self {
+    fn new(env: Env) -> Self {
         Lock {
             ledger: RefCell::new(Ledger::new()),
-            phantom: PhantomData
+            env,
+            phantom: PhantomData,
         }
     }
 }
@@ -125,9 +127,9 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// Lock the JavaScript engine, returning an RAII guard that keeps the lock active as long as the guard is alive.
     /// 
     /// If this is not the currently active context (for example, if it was used to spawn a scoped context with `execute_scoped` or `compute_scoped`), this method will panic.
-    fn lock(&self) -> Lock {
+    fn lock<'c>(&'c self) -> Lock<'c> {
         self.check_active();
-        Lock::new()
+        Lock::new(self.env())
     }
 
     /// Convenience method for locking the JavaScript engine and borrowing a single JS value's internals.

--- a/src/types/binary.rs
+++ b/src/types/binary.rs
@@ -222,7 +222,7 @@ impl<'a> Borrow for &'a JsArrayBuffer {
         // Initialize pointer
         unsafe {
             let pointer = data.as_mut_ptr();
-            (*pointer).size = neon_runtime::arraybuffer::data(&mut (*pointer).base, self.to_raw());
+            (*pointer).size = neon_runtime::arraybuffer::data(guard.env.to_raw(), &mut (*pointer).base, self.to_raw());
         }
 
         // UB if pointer is not initialized!
@@ -247,7 +247,7 @@ impl<'a> BorrowMut for &'a mut JsArrayBuffer {
         // Initialize pointer
         unsafe {
             let pointer = data.as_mut_ptr();
-            (*pointer).size = neon_runtime::arraybuffer::data(&mut (*pointer).base, self.to_raw());
+            (*pointer).size = neon_runtime::arraybuffer::data(guard.env.to_raw(), &mut (*pointer).base, self.to_raw());
         }
 
         // UB if pointer is not initialized!

--- a/src/types/binary.rs
+++ b/src/types/binary.rs
@@ -23,8 +23,9 @@ pub struct JsBuffer(raw::Local);
 impl JsBuffer {
 
     /// Constructs a new `Buffer` object, safely zero-filled.
-    pub fn new<'a, C: Context<'a>>(_: &mut C, size: u32) -> JsResult<'a, JsBuffer> {
-        build(|out| { unsafe { neon_runtime::buffer::new(out, size) } })
+    pub fn new<'a, C: Context<'a>>(cx: &mut C, size: u32) -> JsResult<'a, JsBuffer> {
+        let env = cx.env();
+        build(|out| { unsafe { neon_runtime::buffer::new(env.to_raw(), out, size) } })
     }
 
     /// Constructs a new `Buffer` object, safely zero-filled.

--- a/src/types/binary.rs
+++ b/src/types/binary.rs
@@ -178,7 +178,7 @@ impl<'a> Borrow for &'a JsBuffer {
         // Initialize pointer
         unsafe {
             let pointer = data.as_mut_ptr();
-            (*pointer).size = neon_runtime::buffer::data(&mut (*pointer).base, self.to_raw());
+            (*pointer).size = neon_runtime::buffer::data(guard.env.to_raw(), &mut (*pointer).base, self.to_raw());
         }
 
         // UB if pointer is not initialized!
@@ -203,7 +203,7 @@ impl<'a> BorrowMut for &'a mut JsBuffer {
         // Initialize pointer
         unsafe {
             let pointer = data.as_mut_ptr();
-            (*pointer).size = neon_runtime::buffer::data(&mut (*pointer).base, self.to_raw());
+            (*pointer).size = neon_runtime::buffer::data(guard.env.to_raw(), &mut (*pointer).base, self.to_raw());
         }
 
         // UB if pointer is not initialized!

--- a/test/dynamic/lib/objects.js
+++ b/test/dynamic/lib/objects.js
@@ -81,6 +81,11 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 400100);
   });
 
+  it('gets a 16-byte, zeroed Buffer', function() {
+    var b = addon.return_buffer();
+    assert.ok(b.equals(Buffer.alloc(16)));
+  });
+
   it('correctly reads a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(147,    0);

--- a/test/dynamic/native/src/js/objects.rs
+++ b/test/dynamic/native/src/js/objects.rs
@@ -76,6 +76,11 @@ pub fn write_array_buffer_with_borrow_mut(mut cx: FunctionContext) -> JsResult<J
     Ok(cx.undefined())
 }
 
+pub fn return_buffer(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+    let b: Handle<JsBuffer> = cx.buffer(16)?;
+    Ok(b)
+}
+
 pub fn read_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let b: Handle<JsBuffer> = cx.argument(0)?;
     let i = cx.argument::<JsNumber>(1)?.value() as u32 as usize;

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -47,6 +47,7 @@ register_module!(mut cx, {
     cx.export_function("read_array_buffer_with_borrow", read_array_buffer_with_borrow)?;
     cx.export_function("write_array_buffer_with_lock", write_array_buffer_with_lock)?;
     cx.export_function("write_array_buffer_with_borrow_mut", write_array_buffer_with_borrow_mut)?;
+    cx.export_function("return_buffer", return_buffer)?;
     cx.export_function("read_buffer_with_lock", read_buffer_with_lock)?;
     cx.export_function("read_buffer_with_borrow", read_buffer_with_borrow)?;
     cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -22,7 +22,6 @@ describe('JsObject', function() {
     assert.deepEqual({number: 9000, string: 'hello node'}, addon.return_js_object_with_mixed_content());
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('gets a 16-byte, zeroed ArrayBuffer', function() {
     var b = addon.return_array_buffer();
     assert.equal(b.byteLength, 16);
@@ -32,7 +31,6 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 0);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly reads an ArrayBuffer using the lock API', function() {
     var b = new ArrayBuffer(16);
     var a = new Uint32Array(b);
@@ -46,7 +44,6 @@ describe('JsObject', function() {
     assert.equal(addon.read_array_buffer_with_lock(b, 3), 88888888);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly reads an ArrayBuffer using the borrow API', function() {
     var b = new ArrayBuffer(16);
     var a = new Uint32Array(b);
@@ -60,7 +57,6 @@ describe('JsObject', function() {
     assert.equal(addon.read_array_buffer_with_borrow(b, 3), 89898989);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly writes to an ArrayBuffer using the lock API', function() {
     var b = new ArrayBuffer(16);
     addon.write_array_buffer_with_lock(b, 0, 999);
@@ -73,7 +69,6 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 99991111);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly writes to an ArrayBuffer using the borrow_mut API', function() {
     var b = new ArrayBuffer(16);
     addon.write_array_buffer_with_borrow_mut(b, 0, 434);
@@ -86,7 +81,6 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 400100);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly reads a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(147,    0);
@@ -99,7 +93,6 @@ describe('JsObject', function() {
     assert.equal(addon.read_buffer_with_lock(b, 3), 189189);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly reads a Buffer using the borrow API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(149,      0);
@@ -112,7 +105,6 @@ describe('JsObject', function() {
     assert.equal(addon.read_buffer_with_borrow(b, 3), 22914478);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly writes to a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.fill(0);
@@ -126,7 +118,6 @@ describe('JsObject', function() {
     assert.equal(b.readUInt32LE(12), 421600);
   });
 
-  // ArrayBuffers are not yet implemented in the N-API runtime.
   it('correctly writes to a Buffer using the borrow_mut API', function() {
     var b = Buffer.allocUnsafe(16);
     b.fill(0);

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -23,7 +23,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('gets a 16-byte, zeroed ArrayBuffer', function() {
+  it('gets a 16-byte, zeroed ArrayBuffer', function() {
     var b = addon.return_array_buffer();
     assert.equal(b.byteLength, 16);
     assert.equal((new Uint32Array(b))[0], 0);

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -33,7 +33,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly reads an ArrayBuffer using the lock API', function() {
+  it('correctly reads an ArrayBuffer using the lock API', function() {
     var b = new ArrayBuffer(16);
     var a = new Uint32Array(b);
     a[0] = 47;
@@ -47,7 +47,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly reads an ArrayBuffer using the borrow API', function() {
+  it('correctly reads an ArrayBuffer using the borrow API', function() {
     var b = new ArrayBuffer(16);
     var a = new Uint32Array(b);
     a[0] = 49;
@@ -61,7 +61,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly writes to an ArrayBuffer using the lock API', function() {
+  it('correctly writes to an ArrayBuffer using the lock API', function() {
     var b = new ArrayBuffer(16);
     addon.write_array_buffer_with_lock(b, 0, 999);
     assert.equal((new Uint32Array(b))[0], 999);
@@ -74,7 +74,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly writes to an ArrayBuffer using the borrow_mut API', function() {
+  it('correctly writes to an ArrayBuffer using the borrow_mut API', function() {
     var b = new ArrayBuffer(16);
     addon.write_array_buffer_with_borrow_mut(b, 0, 434);
     assert.equal((new Uint32Array(b))[0], 434);
@@ -87,7 +87,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly reads a Buffer using the lock API', function() {
+  it('correctly reads a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(147,    0);
     b.writeUInt32LE(1133,   4);
@@ -100,7 +100,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly reads a Buffer using the borrow API', function() {
+  it('correctly reads a Buffer using the borrow API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(149,      0);
     b.writeUInt32LE(2244,     4);
@@ -113,7 +113,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly writes to a Buffer using the lock API', function() {
+  it('correctly writes to a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.fill(0);
     addon.write_buffer_with_lock(b, 0, 6);
@@ -127,7 +127,7 @@ describe('JsObject', function() {
   });
 
   // ArrayBuffers are not yet implemented in the N-API runtime.
-  it.skip('correctly writes to a Buffer using the borrow_mut API', function() {
+  it('correctly writes to a Buffer using the borrow_mut API', function() {
     var b = Buffer.allocUnsafe(16);
     b.fill(0);
     addon.write_buffer_with_borrow_mut(b, 0, 16);

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -81,6 +81,11 @@ describe('JsObject', function() {
     assert.equal((new Uint32Array(b))[3], 400100);
   });
 
+  it('gets a 16-byte, zeroed Buffer', function() {
+    var b = addon.return_buffer();
+    assert.ok(b.equals(Buffer.alloc(16)));
+  });
+
   it('correctly reads a Buffer using the lock API', function() {
     var b = Buffer.allocUnsafe(16);
     b.writeUInt32LE(147,    0);

--- a/test/napi/native/src/js/objects.rs
+++ b/test/napi/native/src/js/objects.rs
@@ -76,6 +76,11 @@ pub fn write_array_buffer_with_borrow_mut(mut cx: FunctionContext) -> JsResult<J
     Ok(cx.undefined())
 }
 
+pub fn return_buffer(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+    let b: Handle<JsBuffer> = cx.buffer(16)?;
+    Ok(b)
+}
+
 pub fn read_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let b: Handle<JsBuffer> = cx.argument(0)?;
     let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as u32 as usize;

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -102,6 +102,14 @@ register_module!(|mut cx| {
     cx.export_function("return_js_object_with_mixed_content", return_js_object_with_mixed_content)?;
 
     cx.export_function("return_array_buffer", return_array_buffer)?;
+    cx.export_function("read_array_buffer_with_lock", read_array_buffer_with_lock)?;
+    cx.export_function("read_array_buffer_with_borrow", read_array_buffer_with_borrow)?;
+    cx.export_function("write_array_buffer_with_lock", write_array_buffer_with_lock)?;
+    cx.export_function("write_array_buffer_with_borrow_mut", write_array_buffer_with_borrow_mut)?;
+    cx.export_function("read_buffer_with_lock", read_buffer_with_lock)?;
+    cx.export_function("read_buffer_with_borrow", read_buffer_with_borrow)?;
+    cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;
+    cx.export_function("write_buffer_with_borrow_mut", write_buffer_with_borrow_mut)?;
 
     cx.export_function("panic", panic)?;
     cx.export_function("panic_after_throw", panic_after_throw)?;

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -101,6 +101,8 @@ register_module!(|mut cx| {
     cx.export_function("return_js_object_with_string", return_js_object_with_string)?;
     cx.export_function("return_js_object_with_mixed_content", return_js_object_with_mixed_content)?;
 
+    cx.export_function("return_array_buffer", return_array_buffer)?;
+
     cx.export_function("panic", panic)?;
     cx.export_function("panic_after_throw", panic_after_throw)?;
 

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -106,6 +106,7 @@ register_module!(|mut cx| {
     cx.export_function("read_array_buffer_with_borrow", read_array_buffer_with_borrow)?;
     cx.export_function("write_array_buffer_with_lock", write_array_buffer_with_lock)?;
     cx.export_function("write_array_buffer_with_borrow_mut", write_array_buffer_with_borrow_mut)?;
+    cx.export_function("return_buffer", return_buffer)?;
     cx.export_function("read_buffer_with_lock", read_buffer_with_lock)?;
     cx.export_function("read_buffer_with_borrow", read_buffer_with_borrow)?;
     cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;


### PR DESCRIPTION
Implements the basic operations to create, read, and write ArrayBuffers and Node.js Buffers.

To pass the `napi_env` to the N-API functions, this threads the `Env` value through the `Lock` instance. Lock already guarantees that the lifetimes are OK, but this did make me wonder—should we add a lifetime parameter to `Env` too, bounded by the lifetime of `Context`? `Env` is not supposed to be stored, and end users of Neon don't have access to it so they can't do that, but it is still possible for us to make a mistake (like maybe some structure with an Env in it gets passed into an asynchronous task at some point).