### PR TITLE
Reduce JsFunction::call overhead (via smallvec)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ semver = "0.9"
 cslice = "0.2"
 semver = "0.9.0"
 neon-runtime = { version = "=0.4.2", path = "crates/neon-runtime" }
+smallvec = "1.4.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["minwindef", "libloaderapi", "ntdef"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate neon_runtime;
 extern crate cslice;
 extern crate semver;
+extern crate smallvec;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -19,6 +19,7 @@ use object::{Object, This};
 use object::class::Callback;
 use handle::{Handle, Managed};
 use handle::internal::SuperType;
+use smallvec::SmallVec;
 use self::internal::{ValueInternal, FunctionCallback};
 use self::utf8::Utf8;
 
@@ -587,7 +588,7 @@ impl<CL: Object> JsFunction<CL> {
               A: Value + 'b,
               AS: IntoIterator<Item=Handle<'b, A>>
     {
-        let mut args = args.into_iter().collect::<Vec<_>>();
+        let mut args = args.into_iter().collect::<SmallVec::<[_; 8]>>();
         let (argc, argv) = unsafe { prepare_call(cx, &mut args) }?;
         let env = cx.env().to_raw();
         build(|out| {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -602,7 +602,7 @@ impl<CL: Object> JsFunction<CL> {
         where A: Value + 'b,
               AS: IntoIterator<Item=Handle<'b, A>>
     {
-        let mut args = args.into_iter().collect::<Vec<_>>();
+        let mut args = args.into_iter().collect::<SmallVec::<[_; 8]>>();
         let (argc, argv) = unsafe { prepare_call(cx, &mut args) }?;
         let env = cx.env().to_raw();
         build(|out| {


### PR DESCRIPTION
This shaves 10-20% off of a JsFunction call, in the (presumably) common case of <= 8 args, and should be no worse for > 8 args. We're talking about tens of nanoseconds so not a huge win, of course, but it's a simple change (and smallvec is a very lightweight dependency), so why not?

before: (each line is 100k function calls, with 4 args)
```
100000 	 total: 51.223332ms 	 each: 512ns
100000 	 total: 49.608249ms 	 each: 496ns
100000 	 total: 47.576854ms 	 each: 475ns
100000 	 total: 46.925382ms 	 each: 469ns
100000 	 total: 48.606469ms 	 each: 486ns
100000 	 total: 47.447813ms 	 each: 474ns
100000 	 total: 47.039698ms 	 each: 470ns
100000 	 total: 48.588494ms 	 each: 485ns
100000 	 total: 47.96396ms 	 each: 479ns
100000 	 total: 48.267152ms 	 each: 482ns
run: 494.14ms
```

after:
```
100000 	 total: 40.613036ms 	 each: 406ns
100000 	 total: 44.00374ms 	 each: 440ns
100000 	 total: 40.510302ms 	 each: 405ns
100000 	 total: 39.676057ms 	 each: 396ns
100000 	 total: 39.9972ms 	 each: 399ns
100000 	 total: 39.505668ms 	 each: 395ns
100000 	 total: 40.986956ms 	 each: 409ns
100000 	 total: 40.879661ms 	 each: 408ns
100000 	 total: 40.424424ms 	 each: 404ns
100000 	 total: 38.291358ms 	 each: 382ns
run: 413.305ms
```

Changing JsFunction::call to take a `&mut [Handle<...>]` instead of an IntoIterator is a _hair_ faster, and makes it easy for the user to avoid allocating a Vec of args to pass into call(), but that changes the API, of course, and I don't know what kind of shenanigans `neon_runtime::fun::call` might get up to with the pointer.