### PR TITLE
n-api: use `napi_get_all_property_names`

### DIFF
--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 cfg-if = "0.1.9"
 neon-sys = { version = "=0.4.1", path = "../neon-sys", optional = true }
-nodejs-sys = { version = "0.2.0", optional = true }
+nodejs-sys = { version = "0.7.0", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
This makes the `JsObject::get_own_property_names` actually correct. `napi_get_all_property_names` was added in N-API version 6, so it [raises our support floor to Node.js v10.20.0](https://nodejs.org/api/n-api.html#n_api_n_api_version_matrix).