### PR TITLE
Clean-up: Lots of lint fixes

### DIFF
--- a/crates/neon-runtime/src/nan/scope.rs
+++ b/crates/neon-runtime/src/nan/scope.rs
@@ -3,8 +3,14 @@
 use crate::raw::{HandleScope, EscapableHandleScope, InheritedHandleScope, Isolate};
 
 pub trait Root {
+    /// # Safety
+    /// Allocates an uninitialized scope. See `enter` and `exit`.
     unsafe fn allocate() -> Self;
+    /// # Safety
+    /// Must be called exactly once after creating a `Root` and before usage
     unsafe fn enter(&mut self, _: Isolate);
+    /// # Safety
+    /// Must be called exactly once, if and only if `enter` succeeds
     unsafe fn exit(&mut self, _: Isolate);
 }
 

--- a/crates/neon-runtime/src/napi/array.rs
+++ b/crates/neon-runtime/src/napi/array.rs
@@ -4,7 +4,7 @@ use crate::raw::{Env, Local};
 
 use crate::napi::bindings as napi;
 
-pub unsafe extern "C" fn new(out: &mut Local, env: Env, length: u32) {
+pub unsafe fn new(out: &mut Local, env: Env, length: u32) {
     assert_eq!(
         napi::create_array_with_length(env, length as usize, out as *mut _),
         napi::Status::Ok,
@@ -16,7 +16,7 @@ pub unsafe extern "C" fn new(out: &mut Local, env: Env, length: u32) {
 /// # Panics
 /// This function panics if `array` is not an Array, or if a previous n-api call caused a pending
 /// exception.
-pub unsafe extern "C" fn len(env: Env, array: Local) -> u32 {
+pub unsafe fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
     assert_eq!(
         napi::get_array_length(env, array, &mut len as *mut _),

--- a/crates/neon-runtime/src/napi/arraybuffer.rs
+++ b/crates/neon-runtime/src/napi/arraybuffer.rs
@@ -5,13 +5,13 @@ use std::ptr::null_mut;
 
 use crate::napi::bindings as napi;
 
-pub unsafe extern "C" fn new(out: &mut Local, env: Env, size: u32) -> bool {
+pub unsafe fn new(out: &mut Local, env: Env, size: u32) -> bool {
     let status = napi::create_arraybuffer(env, size as usize, null_mut(), out as *mut _);
 
     status == napi::Status::Ok
 }
 
-pub unsafe extern "C" fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
+pub unsafe fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
     let mut size = 0;
     assert_eq!(
         napi::get_arraybuffer_info(env, obj, base_out as *mut _, &mut size as *mut _),

--- a/crates/neon-runtime/src/napi/arraybuffer.rs
+++ b/crates/neon-runtime/src/napi/arraybuffer.rs
@@ -11,7 +11,7 @@ pub unsafe fn new(out: &mut Local, env: Env, size: u32) -> bool {
     status == napi::Status::Ok
 }
 
-pub unsafe fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
+pub unsafe fn data(env: Env, base_out: &mut *mut c_void, obj: Local) -> usize {
     let mut size = 0;
     assert_eq!(
         napi::get_arraybuffer_info(env, obj, base_out as *mut _, &mut size as *mut _),

--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 mod napi1 {
     use std::os::raw::{c_char, c_void};
     use super::super::types::*;

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -5,7 +5,7 @@ use std::ptr::null_mut;
 
 use crate::napi::bindings as napi;
 
-pub unsafe extern "C" fn new(env: Env, out: &mut Local, size: u32) -> bool {
+pub unsafe fn new(env: Env, out: &mut Local, size: u32) -> bool {
     let mut bytes = null_mut();
     let status = napi::create_buffer(env, size as usize, &mut bytes as *mut _, out as *mut _);
     if status == napi::Status::Ok {
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn new(env: Env, out: &mut Local, size: u32) -> bool {
     }
 }
 
-pub unsafe extern "C" fn uninitialized(env: Env, out: &mut Local, size: u32) -> bool {
+pub unsafe fn uninitialized(env: Env, out: &mut Local, size: u32) -> bool {
     let mut bytes = null_mut();
     let status = napi::create_buffer(env, size as usize, &mut bytes as *mut _, out as *mut _);
     status == napi::Status::Ok
@@ -49,7 +49,7 @@ where
     result.assume_init()
 }
 
-pub unsafe extern "C" fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
+pub unsafe fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
     let mut size = 0;
     assert_eq!(
         napi::get_buffer_info(env, obj, base_out as *mut _, &mut size as *mut _),

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -49,7 +49,7 @@ where
     result.assume_init()
 }
 
-pub unsafe fn data<'a, 'b>(env: Env, base_out: &'a mut *mut c_void, obj: Local) -> usize {
+pub unsafe fn data(env: Env, base_out: &mut *mut c_void, obj: Local) -> usize {
     let mut size = 0;
     assert_eq!(
         napi::get_buffer_info(env, obj, base_out as *mut _, &mut size as *mut _),

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -22,7 +22,7 @@ impl Default for CCallback {
     }
 }
 
-pub unsafe extern "C" fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
+pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
     let mut target: MaybeUninit<Local> = MaybeUninit::zeroed();
 
     let status = napi::get_new_target(
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn is_construct(env: Env, info: FunctionCallbackInfo) -> b
     !target.is_null()
 }
 
-pub unsafe extern "C" fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
+pub unsafe fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
     let status = napi::get_cb_info(
         env,
         info,
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn this(env: Env, info: FunctionCallbackInfo, out: &mut Lo
 
 /// Mutates the `out` argument provided to refer to the associated data value of the
 /// `napi_callback_info`.
-pub unsafe extern "C" fn data(env: Env, info: FunctionCallbackInfo, out: &mut *mut c_void) {
+pub unsafe fn data(env: Env, info: FunctionCallbackInfo, out: &mut *mut c_void) {
     let mut data = null_mut();
     let status = napi::get_cb_info(
         env,
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn data(env: Env, info: FunctionCallbackInfo, out: &mut *m
 }
 
 /// Gets the number of arguments passed to the function.
-pub unsafe extern "C" fn len(env: Env, info: FunctionCallbackInfo) -> i32 {
+pub unsafe fn len(env: Env, info: FunctionCallbackInfo) -> i32 {
     let mut argc = 0usize;
     let status = napi::get_cb_info(
         env,
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn len(env: Env, info: FunctionCallbackInfo) -> i32 {
 }
 
 /// Returns the function arguments as a `SmallVec<[Local; 8]>`
-pub unsafe extern "C" fn argv(env: Env, info: FunctionCallbackInfo) -> SmallVec<[Local; 8]> {
+pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> SmallVec<[Local; 8]> {
     let len = len(env, info);
     let mut args = smallvec![null_mut(); len as usize];
     let mut num_args = args.len();

--- a/crates/neon-runtime/src/napi/convert.rs
+++ b/crates/neon-runtime/src/napi/convert.rs
@@ -2,13 +2,13 @@ use crate::napi::bindings as napi;
 use crate::raw::{Env, Local};
 
 /// This API is currently unused, see https://github.com/neon-bindings/neon/issues/572
-pub unsafe extern "C" fn to_object(out: &mut Local, env: Env, value: Local) -> bool {
+pub unsafe fn to_object(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::coerce_to_object(env, value, out as *mut _);
 
     status == napi::Status::Ok
 }
 
-pub unsafe extern "C" fn to_string(out: &mut Local, env: Env, value: Local) -> bool {
+pub unsafe fn to_string(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::coerce_to_string(env, value, out as *mut _);
 
     status == napi::Status::Ok

--- a/crates/neon-runtime/src/napi/date.rs
+++ b/crates/neon-runtime/src/napi/date.rs
@@ -24,5 +24,5 @@ pub unsafe fn value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
     let status = napi::get_date_value(env, p, &mut value as *mut _);
     assert_eq!(status, napi::Status::Ok);
-    return value;
+    value
 }

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -9,7 +9,7 @@ use crate::napi::bindings as napi;
 
 /// Mutates the `out` argument provided to refer to a newly created `v8::Function`. Returns
 /// `false` if the value couldn't be created.
-pub unsafe extern "C" fn new(out: &mut Local, env: Env, callback: CCallback) -> bool {
+pub unsafe fn new(out: &mut Local, env: Env, callback: CCallback) -> bool {
     let status = napi::create_function(
         env,
         null(),
@@ -22,17 +22,17 @@ pub unsafe extern "C" fn new(out: &mut Local, env: Env, callback: CCallback) -> 
     status == napi::Status::Ok
 }
 
-pub unsafe extern "C" fn get_dynamic_callback(_env: Env, data: *mut c_void) -> *mut c_void {
+pub unsafe fn get_dynamic_callback(_env: Env, data: *mut c_void) -> *mut c_void {
     data
 }
 
-pub unsafe extern "C" fn call(out: &mut Local, env: Env, fun: Local, this: Local, argc: i32, argv: *mut c_void) -> bool {
+pub unsafe fn call(out: &mut Local, env: Env, fun: Local, this: Local, argc: i32, argv: *mut c_void) -> bool {
     let status = napi::call_function(env, this, fun, argc as usize, argv as *const _, out as *mut _);
 
     status == napi::Status::Ok
 }
 
-pub unsafe extern "C" fn construct(out: &mut Local, env: Env, fun: Local, argc: i32, argv: *mut c_void) -> bool {
+pub unsafe fn construct(out: &mut Local, env: Env, fun: Local, argc: i32, argv: *mut c_void) -> bool {
     let status = napi::new_instance(env, fun, argc as usize, argv as *const _, out as *mut _);
 
     status == napi::Status::Ok

--- a/crates/neon-runtime/src/napi/mem.rs
+++ b/crates/neon-runtime/src/napi/mem.rs
@@ -1,7 +1,7 @@
 use crate::raw::{Env, Local};
 use crate::napi::bindings as napi;
 
-pub unsafe extern "C" fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
+pub unsafe fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::strict_equals(env, lhs, rhs, &mut result as *mut _), napi::Status::Ok);
     result

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -4,14 +4,14 @@ use crate::napi::bindings as napi;
 use crate::raw::{Env, Local};
 
 /// Mutates the `out` argument to refer to a `napi_value` containing a newly created JavaScript Object.
-pub unsafe extern "C" fn new(out: &mut Local, env: Env) {
+pub unsafe fn new(out: &mut Local, env: Env) {
     napi::create_object(env, out as *mut _);
 }
 
 #[cfg(feature = "napi-6")]
 /// Mutates the `out` argument to refer to a `napi_value` containing the own property names of the
 /// `object` as a JavaScript Array.
-pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
+pub unsafe fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
     let mut property_names = MaybeUninit::uninit();
 
     if napi::get_all_property_names(
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn get_own_property_names(out: &mut Local, env: Env, objec
 }
 
 /// Mutate the `out` argument to refer to the value at `index` in the given `object`. Returns `false` if the value couldn't be retrieved.
-pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, index: u32) -> bool {
+pub unsafe fn get_index(out: &mut Local, env: Env, object: Local, index: u32) -> bool {
     let status = napi::get_element(env, object, index, out as *mut _);
 
     status == napi::Status::Ok
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn get_index(out: &mut Local, env: Env, object: Local, ind
 /// see [discussion].
 ///
 /// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
-pub unsafe extern "C" fn set_index(out: &mut bool, env: Env, object: Local, index: u32, val: Local) -> bool {
+pub unsafe fn set_index(out: &mut bool, env: Env, object: Local, index: u32, val: Local) -> bool {
     let status = napi::set_element(env, object, index, val);
     *out = status == napi::Status::Ok;
 
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn set_index(out: &mut bool, env: Env, object: Local, inde
 }
 
 /// Mutate the `out` argument to refer to the value at a named `key` in the given `object`. Returns `false` if the value couldn't be retrieved.
-pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, key: *const u8, len: i32) -> bool {
+pub unsafe fn get_string(env: Env, out: &mut Local, object: Local, key: *const u8, len: i32) -> bool {
     let mut key_val = MaybeUninit::uninit();
 
     // Not using `crate::string::new()` because it requires a _reference_ to a Local,
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, ke
 /// see [discussion].
 ///
 /// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
-pub unsafe extern "C" fn set_string(env: Env, out: &mut bool, object: Local, key: *const u8, len: i32, val: Local) -> bool {
+pub unsafe fn set_string(env: Env, out: &mut bool, object: Local, key: *const u8, len: i32, val: Local) -> bool {
     let mut key_val = MaybeUninit::uninit();
 
     *out = true;
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn set_string(env: Env, out: &mut bool, object: Local, key
 
 /// Mutates `out` to refer to the value of the property of `object` named by the `key` value.
 /// Returns false if the value couldn't be retrieved.
-pub unsafe extern "C" fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool {
+pub unsafe fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool {
     let status = napi::get_property(env, object, key, out as *mut _);
 
     status == napi::Status::Ok
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn get(out: &mut Local, env: Env, object: Local, key: Loca
 /// see [discussion].
 ///
 /// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
-pub unsafe extern "C" fn set(out: &mut bool, env: Env, object: Local, key: Local, val: Local) -> bool {
+pub unsafe fn set(out: &mut bool, env: Env, object: Local, key: Local, val: Local) -> bool {
     let status = napi::set_property(env, object, key, val);
     *out = status == napi::Status::Ok;
 

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -35,5 +35,5 @@ pub unsafe fn number(out: &mut Local, env: Env, v: f64) {
 pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
     assert_eq!(napi::get_value_double(env, p, &mut value as *mut f64), napi::Status::Ok);
-    return value;
+    value
 }

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -2,23 +2,23 @@ use crate::raw::{Local, Env};
 use crate::napi::bindings as napi;
 
 /// Mutates the `out` argument provided to refer to the global `undefined` object.
-pub unsafe extern "C" fn undefined(out: &mut Local, env: Env) {
+pub unsafe fn undefined(out: &mut Local, env: Env) {
     napi::get_undefined(env, out as *mut Local);
 }
 
 /// Mutates the `out` argument provided to refer to the global `null` object.
-pub unsafe extern "C" fn null(out: &mut Local, env: Env) {
+pub unsafe fn null(out: &mut Local, env: Env) {
     napi::get_null(env, out as *mut Local);
 }
 
 /// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
-pub unsafe extern "C" fn boolean(out: &mut Local, env: Env, b: bool) {
+pub unsafe fn boolean(out: &mut Local, env: Env, b: bool) {
     napi::get_boolean(env, b, out as *mut Local);
 }
 
 /// Get the boolean value out of a `Local` object. If the `Local` object does not contain a
 /// boolean, this function panics.
-pub unsafe extern "C" fn boolean_value(env: Env, p: Local) -> bool {
+pub unsafe fn boolean_value(env: Env, p: Local) -> bool {
     let mut value = false;
     assert_eq!(napi::get_value_bool(env, p, &mut value as *mut bool), napi::Status::Ok);
     value
@@ -26,13 +26,13 @@ pub unsafe extern "C" fn boolean_value(env: Env, p: Local) -> bool {
 
 /// Mutates the `out` argument provided to refer to a newly created `Local` containing a
 /// JavaScript number.
-pub unsafe extern "C" fn number(out: &mut Local, env: Env, v: f64) {
+pub unsafe fn number(out: &mut Local, env: Env, v: f64) {
     napi::create_double(env, v, out as *mut Local);
 }
 
 /// Gets the underlying value of an `Local` object containing a JavaScript number. Panics if
 /// the given `Local` is not a number.
-pub unsafe extern "C" fn number_value(env: Env, p: Local) -> f64 {
+pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
     assert_eq!(napi::get_value_double(env, p, &mut value as *mut f64), napi::Status::Ok);
     return value;

--- a/crates/neon-runtime/src/napi/raw.rs
+++ b/crates/neon-runtime/src/napi/raw.rs
@@ -18,6 +18,12 @@ impl HandleScope {
     pub fn new() -> Self { Self { word: ptr::null_mut() } }
 }
 
+impl Default for HandleScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct EscapableHandleScope {
@@ -26,6 +32,12 @@ pub struct EscapableHandleScope {
 
 impl EscapableHandleScope {
     pub fn new() -> Self { Self { word: ptr::null_mut() } }
+}
+
+impl Default for EscapableHandleScope {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/neon-runtime/src/napi/scope.rs
+++ b/crates/neon-runtime/src/napi/scope.rs
@@ -52,12 +52,12 @@ impl Root for InheritedHandleScope {
     unsafe fn exit(&mut self, _: Env) { }
 }
 
-pub unsafe extern "C" fn escape(env: Env, out: &mut Local, scope: *mut EscapableHandleScope, value: Local) {
+pub unsafe fn escape(env: Env, out: &mut Local, scope: *mut EscapableHandleScope, value: Local) {
     let status = napi::escape_handle(env, (*scope).word, value, out as *mut _);
 
     assert_eq!(status, napi::Status::Ok);
 }
 
-pub unsafe extern "C" fn get_global(env: Env, out: &mut Local) {
+pub unsafe fn get_global(env: Env, out: &mut Local) {
     assert_eq!(crate::napi::bindings::get_global(env, out as *mut _), napi::Status::Ok);
 }

--- a/crates/neon-runtime/src/napi/string.rs
+++ b/crates/neon-runtime/src/napi/string.rs
@@ -15,7 +15,7 @@ pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool 
     status == napi::Status::Ok
 }
 
-pub unsafe extern "C" fn utf8_len(env: Env, value: Local) -> isize {
+pub unsafe fn utf8_len(env: Env, value: Local) -> isize {
     let mut len = MaybeUninit::uninit();
     let status = napi::get_value_string_utf8(
         env,
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn utf8_len(env: Env, value: Local) -> isize {
     len.assume_init() as isize
 }
 
-pub unsafe extern "C" fn data(env: Env, out: *mut u8, len: isize, value: Local) -> isize {
+pub unsafe fn data(env: Env, out: *mut u8, len: isize, value: Local) -> isize {
     let mut read = MaybeUninit::uninit();
     let status = napi::get_value_string_utf8(
         env,

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -8,65 +8,65 @@ unsafe fn is_type(env: Env, val: Local, expect: napi::ValueType) -> bool {
     actual == expect
 }
 
-pub unsafe extern "C" fn is_undefined(env: Env, val: Local) -> bool {
+pub unsafe fn is_undefined(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Undefined)
 }
 
-pub unsafe extern "C" fn is_null(env: Env, val: Local) -> bool {
+pub unsafe fn is_null(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Null)
 }
 
 /// Is `val` a JavaScript number?
-pub unsafe extern "C" fn is_number(env: Env, val: Local) -> bool {
+pub unsafe fn is_number(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Number)
 }
 
 /// Is `val` a JavaScript boolean?
-pub unsafe extern "C" fn is_boolean(env: Env, val: Local) -> bool {
+pub unsafe fn is_boolean(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Boolean)
 }
 
 /// Is `val` a JavaScript string?
-pub unsafe extern "C" fn is_string(env: Env, val: Local) -> bool {
+pub unsafe fn is_string(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::String)
 }
 
-pub unsafe extern "C" fn is_object(env: Env, val: Local) -> bool {
+pub unsafe fn is_object(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Object)
 }
 
-pub unsafe extern "C" fn is_array(env: Env, val: Local) -> bool {
+pub unsafe fn is_array(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::is_array(env, val, &mut result as *mut _), napi::Status::Ok);
     result
 }
 
-pub unsafe extern "C" fn is_function(env: Env, val: Local) -> bool {
+pub unsafe fn is_function(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Function)
 }
 
-pub unsafe extern "C" fn is_error(env: Env, val: Local) -> bool {
+pub unsafe fn is_error(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::is_error(env, val, &mut result as *mut _), napi::Status::Ok);
     result
 }
 
 /// Is `val` a Node.js Buffer instance?
-pub unsafe extern "C" fn is_buffer(env: Env, val: Local) -> bool {
+pub unsafe fn is_buffer(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::is_buffer(env, val, &mut result as *mut _), napi::Status::Ok);
     result
 }
 
 /// Is `val` an ArrayBuffer instance?
-pub unsafe extern "C" fn is_arraybuffer(env: Env, val: Local) -> bool {
+pub unsafe fn is_arraybuffer(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::is_arraybuffer(env, val, &mut result as *mut _), napi::Status::Ok);
     result
 }
 
 #[cfg(feature = "napi-5")]
-pub unsafe extern "C" fn is_date(env: Env, val: Local) -> bool {
+pub unsafe fn is_date(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::is_date(env, val, &mut result as *mut _), napi::Status::Ok);
     result

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -109,7 +109,7 @@ mod build {
             .find(node_root_dir_flag_pattern)
             .map(|i| i + node_root_dir_flag_pattern.len())
             .expect("Couldn't find node_root_dir in node-gyp output.");
-        let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find("'").unwrap() + node_root_dir_start_index;
+        let node_root_dir_end_index = node_gyp_output[node_root_dir_start_index..].find('\'').unwrap() + node_root_dir_start_index;
         &node_gyp_output[node_root_dir_start_index..node_root_dir_end_index]
     }
 
@@ -131,7 +131,7 @@ mod build {
             .find(node_lib_file_flag_pattern)
             .map(|i| i + node_lib_file_flag_pattern.len())
             .expect("Couldn't find node_lib_file in node-gyp output.");
-        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find("'").unwrap() + node_lib_file_start_index;
+        let node_lib_file_end_index = node_gyp_output[node_lib_file_start_index..].find('\'').unwrap() + node_lib_file_start_index;
         &node_gyp_output[node_lib_file_start_index..node_lib_file_end_index]
     }
 
@@ -147,7 +147,7 @@ mod build {
         }
 
         // Ensure that all package.json dependencies and dev dependencies are installed.
-        npm(native_dir).args(&["install", "--silent"]).status().ok().expect("Failed to run \"npm install\" for neon-sys!");
+        npm(native_dir).args(&["install", "--silent"]).status().expect("Failed to run \"npm install\" for neon-sys!");
 
         // Run `node-gyp configure` in verbose mode to read node_root_dir on Windows.
         let output = npm(native_dir)
@@ -173,7 +173,6 @@ mod build {
         let build_output = npm(native_dir)
             .args(&["run", if debug() { "build-debug" } else { "build-release" }])
             .output()
-            .ok()
             .expect("Failed to run \"node-gyp build\" for neon-sys!");
 
         let node_gyp_build_output = String::from_utf8_lossy(&build_output.stderr);

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -156,11 +156,11 @@ mod build {
             .expect("Failed to run \"node-gyp configure\" for neon-sys!");
 
         if !output.status.success() {
-            panic!(format!(
+            panic!(
                 "Failed to run \"node-gyp configure\" for neon-sys!\n Out: {}\n Err: {}",
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)
-            ));
+            );
         }
 
         if cfg!(windows) {

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -45,6 +45,12 @@ impl HandleScope {
     pub fn new() -> HandleScope { unsafe { mem::zeroed() } }
 }
 
+impl Default for HandleScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 const ESCAPABLE_HANDLE_SCOPE_SIZE: usize = 32;
 
 /// A V8 `EscapableHandleScope`.
@@ -61,6 +67,12 @@ pub struct EscapableHandleScope {
 
 impl EscapableHandleScope {
     pub fn new() -> EscapableHandleScope { unsafe { mem::zeroed() } }
+}
+
+impl Default for EscapableHandleScope {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[repr(C)]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -250,7 +250,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(feature = "try-catch-api")]
-    fn try_catch<'b: 'a, T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
+    fn try_catch<T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
         where F: FnOnce(&mut Self) -> NeonResult<T>
     {
         self.try_catch_internal(f)

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -52,7 +52,7 @@ impl CallbackInfo<'_> {
     }
 
     #[cfg(feature = "legacy-runtime")]
-    pub fn set_return<'a, 'b, T: Value>(&'a self, value: Handle<'b, T>) {
+    pub fn set_return<T: Value>(&self, value: Handle<T>) {
         unsafe {
             neon_runtime::call::set_return(self.info, value.to_raw())
         }
@@ -332,7 +332,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     /// Throws a JS value.
-    fn throw<'b, T: Value, U>(&mut self, v: Handle<'b, T>) -> NeonResult<U> {
+    fn throw<T: Value, U>(&mut self, v: Handle<T>) -> NeonResult<U> {
         unsafe {
             neon_runtime::error::throw(self.env().to_raw(), v.to_raw());
         }
@@ -547,6 +547,9 @@ impl<'a, T: This> CallContext<'a, T> {
 
     /// Indicates the number of arguments that were passed to the function.
     pub fn len(&self) -> i32 { self.info.len(self) }
+
+    /// Indicates if no arguments were passed to the function.
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Produces the `i`th argument, or `None` if `i` is greater than or equal to `self.len()`.
     pub fn argument_opt(&mut self, i: i32) -> Option<Handle<'a, JsValue>> {

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -48,7 +48,7 @@ impl<'a, T: Managed + 'a> Eq for Handle<'a, T> { }
 impl<'a, T: Managed + 'a> Handle<'a, T> {
     pub(crate) fn new_internal(value: T) -> Handle<'a, T> {
         Handle {
-            value: value,
+            value,
             phantom: PhantomData
         }
     }
@@ -193,13 +193,13 @@ impl<'a, T: Value> Handle<'a, T> {
 
 impl<'a, T: Managed> Deref for Handle<'a, T> {
     type Target = T;
-    fn deref<'b>(&'b self) -> &'b T {
+    fn deref(&self) -> &T {
         &self.value
     }
 }
 
 impl<'a, T: Managed> DerefMut for Handle<'a, T> {
-    fn deref_mut<'b>(&'b mut self) -> &'b mut T {
+    fn deref_mut(&mut self) -> &mut T {
         &mut self.value
     }
 }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -3,16 +3,16 @@
 use semver::Version;
 
 /// The Neon version.
-pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The Neon major version.
-pub const MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
+pub const MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
 
 /// The Neon minor version.
-pub const MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
+pub const MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
 
 /// The neon patch version.
-pub const PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
+pub const PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
 
 /// Produces a `semver::Version` data structure representing the Neon version.
 pub fn version() -> Version {
@@ -29,8 +29,8 @@ pub fn version() -> Version {
 
 /// The current build profile (either `"release"` or `"debug"`).
 #[cfg(neon_profile = "release")]
-pub const BUILD_PROFILE: &'static str = "release";
+pub const BUILD_PROFILE: &str = "release";
 
 /// The current build profile (either `"release"` or `"debug"`).
 #[cfg(not(neon_profile = "release"))]
-pub const BUILD_PROFILE: &'static str = "debug";
+pub const BUILD_PROFILE: &str = "debug";

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -41,7 +41,7 @@ impl<T: Class> Callback<()> for MethodCallback<T> {
         }
     }
 
-    fn as_ptr(self) -> *mut c_void {
+    fn into_ptr(self) -> *mut c_void {
         self.0 as *mut c_void
     }
 }
@@ -78,7 +78,7 @@ impl Callback<()> for ConstructorCallCallback {
         }
     }
 
-    fn as_ptr(self) -> *mut c_void {
+    fn into_ptr(self) -> *mut c_void {
         self.0 as *mut c_void
     }
 }
@@ -95,7 +95,7 @@ impl<T: Class> Callback<*mut c_void> for AllocateCallback<T> {
                     mem::transmute(neon_runtime::class::get_allocate_kernel(data));
                 if let Ok(value) = convert_panics(env, || { kernel(cx) }) {
                     let p = Box::into_raw(Box::new(value));
-                    mem::transmute(p)
+                    p.cast()
                 } else {
                     null_mut()
                 }
@@ -103,7 +103,7 @@ impl<T: Class> Callback<*mut c_void> for AllocateCallback<T> {
         }
     }
 
-    fn as_ptr(self) -> *mut c_void {
+    fn into_ptr(self) -> *mut c_void {
         self.0 as *mut c_void
     }
 }
@@ -130,7 +130,7 @@ impl<T: Class> Callback<bool> for ConstructCallback<T> {
         }
     }
 
-    fn as_ptr(self) -> *mut c_void {
+    fn into_ptr(self) -> *mut c_void {
         self.0 as *mut c_void
     }
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -79,6 +79,7 @@ mod traits {
 
     /// The trait of types that can be a function's `this` binding.
     pub unsafe trait This: Managed {
+        #[allow(clippy::wrong_self_convention)]
         fn as_this(h: raw::Local) -> Self;
     }
 }
@@ -220,6 +221,7 @@ mod traits {
 
     /// The trait of types that can be a function's `this` binding.
     pub unsafe trait This: Managed {
+        #[allow(clippy::wrong_self_convention)]
         fn as_this(env: Env, h: raw::Local) -> Self;
     }
 }

--- a/src/types/binary.rs
+++ b/src/types/binary.rs
@@ -170,7 +170,7 @@ impl<'a> BinaryData<'a> {
         if self.size == 0 {
             &[]
         } else {
-            let base = unsafe { mem::transmute(self.base) };
+            let base = self.base.cast();
             let len = self.size / mem::size_of::<T>();
             unsafe { slice::from_raw_parts(base, len) }
         }
@@ -196,7 +196,7 @@ impl<'a> BinaryData<'a> {
         if self.size == 0 {
             &mut []
         } else {
-            let base = unsafe { mem::transmute(self.base) };
+            let base = self.base.cast();
             let len = self.size / mem::size_of::<T>();
             unsafe { slice::from_raw_parts_mut(base, len) }
         }
@@ -205,6 +205,11 @@ impl<'a> BinaryData<'a> {
     /// Produces the length of the buffer, in bytes.
     pub fn len(self) -> usize {
         self.size
+    }
+
+    /// Returns `true` if the buffer is empty
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
     }
 }
 

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -111,7 +111,7 @@ impl JsDate {
     /// `JsDate::MIN_VALUE` and `JsDate::MAX_VALUE` or if it is `NaN`
     pub fn is_valid<'a, C: Context<'a>>(self, cx: &mut C) -> bool {
         let value = self.value(cx);
-        value <= JsDate::MAX_VALUE && value >= JsDate::MIN_VALUE
+        (JsDate::MIN_VALUE..=JsDate::MAX_VALUE).contains(&value)
     }
 }
 

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -46,8 +46,8 @@ impl<T: Value> Callback<()> for FunctionCallback<T> {
         }
     }
 
-    fn as_ptr(self) -> *mut c_void {
-        unsafe { mem::transmute(self.0) }
+    fn into_ptr(self) -> *mut c_void {
+        self.0 as *mut _
     }
 }
 
@@ -74,8 +74,8 @@ impl<T: Value> Callback<raw::Local> for FunctionCallback<T> {
         }
     }
 
-    fn as_ptr(self) -> *mut c_void {
-        unsafe { mem::transmute(self.0) }
+    fn into_ptr(self) -> *mut c_void {
+        self.0 as *mut _
     }
 }
 
@@ -98,7 +98,7 @@ pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
     }
 
     /// Converts the callback to a raw void pointer.
-    fn as_ptr(self) -> *mut c_void;
+    fn into_ptr(self) -> *mut c_void;
 
     /// Exports the callback as a pair consisting of the static `Self::invoke`
     /// method and the computed callback, both converted to raw void pointers.
@@ -109,7 +109,7 @@ pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
         let invoke = Self::invoke_compat;
         CCallback {
             static_callback: unsafe { mem::transmute(invoke as usize) },
-            dynamic_callback: self.as_ptr()
+            dynamic_callback: self.into_ptr()
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -134,6 +134,7 @@ impl JsUndefined {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn as_this_compat(env: Env, _: raw::Local) -> Self {
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
@@ -530,6 +531,16 @@ impl JsArray {
     #[cfg(feature = "napi-1")]
     pub fn len<'a, C: Context<'a>>(self, cx: &mut C) -> u32 {
         self.len_inner(cx.env())
+    }
+
+    #[cfg(feature = "legacy-runtime")]
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    #[cfg(feature = "napi-1")]
+    pub fn is_empty<'a, C: Context<'a>>(self, cx: &mut C) -> bool {
+        self.len(cx) == 0
     }
 }
 

--- a/src/types/utf8.rs
+++ b/src/types/utf8.rs
@@ -63,7 +63,7 @@ impl<'a> Utf8<'a> {
         }
 
         SmallUtf8 {
-            contents: contents
+            contents,
         }
     }
 }

--- a/test/napi/src/js/coercions.rs
+++ b/test/napi/src/js/coercions.rs
@@ -2,5 +2,5 @@ use neon::prelude::*;
 
 pub fn to_string(mut cx: FunctionContext) -> JsResult<JsString> {
     let arg: Handle<JsValue> = cx.argument(0)?;
-    Ok(arg.to_string(&mut cx)?)
+    arg.to_string(&mut cx)
 }

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -107,7 +107,7 @@ pub fn throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
 
     cx.try_catch(|cx| cx.throw(v))
         .map(|_: ()| Ok(cx.string("unreachable").upcast()))
-        .unwrap_or_else(|err| Ok(err))
+        .unwrap_or_else(Ok)
 }
 
 pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
@@ -128,10 +128,7 @@ pub fn get_number_or_default(mut cx: FunctionContext) -> JsResult<JsNumber> {
 
 pub fn is_construct(mut cx: FunctionContext) -> JsResult<JsObject> {
     let this = cx.this();
-    let construct = match cx.kind() {
-        CallKind::Construct => true,
-        _ => false
-    };
+    let construct = matches!(cx.kind(), CallKind::Construct);
     let construct = cx.boolean(construct);
     this.set(&mut cx, "wasConstructed", construct)?;
     Ok(this)

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -51,8 +51,8 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
 
     let one = cx.number(1);
     let two = cx.number(2.1);
-    assert_eq!(one.value(&mut cx), 1.0);
-    assert_eq!(two.value(&mut cx), 2.1);
+    assert!((one.value(&mut cx) - 1.0).abs() < f64::EPSILON);
+    assert!((two.value(&mut cx) - 2.1).abs() < f64::EPSILON);
     cx.export_value("one", one)?;
     cx.export_value("two", two)?;
 
@@ -70,14 +70,14 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         rust_created.set(&mut cx, "whatever", whatever)?;
     }
 
-    assert_eq!({
+    assert!(({
         let v: Handle<JsNumber> = rust_created.get(&mut cx, "a")?.downcast_or_throw(&mut cx)?;
         v.value(&mut cx)
-    }, 1.0f64);
-    assert_eq!({
+    } - 1.0f64).abs() < f64::EPSILON);
+    assert!(({
         let v: Handle<JsNumber> = rust_created.get(&mut cx, 0)?.downcast_or_throw(&mut cx)?;
         v.value(&mut cx)
-    }, 1.0f64);
+    } - 1.0f64).abs() < f64::EPSILON);
     assert_eq!({
         let v: Handle<JsBoolean> = rust_created.get(&mut cx, "whatever")?.downcast_or_throw(&mut cx)?;
         v.value(&mut cx)


### PR DESCRIPTION
This fixes most clippy warnings. A couple would be breaking changes to public APIs and are ignored.

There are also lots of breaking changes to `neon-runtime`, but we consider that internal.

The `missing_safety_docs` lint is not addressed because that will take a pretty long time to implement.

```
cargo clippy --no-default-features --features legacy-runtime -- -A clippy::missing_safety_doc
cargo clippy --no-default-features --features napi-experimental -- -A clippy::missing_safety_doc
```

After this lands, I would like to `cargo fmt` the entire codebase.