### PR TITLE
napi tidbits: finish `neon_runtime::napi::array`

### DIFF
--- a/crates/neon-runtime/src/napi/array.rs
+++ b/crates/neon-runtime/src/napi/array.rs
@@ -1,10 +1,15 @@
 //! Facilities for working with Array `napi_value`s.
 
-use raw::{Local, Env};
+use raw::{Env, Local};
 
 use nodejs_sys as napi;
 
-pub unsafe extern "C" fn new(_out: &mut Local, _env: Env, _length: u32) { unimplemented!() }
+pub unsafe extern "C" fn new(out: &mut Local, env: Env, length: u32) {
+    assert_eq!(
+        napi::napi_create_array_with_length(env, length as usize, out as *mut _),
+        napi::napi_status::napi_ok,
+    );
+}
 
 /// Gets the length of a `napi_value` containing a JavaScript Array.
 ///
@@ -13,6 +18,9 @@ pub unsafe extern "C" fn new(_out: &mut Local, _env: Env, _length: u32) { unimpl
 /// exception.
 pub unsafe extern "C" fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
-    assert_eq!(napi::napi_get_array_length(env, array, &mut len as *mut _), napi::napi_status::napi_ok);
+    assert_eq!(
+        napi::napi_get_array_length(env, array, &mut len as *mut _),
+        napi::napi_status::napi_ok
+    );
     len
 }

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -5,11 +5,8 @@ use nodejs_sys as napi;
 /// Return true if an `napi_value` `val` has the expected value type.
 unsafe fn is_type(env: Env, val: Local, expect: napi::napi_valuetype) -> bool {
     let mut actual = napi::napi_valuetype::napi_undefined;
-    if napi::napi_typeof(env, val, &mut actual as *mut _) == napi::napi_status::napi_ok {
-        actual == expect
-    } else {
-        false
-    }
+    assert_eq!(napi::napi_typeof(env, val, &mut actual as *mut _), napi::napi_status::napi_ok);
+    actual == expect
 }
 
 pub unsafe extern "C" fn is_undefined(_env: Env, _val: Local) -> bool { unimplemented!() }
@@ -37,11 +34,8 @@ pub unsafe extern "C" fn is_object(env: Env, val: Local) -> bool {
 
 pub unsafe extern "C" fn is_array(env: Env, val: Local) -> bool {
     let mut result = false;
-    if napi::napi_is_array(env, val, &mut result as *mut _) == napi::napi_status::napi_ok {
-        result
-    } else {
-        false
-    }
+    assert_eq!(napi::napi_is_array(env, val, &mut result as *mut _), napi::napi_status::napi_ok);
+    result
 }
 
 pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -35,7 +35,14 @@ pub unsafe extern "C" fn is_object(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_object)
 }
 
-pub unsafe extern "C" fn is_array(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_array(env: Env, val: Local) -> bool {
+    let mut result = false;
+    if napi::napi_is_array(env, val, &mut result as *mut _) == napi::napi_status::napi_ok {
+        result
+    } else {
+        false
+    }
+}
 
 pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_function)

--- a/test/napi/lib/arrays.js
+++ b/test/napi/lib/arrays.js
@@ -1,0 +1,16 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('JsArray', function() {
+  it('return a JsArray built in Rust', function () {
+    assert.deepEqual([], addon.return_js_array());
+  });
+
+  it('return a JsArray with a number at index 0', function () {
+    assert.deepEqual([9000], addon.return_js_array_with_number());
+  });
+
+  it('return a JsArray with an string at index 0', function () {
+    assert.deepEqual(["hello node"], addon.return_js_array_with_string());
+  });
+});

--- a/test/napi/lib/arrays.js
+++ b/test/napi/lib/arrays.js
@@ -13,4 +13,12 @@ describe('JsArray', function() {
   it('return a JsArray with an string at index 0', function () {
     assert.deepEqual(["hello node"], addon.return_js_array_with_string());
   });
+
+  it('can read from a JsArray', function () {
+    assert.strictEqual(addon.read_js_array([1234]), 1234);
+  });
+
+  it('returns undefined when accessing outside JsArray bounds', function () {
+    assert.strictEqual(addon.read_js_array([]), undefined);
+  });
 });

--- a/test/napi/native/src/js/arrays.rs
+++ b/test/napi/native/src/js/arrays.rs
@@ -1,0 +1,19 @@
+use neon::prelude::*;
+
+pub fn return_js_array(mut cx: FunctionContext) -> JsResult<JsArray> {
+    Ok(cx.empty_array())
+}
+
+pub fn return_js_array_with_number(mut cx: FunctionContext) -> JsResult<JsArray> {
+    let array: Handle<JsArray> = JsArray::new(&mut cx, 1);
+    let n = cx.number(9000.0);
+    array.set(&mut cx, 0, n)?;
+    Ok(array)
+}
+
+pub fn return_js_array_with_string(mut cx: FunctionContext) -> JsResult<JsArray> {
+    let array: Handle<JsArray> = JsArray::new(&mut cx, 1);
+    let s = cx.string("hello node");
+    array.set(&mut cx, 0, s)?;
+    Ok(array)
+}

--- a/test/napi/native/src/js/arrays.rs
+++ b/test/napi/native/src/js/arrays.rs
@@ -17,3 +17,10 @@ pub fn return_js_array_with_string(mut cx: FunctionContext) -> JsResult<JsArray>
     array.set(&mut cx, 0, s)?;
     Ok(array)
 }
+
+pub fn read_js_array(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let array: Handle<JsArray> = cx.argument(0)?;
+    let first_element = array.get(&mut cx, 0)?;
+
+    Ok(first_element)
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -102,6 +102,7 @@ register_module!(|mut cx| {
     cx.export_function("return_js_array", return_js_array)?;
     cx.export_function("return_js_array_with_number", return_js_array_with_number)?;
     cx.export_function("return_js_array_with_string", return_js_array_with_string)?;
+    cx.export_function("read_js_array", read_js_array)?;
 
     cx.export_function("return_js_global_object", return_js_global_object)?;
     cx.export_function("return_js_object", return_js_object)?;

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -1,11 +1,13 @@
 use neon::prelude::*;
 
 mod js {
+    pub mod arrays;
     pub mod errors;
     pub mod functions;
     pub mod objects;
 }
 
+use js::arrays::*;
 use js::errors::*;
 use js::functions::*;
 use js::objects::*;
@@ -96,6 +98,10 @@ register_module!(|mut cx| {
     cx.export_function("check_string_and_number", check_string_and_number)?;
     cx.export_function("execute_scoped", execute_scoped)?;
     cx.export_function("compute_scoped", compute_scoped)?;
+
+    cx.export_function("return_js_array", return_js_array)?;
+    cx.export_function("return_js_array_with_number", return_js_array_with_number)?;
+    cx.export_function("return_js_array_with_string", return_js_array_with_string)?;
 
     cx.export_function("return_js_global_object", return_js_global_object)?;
     cx.export_function("return_js_object", return_js_object)?;


### PR DESCRIPTION
This PR:
- ports the array tests from NAN
- implements `neon_runtime::napi::array::new`, so Rust can create arrays
- implements `neon_runtime::napi::tag::is_array`, so Rust can downcast to arrays, eg. to receive arrays as parameters
- adds a test for the downcasting-to-array case which was not tested by `test/dynamic` yet