### PR TITLE
napi tidbits: implement remaining tag checks

### DIFF
--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -48,11 +48,8 @@ pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {
 
 pub unsafe extern "C" fn is_error(env: Env, val: Local) -> bool {
     let mut result = false;
-    if napi::napi_is_error(env, val, &mut result as *mut _) == napi::napi_status::napi_ok {
-        result
-    } else {
-        false
-    }
+    assert_eq!(napi::napi_is_error(env, val, &mut result as *mut _), napi::napi_status::napi_ok);
+    result
 }
 
 /// Is `val` a Node.js Buffer instance?

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -9,9 +9,13 @@ unsafe fn is_type(env: Env, val: Local, expect: napi::napi_valuetype) -> bool {
     actual == expect
 }
 
-pub unsafe extern "C" fn is_undefined(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_undefined(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_undefined)
+}
 
-pub unsafe extern "C" fn is_null(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_null(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::napi_valuetype::napi_null)
+}
 
 /// Is `val` a JavaScript number?
 pub unsafe extern "C" fn is_number(env: Env, val: Local) -> bool {
@@ -42,7 +46,14 @@ pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {
     is_type(env, val, napi::napi_valuetype::napi_function)
 }
 
-pub unsafe extern "C" fn is_error(_env: Env, _val: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn is_error(env: Env, val: Local) -> bool {
+    let mut result = false;
+    if napi::napi_is_error(env, val, &mut result as *mut _) == napi::napi_status::napi_ok {
+        result
+    } else {
+        false
+    }
+}
 
 /// Is `val` a Node.js Buffer instance?
 pub unsafe extern "C" fn is_buffer(env: Env, val: Local) -> bool {

--- a/test/napi/lib/types.js
+++ b/test/napi/lib/types.js
@@ -1,0 +1,78 @@
+var addon = require('../native');
+var assert = require('chai').assert;
+
+describe('type checks', function() {
+  it('is_array', function () {
+    assert(addon.is_array([]));
+    assert(addon.is_array(new Array()));
+    assert(!addon.is_array(null));
+    assert(!addon.is_array(1));
+    assert(!addon.is_array({ 0: 'a', 1: 'b', length: 2 }));
+  });
+
+  it('is_array_buffer', function () {
+    assert(addon.is_array_buffer(new ArrayBuffer(0)));
+    assert(!addon.is_array_buffer(new DataView(new ArrayBuffer(0))));
+    assert(!addon.is_array_buffer(new Uint8Array(1024)));
+    assert(!addon.is_array_buffer(Buffer.alloc(64)));
+    assert(!addon.is_array_buffer([]));
+    assert(!addon.is_array_buffer('hello world'));
+  });
+
+  it('is_boolean', function () {
+    assert(addon.is_boolean(true));
+    assert(addon.is_boolean(false));
+    assert(!addon.is_boolean(new Boolean(true)));
+    assert(!addon.is_boolean(new Boolean(false)));
+  });
+
+  it('is_buffer', function () {
+    assert(addon.is_buffer(Buffer.alloc(64)));
+    assert(addon.is_buffer(new Uint8Array(64)));
+    assert(!addon.is_buffer(new ArrayBuffer(64)));
+  });
+
+  it('is_error', function () {
+    assert(addon.is_error(new Error()));
+    assert(addon.is_error(new TypeError()));
+    class SubclassError extends Error {}
+    assert(addon.is_error(new SubclassError()));
+    assert(!addon.is_error('something went wrong!'));
+  });
+
+  it('is_null', function () {
+    assert(addon.is_null(null));
+    assert(!addon.is_null(undefined));
+    assert(!addon.is_null('anything other than null'));
+  });
+
+  it('is_number', function () {
+    assert(addon.is_number(0));
+    assert(addon.is_number(1.4526456453));
+    assert(addon.is_number(NaN));
+    assert(!addon.is_number(new Number(2)));
+    assert(!addon.is_number('42'));
+  });
+
+  it('is_object', function () {
+    assert(addon.is_object({}));
+    assert(addon.is_object(new Number(1)));
+    assert(addon.is_object(new String('1')));
+    // Unlike `typeof`, is_object does *not* consider `null` to be an Object.
+    assert(!addon.is_object(null));
+    assert(!addon.is_object(undefined));
+    assert(!addon.is_object(1));
+    assert(!addon.is_object('1'));
+  });
+
+  it('is_string', function () {
+    assert(addon.is_string('1'));
+    assert(!addon.is_string(new String('1')));
+  });
+
+  it('is_undefined', function () {
+    assert(addon.is_undefined(undefined));
+    assert(!addon.is_undefined(null));
+    assert(!addon.is_undefined('anything other than undefined'));
+  });
+});

--- a/test/napi/native/src/js/types.rs
+++ b/test/napi/native/src/js/types.rs
@@ -1,0 +1,61 @@
+use neon::prelude::*;
+
+pub fn is_string(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsString, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_array(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsArray, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_array_buffer(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsArrayBuffer, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_boolean(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsBoolean, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_buffer(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsBuffer, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_error(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsError, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_null(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsNull, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_number(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsNumber, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_object(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsObject, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
+pub fn is_undefined(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let is_string = val.is_a::<JsUndefined, _>(&mut cx);
+    Ok(cx.boolean(is_string))
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -7,6 +7,7 @@ mod js {
     pub mod functions;
     pub mod numbers;
     pub mod objects;
+    pub mod types;
     pub mod strings;
 }
 
@@ -16,6 +17,7 @@ use js::errors::*;
 use js::functions::*;
 use js::numbers::*;
 use js::objects::*;
+use js::types::*;
 use js::strings::*;
 
 register_module!(|mut cx| {
@@ -140,6 +142,17 @@ register_module!(|mut cx| {
     cx.export_function("read_buffer_with_borrow", read_buffer_with_borrow)?;
     cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;
     cx.export_function("write_buffer_with_borrow_mut", write_buffer_with_borrow_mut)?;
+
+    cx.export_function("is_array", is_array)?;
+    cx.export_function("is_array_buffer", is_array_buffer)?;
+    cx.export_function("is_boolean", is_boolean)?;
+    cx.export_function("is_buffer", is_buffer)?;
+    cx.export_function("is_error", is_error)?;
+    cx.export_function("is_null", is_null)?;
+    cx.export_function("is_number", is_number)?;
+    cx.export_function("is_object", is_object)?;
+    cx.export_function("is_string", is_string)?;
+    cx.export_function("is_undefined", is_undefined)?;
 
     cx.export_function("new_error", new_error)?;
     cx.export_function("new_type_error", new_type_error)?;


### PR DESCRIPTION
Implements the remaining `is_*` runtime functions using `napi_typeof`.
`napi_typeof` uses the V8 `->IsObject()` family of functions, just like neon's NAN backend  does.

This does introduce one minor difference: `neon_runtime::nan::tag::is_object()` matches External values, while `neon_runtime::napi::tag::is_object()` does not. I don't think we currently have any ways that External values can be accessed directly, though, so it should not matter. And if and when we do, we should probably have `is_external()` rather than treating them as objects?