### PR TITLE
Implement FunctionContext::kind() for N-API

### DIFF
--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -30,14 +30,22 @@ pub unsafe extern "C" fn get_isolate(_info: FunctionCallbackInfo) -> Env { unimp
 pub unsafe extern "C" fn current_isolate() -> Env { panic!("current_isolate won't be implemented in n-api") }
 
 pub unsafe extern "C" fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
-    let mut target: MaybeUninit<napi::napi_value> = MaybeUninit::zeroed();
+    let mut target: MaybeUninit<Local> = MaybeUninit::zeroed();
+
     let status = napi::napi_get_new_target(
         env,
         info,
         target.as_mut_ptr()
     );
+
     assert_eq!(status, napi::napi_status::napi_ok);
-    let target: napi::napi_value = target.assume_init();
+
+    // napi_get_new_target is guaranteed to assign to target, so it's initialized.
+    let target: Local = target.assume_init();
+
+    // By the napi_get_new_target contract, target will either be NULL if the current
+    // function was called without `new`, or a valid napi_value handle if the current
+    // function was called with `new`.
     !target.is_null()
 }
 

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -105,4 +105,9 @@ describe('JsFunction', function() {
   it('gets a regular value with cx.try_catch', function() {
     assert.equal(addon.call_and_catch(() => { return 42 }), 42);
   });
+
+  it('distinguishes calls from constructs', function() {
+    assert.equal(addon.is_construct.call({}).wasConstructed, false);
+    assert.equal((new addon.is_construct()).wasConstructed, true);
+  });
 });

--- a/test/napi/native/src/js/functions.rs
+++ b/test/napi/native/src/js/functions.rs
@@ -118,3 +118,14 @@ pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
         f.call(cx, global, args)
     }).unwrap_or_else(|err| err))
 }
+
+pub fn is_construct(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let this = cx.this();
+    let construct = match cx.kind() {
+        CallKind::Construct => true,
+        _ => false
+    };
+    let construct = cx.boolean(construct);
+    this.set(&mut cx, "wasConstructed", construct)?;
+    Ok(this)
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -164,6 +164,7 @@ register_module!(|mut cx| {
 
     cx.export_function("throw_and_catch", throw_and_catch)?;
     cx.export_function("call_and_catch", call_and_catch)?;
+    cx.export_function("is_construct", is_construct)?;
 
     fn call_get_own_property_names(mut cx: FunctionContext) -> JsResult<JsArray> {
         let object = cx.argument::<JsObject>(0)?;


### PR DESCRIPTION
Implements `FunctionContext::kind()` for the N-API port.

A thought occurred to me when working on this: N-API's `napi_get_new_target()` is a better and more general API than `cx.kind()`. I think `cx.kind()` is harmless and we can keep it around forever, but in the future I think we should add a `FunctionContext::new_target()` API for just the N-API backend. The signature would look something like:

```rust
impl<'a, T: This> CallContext<'a, T> {
    pub fn new_target(&mut self) -> Option<Handle<'a, JsValue>>;
}
```

And then `kind()` wouldn't be much different from asking if `new_target()` returned a `Some` or a `None`.