### PR TITLE
Increase test timeouts to 5s

### DIFF
--- a/test/cli/package.json
+++ b/test/cli/package.json
@@ -48,7 +48,7 @@
     "ts-unknown": "^0.2.0"
   },
   "scripts": {
-    "test": "npm run transpile && mocha lib/**/*.js",
+    "test": "npm run transpile && mocha --timeout 5000 lib/**/*.js",
     "transpile": "tsc"
   }
 }

--- a/test/dynamic/package.json
+++ b/test/dynamic/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "install": "node ../../cli/bin/cli.js build --release",
-    "test": "mocha --recursive lib"
+    "test": "mocha --timeout 5000 --recursive lib"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/napi/package.json
+++ b/test/napi/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "install": "node ../../cli/bin/cli.js build --release",
-    "test": "mocha --recursive lib"
+    "test": "mocha --timeout 5000 --recursive lib"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Increase mocha tests' timeout to 5s, to decrease the number of nondeterministic test failures in GitHub Actions.