### PR TITLE
Port win_delay_load_hook

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    # for `bindgen`
+    # not sure if this is the right thing to do but i wanna see if it compiles
+    - run: choco install llvm
     # - name: update node-gyp to latest
     #   # https://github.com/nodejs/node-gyp/issues/1933#issuecomment-586915535
     #   run: npm install -g node-gyp@latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,12 +30,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    # for `bindgen`
-    # not sure if this is the right thing to do but i wanna see if it compiles
-    - run: choco install llvm
+    - name: Install libclang
+      uses: KyleMayes/install-llvm-action@7770802
+      with:
+        version: "10"
+        directory: ${{ runner.temp }}/llvm
     # - name: update node-gyp to latest
     #   # https://github.com/nodejs/node-gyp/issues/1933#issuecomment-586915535
     #   run: npm install -g node-gyp@latest
     - run: npm config set msvs_version 2019
     - name: run cargo test
       run: cargo test --release
+      env:
+        LIBCLANG_PATH: ${{ runner.temp }}/llvm/bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ cslice = "0.2"
 semver = "0.9.0"
 neon-runtime = { version = "=0.4.0", path = "crates/neon-runtime" }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.9", features = ["minwindef", "libloaderapi", "ntdef"] }
+
 [features]
 default = ["legacy-runtime"]
 

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -13,3 +13,6 @@ cfg-if = "0.1.9"
 
 [build-dependencies]
 cfg-if = "0.1.9"
+
+[target.'cfg(windows)'.dependencies]
+ureq = { version = "1.3.0", default-features = false, features = ["native-tls"] }

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -13,6 +13,3 @@ cfg-if = "0.1.9"
 
 [build-dependencies]
 cfg-if = "0.1.9"
-
-[target.'cfg(windows)'.dependencies]
-ureq = { version = "1.3.0", default-features = false, features = ["native-tls"] }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -76,7 +76,10 @@ cfg_if! {
                 let basename = node_lib_path.file_stem().expect("Could not parse lib name from NEON_NODE_LIB. Does the path include the full file name?");
 
                 println!("cargo:rustc-link-search=native={}", dir.display());
-                // Littul hack to output the OsStr file stem
+                // `basename` is an OsStr, we can output it anyway by re-wrapping it in a Path
+                // Both `dir` and `basename` will be mangled (contain replacement characters) if
+                // they are not UTF-8 paths. If we don't mangle them though, Cargo will: so
+                // non-UTF-8 paths are simply not supported.
                 println!("cargo:rustc-link-lib={}", Path::new(basename).display());
                 return;
             }

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -103,6 +103,8 @@ cfg_if! {
 
             println!("cargo:rustc-link-search=native={}", env!("OUT_DIR"));
             println!("cargo:rustc-link-lib=node-{}", arch);
+            println!("cargo:rustc-cdylib-link-arg=delayimp.lib");
+            println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:node.exe");
         }
     } else if #[cfg(target_os = "macos")] {
         /// Set up the build environment by setting Cargo configuration variables.

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -81,7 +81,9 @@ cfg_if! {
                 return;
             }
 
-            let version = node_version().expect("Could not determine Node.js version");
+            let version = std::env::var("npm_config_target")
+                .or_else(|_| node_version())
+                .expect("Could not determine Node.js version");
             let arch = if std::env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86" {
                 "x86"
             } else {

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -33,16 +33,15 @@ cfg_if! {
         }
     } else if #[cfg(windows)] {
         // ^ automatically not neon-sys
