### PR TITLE
napi tidbits: port numbers and strings test from nan

### DIFF
--- a/test/napi/lib/numbers.js
+++ b/test/napi/lib/numbers.js
@@ -1,0 +1,50 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('JsNumber', function() {
+  it('return a JsNumber built in Rust', function () {
+    assert.equal(addon.return_js_number(), 9000);
+  });
+
+  it('return a JsNumber for a large int built in Rust', function () {
+    assert.equal(addon.return_large_js_number(), 4294967296);
+  });
+
+  it('return a negative JsNumber int built in Rust', function () {
+    assert.equal(addon.return_negative_js_number(), -9000);
+  });
+
+  it('return a JsNumber float built in Rust', function () {
+    assert.equal(addon.return_float_js_number(), 1.4747);
+  });
+
+  it('return a negative JsNumber float built in Rust', function () {
+    assert.equal(addon.return_negative_float_js_number(), -1.4747);
+  });
+
+  describe('round trips', function () {
+    it('accept and return a number', function () {
+      assert.equal(addon.accept_and_return_js_number(1), 1);
+    });
+
+    it('accept and return a large number as a JsNumber', function () {
+      assert.equal(addon.accept_and_return_large_js_number(9007199254740991), 9007199254740991);
+    });
+
+    it('will be safe below Number.MAX_SAFE_INTEGER', function () {
+      assert.notEqual(addon.accept_and_return_large_js_number(9007199254740990), 9007199254740991);
+    });
+
+    it('will not be save above Number.MAX_SAFE_INTEGER', function () {
+      assert.equal(addon.accept_and_return_large_js_number(9007199254740993), 9007199254740992);
+    });
+
+    it('accept and return a float as a JsNumber', function () {
+      assert.equal(addon.accept_and_return_float_js_number(0.23423), 0.23423);
+    });
+
+    it('accept and return a negative number as a JsNumber', function () {
+      assert.equal(addon.accept_and_return_negative_js_number(-55), -55);
+    });
+  });
+});

--- a/test/napi/lib/strings.js
+++ b/test/napi/lib/strings.js
@@ -1,0 +1,8 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('JsString', function() {
+  it('should return a JsString built in Rust', function () {
+    assert.equal(addon.return_js_string(), "hello node");
+  });
+});

--- a/test/napi/native/src/js/numbers.rs
+++ b/test/napi/native/src/js/numbers.rs
@@ -1,0 +1,41 @@
+use neon::prelude::*;
+
+pub fn return_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    Ok(cx.number(9000_f64))
+}
+
+pub fn return_large_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    Ok(cx.number(4294967296_f64))
+}
+
+pub fn return_negative_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    Ok(cx.number(-9000_f64))
+}
+
+pub fn return_float_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    Ok(cx.number(1.4747_f64))
+}
+
+pub fn return_negative_float_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    Ok(cx.number(-1.4747_f64))
+}
+
+pub fn accept_and_return_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let number: Handle<JsNumber> = cx.argument(0)?;
+    Ok(number)
+}
+
+pub fn accept_and_return_large_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let number: Handle<JsNumber> = cx.argument(0)?;
+    Ok(number)
+}
+
+pub fn accept_and_return_float_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let number: Handle<JsNumber> = cx.argument(0)?;
+    Ok(number)
+}
+
+pub fn accept_and_return_negative_js_number(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let number: Handle<JsNumber> = cx.argument(0)?;
+    Ok(number)
+}

--- a/test/napi/native/src/js/strings.rs
+++ b/test/napi/native/src/js/strings.rs
@@ -1,0 +1,5 @@
+use neon::prelude::*;
+
+pub fn return_js_string(mut cx: FunctionContext) -> JsResult<JsString> {
+    Ok(cx.string("hello node"))
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -3,12 +3,16 @@ use neon::prelude::*;
 mod js {
     pub mod errors;
     pub mod functions;
+    pub mod numbers;
     pub mod objects;
+    pub mod strings;
 }
 
 use js::errors::*;
 use js::functions::*;
+use js::numbers::*;
 use js::objects::*;
+use js::strings::*;
 
 register_module!(|mut cx| {
     let greeting = cx.string("Hello, World!");
@@ -84,6 +88,18 @@ register_module!(|mut cx| {
     }
 
     cx.export_function("add1", add1)?;
+
+    cx.export_function("return_js_string", return_js_string)?;
+
+    cx.export_function("return_js_number", return_js_number)?;
+    cx.export_function("return_large_js_number", return_large_js_number)?;
+    cx.export_function("return_negative_js_number", return_negative_js_number)?;
+    cx.export_function("return_float_js_number", return_float_js_number)?;
+    cx.export_function("return_negative_float_js_number", return_negative_float_js_number)?;
+    cx.export_function("accept_and_return_js_number", accept_and_return_js_number)?;
+    cx.export_function("accept_and_return_large_js_number", accept_and_return_large_js_number)?;
+    cx.export_function("accept_and_return_float_js_number", accept_and_return_float_js_number)?;
+    cx.export_function("accept_and_return_negative_js_number", accept_and_return_negative_js_number)?;
 
     cx.export_function("return_js_function", return_js_function)?;
     cx.export_function("call_js_function", call_js_function)?;


### PR DESCRIPTION
All the numbers and strings functions were already implemented in `neon-runtime` for N-API, but they were not tested. This PR copy-pastes the existing NAN tests from `test/dynamic` to `test/napi`.