### PR TITLE
Disable duplicate CI jobs for internal PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Disable this on our own internal PRs since it'll be run on the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Rust ${{ matrix.rust-toolchain }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Disable this on our own internal PRs since it'll be run on the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     steps:
     - uses: actions/checkout@v2
     - name: Use Rust ${{ matrix.rust-toolchain }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,9 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-  pull_request: true
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-  pull_request
+    pull_request
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request:
+    pull_request: true
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request: true
+  pull_request: true
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request
+    pull_request:
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,14 +1,16 @@
 name: Test on Linux
 
-on: [push, pull_request]
+on:
+  push:
+    # Disable this on our own internal PRs.
+    branches:
+      - master
+  pull_request
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    # Disable this on our own internal PRs since it'll be run on the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     strategy:
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: Test on Linux
 
 on:
   push:
-    # Disable this on our own internal PRs.
+    # Prevent duplicate runs of this workflow on our own internal PRs.
     branches:
       - master
   pull_request:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Disable this on our own internal PRs since it'll be run on the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,9 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-  pull_request: true
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-  pull_request
+    pull_request
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request:
+    pull_request: true
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request: true
+  pull_request: true
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request
+    pull_request:
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,14 +1,16 @@
 name: Test on MacOS
 
-on: [push, pull_request]
+on:
+  push:
+    # Disable this on our own internal PRs.
+    branches:
+      - master
+  pull_request
 
 jobs:
   build:
 
     runs-on: macos-latest
-
-    # Disable this on our own internal PRs since it'll be run on the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     strategy:
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@ name: Test on MacOS
 
 on:
   push:
-    # Disable this on our own internal PRs.
+    # Prevent duplicate runs of this workflow on our own internal PRs.
     branches:
       - master
   pull_request:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: macos-latest
 
+    # Disable this on our own internal PRs since it'll be run on the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,9 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-  pull_request: true
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-  pull_request
+    pull_request
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request:
+    pull_request: true
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request: true
+  pull_request: true
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,14 +1,16 @@
 name: Test on Windows
 
-on: [push, pull_request]
+on:
+  push:
+    # Disable this on our own internal PRs.
+    branches:
+      - master
+  pull_request
 
 jobs:
   build:
 
     runs-on: windows-latest
-
-    # Disable this on our own internal PRs since it'll be run on the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     # Disable this on our own internal PRs.
     branches:
       - master
-    pull_request
+    pull_request:
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: Test on Windows
 
 on:
   push:
-    # Disable this on our own internal PRs.
+    # Prevent duplicate runs of this workflow on our own internal PRs.
     branches:
       - master
   pull_request:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: windows-latest
 
+    # Disable this on our own internal PRs since it'll be run on the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]


### PR DESCRIPTION
Disable the tests for `pull_request` events created by our own internal PRs, since they already get triggered for the push to the branch, resulting in duplicate CI jobs. See:

https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/5

**Before:**

<img width="926" alt="image" src="https://user-images.githubusercontent.com/307871/89116976-bc4e3100-d44e-11ea-999d-ff98e054d790.png">

**After:**

<img width="929" alt="image" src="https://user-images.githubusercontent.com/307871/89125845-21794500-d496-11ea-9b1b-d54f30cf3c8c.png">