-        use std::io::{Error, ErrorKind, Result};
+        use std::io::{Error, ErrorKind, Write, Result};
         use std::process::Command;
         use std::path::Path;
 
         fn node_version() -> Result<String> {
             let output = Command::new("node").arg("-v").output()?;
             if !output.status.success() {
-                let hopefully_stack_trace = String::from_utf8(output.stderr)
-                    .unwrap_or_else(|_| "<subprocess output garbage>".to_string());
-                panic!("Could not download node.lib: {}", hopefully_stack_trace);
+                let _ = std::io::stderr().write_all(&output.stderr);
+                panic!("Could not download node.lib. There is likely more information from stderr above.");
             }
             let stdout = String::from_utf8(output.stdout).map_err(|error| {
                 Error::new(ErrorKind::InvalidData, error)

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -89,8 +89,13 @@ cfg_if! {
                 "x64"
             };
 
-            let node_lib = download_node_lib(&version, arch).expect("Could not download `node.lib`");
-            std::fs::write(format!(r"{}\node-{}.lib", env!("OUT_DIR"), arch), &node_lib).expect("Could not save `node.lib`");
+            let node_lib_store_path = format!(r"{}/node-{}.lib", env!("OUT_DIR"), arch);
+
+            // Download node.lib if it does not exist
+            if let Err(_) = std::fs::metadata(&node_lib_store_path) {
+                let node_lib = download_node_lib(&version, arch).expect("Could not download `node.lib`");
+                std::fs::write(&node_lib_store_path, &node_lib).expect("Could not save `node.lib`");
+            }
 
             println!("cargo:rustc-link-search=native={}", env!("OUT_DIR"));
             println!("cargo:rustc-link-lib=node-{}", arch);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ mod tests {
         };
 
         eprintln!("Running Neon test: {} {} {}", shell, command_flag, cmd);
-    
+
         assert!(Command::new(&shell)
                         .current_dir(dir)
                         .args(&[&command_flag, cmd])
@@ -495,11 +495,10 @@ mod tests {
         if std::env::var("CI") == Ok("true".to_string()) {
             run("cargo package", &test_package);
         } else {
-            run("cargo package --allow-dirty", &test_package);            
+            run("cargo package --allow-dirty", &test_package);
         }
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn napi_test() {
         let _guard = TEST_MUTEX.lock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,13 @@ extern crate semver;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(target_os = "windows")]
+extern crate winapi;
+
+#[cfg(target_os = "windows")]
+// This module statically provides a delayed load hook: we don't need to call anything to initialize it.
+mod win_delay_load_hook;
+
 pub mod context;
 pub mod handle;
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ extern crate lazy_static;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "napi-runtime"))]
 // This module statically provides a delayed load hook: we don't need to call anything to initialize it.
 mod win_delay_load_hook;
 

--- a/src/win_delay_load_hook.rs
+++ b/src/win_delay_load_hook.rs
@@ -48,16 +48,16 @@ struct DelayLoadInfo {
 #[allow(non_snake_case)]
 type PfnDliHook = unsafe extern "C" fn(dliNotify: usize, pdli: *const DelayLoadInfo) -> FARPROC;
 
+const HOST_BINARIES: &[&[u8]] = &[b"node.exe", b"electron.exe"];
+
 unsafe extern "C" fn load_exe_hook(event: usize, info: *const DelayLoadInfo) -> FARPROC {
-    // TODO this may need to be "electron.exe" in some cases
-    let host_binary = b"node.exe";
 
     if event != 0x01 /* dliNotePreLoadLibrary */ {
         return null_mut();
     }
 
     let dll_name = CStr::from_ptr((*info).szDll);
-    if dll_name.to_bytes() != host_binary {
+    if !HOST_BINARIES.iter().any(|&host_name| host_name == dll_name.to_bytes()) {
         return null_mut();
     }
 

--- a/src/win_delay_load_hook.rs
+++ b/src/win_delay_load_hook.rs
@@ -1,0 +1,72 @@
+//! Rust port of [win_delay_load_hook.cc][].
+//!
+//! When the addon tries to load the "node.exe" DLL module, this module gives it the pointer to the
+//! .exe we are running in instead. Typically, that will be the same value. But if the node executable
+//! was renamed, you would not otherwise get the correct DLL.
+//!
+//! [win_delay_load_hook.cc]: https://github.com/nodejs/node-gyp/blob/e18a61afc1669d4897e6c5c8a6694f4995a0f4d6/src/win_delay_load_hook.cc
+
+use winapi::shared::minwindef::{BOOL, DWORD, FARPROC, HMODULE, LPVOID};
+use winapi::shared::ntdef::LPCSTR;
+use winapi::um::libloaderapi::GetModuleHandleA;
+use std::ffi::CStr;
+use std::ptr::null_mut;
+
+// Structures hand-copied from
+// https://docs.microsoft.com/en-us/cpp/build/reference/structure-and-constant-definitions
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct DelayLoadProc {
+    fImportByName: BOOL,
+    // Technically this is `union{LPCSTR; DWORD;}` but we don't access it anyways.
+    szProcName: LPCSTR,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct DelayLoadInfo {
+    /// size of structure
+    cb: DWORD,
+    /// raw form of data (everything is there)
+    /// Officially a pointer to ImgDelayDescr but we don't access it.
+    pidd: LPVOID,
+    /// points to address of function to load
+    ppfn: *mut FARPROC,
+    /// name of dll
+    szDll: LPCSTR,
+    /// name or ordinal of procedure
+    dlp: DelayLoadProc,
+    /// the hInstance of the library we have loaded
+    hmodCur: HMODULE,
+    /// the actual function that will be called
+    pfnCur: FARPROC,
+    /// error received (if an error notification)
+    dwLastError: DWORD,
+}
+
+#[allow(non_snake_case)]
+type PfnDliHook = unsafe extern "C" fn(dliNotify: usize, pdli: *const DelayLoadInfo) -> FARPROC;
+
+unsafe extern "C" fn load_exe_hook(event: usize, info: *const DelayLoadInfo) -> FARPROC {
+    // TODO this may need to be "electron.exe" in some cases
+    let host_binary = b"node.exe";
+
+    if event != 0x01 /* dliNotePreLoadLibrary */ {
+        return null_mut();
+    }
+
+    let dll_name = CStr::from_ptr((*info).szDll);
+    if dll_name.to_bytes() != host_binary {
+        return null_mut();
+    }
+
+    let exe_handle = GetModuleHandleA(null_mut());
+
+    // PfnDliHook sometimes has to return a FARPROC, sometimes an HMODULE, but only one
+    // of them could be specified in the header, so we have to cast our HMODULE to that.
+    exe_handle as FARPROC
+}
+
+#[no_mangle]
+static mut __pfnDliNotifyHook2: *mut PfnDliHook = load_exe_hook as *mut PfnDliHook;


### PR DESCRIPTION
This builds on https://github.com/neon-bindings/neon/pull/583 to support the renamed executable use case mentioned in that OP.

This PR ports the win_delay_load_hook from node-gyp to Rust. See https://github.com/neon-bindings/neon/issues/584#user-content-delay-load-hook for background and reasoning.

Todo:
- [x] Support "electron.exe". I think we were just going to hardcode a list of acceptable names, since there are not many, and this code is likely to be temporary anyways.