### PR TITLE
Add redirect support for downloading node.lib

### DIFF
--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -13,3 +13,6 @@ cfg-if = "0.1.9"
 
 [build-dependencies]
 cfg-if = "0.1.9"
+
+[target.'cfg(windows)'.dependencies]
+ureq = { version = "1.3.0", default-features = false, features = ["native-tls"] }


### PR DESCRIPTION
I added primitive redirect support for downloading node.lib in NAPI since Electron uses it. While its nice not pulling in any external Rust or Js deps in the build script, I think some time should be spent at some point making the download process more robust.
