### PR TITLE
Support nodejs-mobile on Android and iOS

### DIFF
--- a/cli/src/build-settings.ts
+++ b/cli/src/build-settings.ts
@@ -57,7 +57,11 @@ export default class BuildSettings {
       npm_config_disturl:           process.env.npm_config_disturl || null,
       npm_config_runtime:           process.env.npm_config_runtime || null,
       npm_config_build_from_source: process.env.npm_config_build_from_source || null,
-      npm_config_devdir:            process.env.npm_config_devdir || null
+      npm_config_devdir:            process.env.npm_config_devdir || null,
+      npm_config_node_engine:       process.env.npm_config_node_engine || null,
+      npm_config_nodedir:           process.env.npm_config_nodedir || null,
+      npm_config_node_gyp:          process.env.npm_config_node_gyp || null,
+      npm_config_platform:          process.env.npm_config_platform || null
     });
   }
 

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -94,7 +94,7 @@ mod build {
     //
     //     gyp verb architecture ia32
     fn parse_node_arch(node_gyp_output: &str) -> String {
-        let version_regex = Regex::new(r"gyp verb architecture (?P<arch>ia32|x64)").unwrap();
+        let version_regex = Regex::new(r"gyp verb architecture (?P<arch>ia32|x64|arm|arm64)").unwrap();
         let captures = version_regex.captures(&node_gyp_output).unwrap();
         String::from(&captures["arch"])
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ macro_rules! register_module {
         #[cfg_attr(target_os = "linux", link_section = ".ctors")]
         #[cfg_attr(target_os = "android", link_section = ".ctors")]
         #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
+        #[cfg_attr(target_os = "ios", link_section = "__DATA,__mod_init_func")]
         #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
         #[used]
         pub static __LOAD_NEON_MODULE: extern "C" fn() = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ macro_rules! register_module {
         // Mark this function as a global constructor (like C++).
         #[allow(improper_ctypes)]
         #[cfg_attr(target_os = "linux", link_section = ".ctors")]
+        #[cfg_attr(target_os = "android", link_section = ".ctors")]
         #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
         #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
         #[used]

--- a/test/cli/src/unit/build-settings.ts
+++ b/test/cli/src/unit/build-settings.ts
@@ -7,6 +7,10 @@ describe('build settings', () => {
     npm_config_arch: null,
     npm_config_target_arch: null,
     npm_config_disturl: null,
+    npm_config_node_engine: null,
+    npm_config_node_gyp: null,
+    npm_config_nodedir: null,
+    npm_config_platform: null,
     npm_config_runtime: null,
     npm_config_build_from_source: null,
     npm_config_devdir: null
@@ -55,6 +59,10 @@ describe('build settings', () => {
         npm_config_arch:              process.env.npm_config_arch || null,
         npm_config_target_arch:       process.env.npm_config_target_arch || null,
         npm_config_disturl:           process.env.npm_config_disturl || null,
+        npm_config_node_engine:       process.env.npm_config_node_engine || null,
+        npm_config_node_gyp:          process.env.npm_config_node_gyp || null,
+        npm_config_nodedir:           process.env.npm_config_nodedir || null,
+        npm_config_platform:          process.env.npm_config_platform || null,
         npm_config_runtime:           process.env.npm_config_runtime || null,
         npm_config_build_from_source: process.env.npm_config_build_from_source || null,
         npm_config_devdir:            process.env.npm_config_devdir || null


### PR DESCRIPTION
Neon is really great, and I've been intending to use it on mobile, specifically through [Node.js Mobile](https://code.janeasystems.com/nodejs-mobile) (a fork of Node.js with platform-specific tweaks for iOS and Android).

I've been following [this issue at nodejs-mobile](https://github.com/JaneaSystems/nodejs-mobile/issues/193) where people have figured out how to make things work. My PR contains many ideas from that discussion, and is a follow-up to PR #411. 

I have confirmed that these changes allowed me to compile [ssb-neon-keys](https://github.com/staltz/ssb-neon-keys) to `armv7-linux-androideabi` and `aarch64-linux-android` through nodejs-mobile's tooling (which includes a fork of node-gyp: `nodejs-mobile-gyp`), and it correctly runs on Android devices (both armv7 and arm64).

This PR does not address iOS support. I'm working on that, and I think the changes required in Neon will look considerably different from these changes, so it's worth submitting different PRs to make it clear what changes enable what support.