### PR TITLE
napi tidbits: finish up type coercion APIs

### DIFF
--- a/crates/neon-runtime/src/napi/convert.rs
+++ b/crates/neon-runtime/src/napi/convert.rs
@@ -2,6 +2,7 @@ use nodejs_sys as napi;
 
 use raw::{Env, Local};
 
+/// This API is currently unused, see https://github.com/neon-bindings/neon/issues/572
 pub unsafe extern "C" fn to_object(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::napi_coerce_to_object(env, value, out as *mut _);
 

--- a/crates/neon-runtime/src/napi/convert.rs
+++ b/crates/neon-runtime/src/napi/convert.rs
@@ -2,7 +2,11 @@ use nodejs_sys as napi;
 
 use raw::{Env, Local};
 
-pub unsafe extern "C" fn to_object(_out: &mut Local, _value: &Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn to_object(out: &mut Local, env: Env, value: Local) -> bool {
+    let status = napi::napi_coerce_to_object(env, value, out as *mut _);
+
+    status == napi::napi_status::napi_ok
+}
 
 pub unsafe extern "C" fn to_string(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::napi_coerce_to_string(env, value, out as *mut _);

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -183,8 +183,8 @@ extern "C" bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Isolate *i
   return maybe.ToLocal(out);
 }
 
-extern "C" bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::Value> *value) {
-  Nan::MaybeLocal<v8::Object> maybe = Nan::To<v8::Object>(*value);
+extern "C" bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Isolate *isolate, v8::Local<v8::Value> value) {
+  Nan::MaybeLocal<v8::Object> maybe = Nan::To<v8::Object>(value);
   return maybe.ToLocal(out);
 }
 

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -55,7 +55,7 @@ extern "C" {
   size_t Neon_String_Data(char *out, size_t len, v8::Local<v8::Value> str);
 
   bool Neon_Convert_ToString(v8::Local<v8::String> *out, v8::Isolate *isolate, v8::Local<v8::Value> value);
-  bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Local<v8::Value> *value);
+  bool Neon_Convert_ToObject(v8::Local<v8::Object> *out, v8::Isolate *isolate, v8::Local<v8::Value> value);
 
   bool Neon_Buffer_New(v8::Isolate *isolate, v8::Local<v8::Object> *out, uint32_t size);
   size_t Neon_Buffer_Data(v8::Isolate *isolate, void **base_out, v8::Local<v8::Object> obj);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -141,7 +141,7 @@ extern "C" {
     pub fn Neon_Class_HasInstance(metadata: *mut c_void, v: Local) -> bool;
     pub fn Neon_Class_GetInstanceInternals(obj: Local) -> *mut c_void;
 
-    pub fn Neon_Convert_ToObject(out: &mut Local, value: &Local) -> bool;
+    pub fn Neon_Convert_ToObject(out: &mut Local, isolate: Isolate, value: Local) -> bool;
     pub fn Neon_Convert_ToString(out: &mut Local, isolate: Isolate, value: Local) -> bool;
 
     pub fn Neon_Error_Throw(val: Local);

--- a/test/napi/lib/coercions.js
+++ b/test/napi/lib/coercions.js
@@ -1,0 +1,10 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('coercions', function() {
+  it('can stringify', function () {
+    assert.strictEqual(addon.to_string([1, 2, 3]), '1,2,3');
+    assert.strictEqual(addon.to_string(new Map()), '[object Map]');
+    assert.strictEqual(addon.to_string({ a: 'b' }), '[object Object]');
+  });
+});

--- a/test/napi/native/src/js/coercions.rs
+++ b/test/napi/native/src/js/coercions.rs
@@ -1,0 +1,6 @@
+use neon::prelude::*;
+
+pub fn to_string(mut cx: FunctionContext) -> JsResult<JsString> {
+    let arg: Handle<JsValue> = cx.argument(0)?;
+    Ok(arg.to_string(&mut cx)?)
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -1,11 +1,13 @@
 use neon::prelude::*;
 
 mod js {
+    pub mod coercions;
     pub mod errors;
     pub mod functions;
     pub mod objects;
 }
 
+use js::coercions::*;
 use js::errors::*;
 use js::functions::*;
 use js::objects::*;
@@ -96,6 +98,8 @@ register_module!(|mut cx| {
     cx.export_function("check_string_and_number", check_string_and_number)?;
     cx.export_function("execute_scoped", execute_scoped)?;
     cx.export_function("compute_scoped", compute_scoped)?;
+
+    cx.export_function("to_string", to_string)?;
 
     cx.export_function("return_js_global_object", return_js_global_object)?;
     cx.export_function("return_js_object", return_js_object)?;


### PR DESCRIPTION
This implements the `neon_runtime::napi::convert::to_object` function, which is currently not exposed (https://github.com/neon-bindings/neon/issues/572).

This also adds a test for the `neon_runtime::napi::convert::to_string` function (through `neon::Value::to_string`).