### PR TITLE
Download and link `node.lib` on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    # for `bindgen`
+    # not sure if this is the right thing to do but i wanna see if it compiles
+    - run: choco install llvm
     # - name: update node-gyp to latest
     #   # https://github.com/nodejs/node-gyp/issues/1933#issuecomment-586915535
     #   run: npm install -g node-gyp@latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,12 +30,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    # for `bindgen`
-    # not sure if this is the right thing to do but i wanna see if it compiles
-    - run: choco install llvm
+    - name: Install libclang
+      uses: KyleMayes/install-llvm-action@7770802
+      with:
+        version: "10"
+        directory: ${{ runner.temp }}/llvm
     # - name: update node-gyp to latest
     #   # https://github.com/nodejs/node-gyp/issues/1933#issuecomment-586915535
     #   run: npm install -g node-gyp@latest
     - run: npm config set msvs_version 2019
     - name: run cargo test
       run: cargo test --release
+      env:
+        LIBCLANG_PATH: ${{ runner.temp }}/llvm/bin

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -13,3 +13,6 @@ cfg-if = "0.1.9"
 
 [build-dependencies]
 cfg-if = "0.1.9"
+
+[target.'cfg(windows)'.dependencies]
+ureq = { version = "1.3.0", default-features = false, features = ["native-tls"] }

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -13,6 +13,3 @@ cfg-if = "0.1.9"
 
 [build-dependencies]
 cfg-if = "0.1.9"
-
-[target.'cfg(windows)'.dependencies]
-ureq = { version = "1.3.0", default-features = false, features = ["native-tls"] }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -76,7 +76,10 @@ cfg_if! {
                 let basename = node_lib_path.file_stem().expect("Could not parse lib name from NEON_NODE_LIB. Does the path include the full file name?");
 
                 println!("cargo:rustc-link-search=native={}", dir.display());
-                // Littul hack to output the OsStr file stem
+                // `basename` is an OsStr, we can output it anyway by re-wrapping it in a Path
+                // Both `dir` and `basename` will be mangled (contain replacement characters) if
+                // they are not UTF-8 paths. If we don't mangle them though, Cargo will: so
+                // non-UTF-8 paths are simply not supported.
                 println!("cargo:rustc-link-lib={}", Path::new(basename).display());
                 return;
             }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -81,7 +81,9 @@ cfg_if! {
                 return;
             }
 
-            let version = node_version().expect("Could not determine Node.js version");
+            let version = std::env::var("npm_config_target")
+                .or_else(|_| node_version())
+                .expect("Could not determine Node.js version");
             let arch = if std::env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86" {
                 "x86"
             } else {

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -33,16 +33,15 @@ cfg_if! {
         }
     } else if #[cfg(windows)] {
         // ^ automatically not neon-sys
-        use std::io::{Error, ErrorKind, Result};
+        use std::io::{Error, ErrorKind, Write, Result};
         use std::process::Command;
         use std::path::Path;
 
         fn node_version() -> Result<String> {
             let output = Command::new("node").arg("-v").output()?;
             if !output.status.success() {
-                let hopefully_stack_trace = String::from_utf8(output.stderr)
-                    .unwrap_or_else(|_| "<subprocess output garbage>".to_string());
-                panic!("Could not download node.lib: {}", hopefully_stack_trace);
+                let _ = std::io::stderr().write_all(&output.stderr);
+                panic!("Could not download node.lib. There is likely more information from stderr above.");
             }
             let stdout = String::from_utf8(output.stdout).map_err(|error| {
                 Error::new(ErrorKind::InvalidData, error)

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -89,8 +89,13 @@ cfg_if! {
                 "x64"
             };
 
-            let node_lib = download_node_lib(&version, arch).expect("Could not download `node.lib`");
-            std::fs::write(format!(r"{}\node-{}.lib", env!("OUT_DIR"), arch), &node_lib).expect("Could not save `node.lib`");
+            let node_lib_store_path = format!(r"{}/node-{}.lib", env!("OUT_DIR"), arch);
+
+            // Download node.lib if it does not exist
+            if let Err(_) = std::fs::metadata(&node_lib_store_path) {
+                let node_lib = download_node_lib(&version, arch).expect("Could not download `node.lib`");
+                std::fs::write(&node_lib_store_path, &node_lib).expect("Could not save `node.lib`");
+            }
 
             println!("cargo:rustc-link-search=native={}", env!("OUT_DIR"));
             println!("cargo:rustc-link-lib=node-{}", arch);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ mod tests {
         };
 
         eprintln!("Running Neon test: {} {} {}", shell, command_flag, cmd);
-    
+
         assert!(Command::new(&shell)
                         .current_dir(dir)
                         .args(&[&command_flag, cmd])
@@ -495,11 +495,10 @@ mod tests {
         if std::env::var("CI") == Ok("true".to_string()) {
             run("cargo package", &test_package);
         } else {
-            run("cargo package --allow-dirty", &test_package);            
+            run("cargo package --allow-dirty", &test_package);
         }
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn napi_test() {
         let _guard = TEST_MUTEX.lock();


### PR DESCRIPTION
This enables N-API tests on Windows and sets up the linking stuff that we need for the average Node.js addon.

Todo:
- [x] should x64 architecture not be hardcoded? :thinking: 
- [x] support passing in an env var with the path to a preexisting node.lib file, so you can do this offline
- [x] avoid redownloading it if we already have it

This also does not yet handle the case where the `node.exe` executable has been renamed, and will crash if loaded into a `notnode.exe`. That will be a separate PR.