### PR TITLE
Build Improvements

### DIFF
--- a/cli/src/target.ts
+++ b/cli/src/target.ts
@@ -31,22 +31,27 @@ export type TargetOptions = {
 export default class Target {
   readonly crate: Crate;
   readonly release: boolean;
-  readonly arch: string;
   readonly triple: string;
   readonly subdirectory: string;
   readonly root: string;
   readonly dylib: string;
 
   constructor(crate: Crate, options: TargetOptions = {}) {
-    let { release = true, arch = process.env.npm_config_arch || process.arch } = options;
+    let { release = true, arch = process.env.npm_config_arch } = options;
     this.crate = crate;
     this.release = release;
-    this.arch = arch;
+    this.triple = '';
 
     if (process.platform === 'win32') {
-      this.triple = (arch === 'ia32') ? 'i686-pc-windows-msvc' : 'x86_64-pc-windows-msvc';
-    } else {
-      this.triple = '';
+      switch (arch) {
+        case 'ia32':
+          this.triple = 'i686-pc-windows-msvc';
+          break;
+        case 'x64':
+          this.triple = 'x86_64-pc-windows-msvc';
+          break;
+        default:
+      }
     }
 
     if (process.env.CARGO_BUILD_TARGET) {

--- a/cli/src/target.ts
+++ b/cli/src/target.ts
@@ -8,6 +8,7 @@ const LIB_PREFIX: Record<string, string> = {
   'darwin':  "lib",
   'freebsd': "lib",
   'linux':   "lib",
+  'openbsd': "lib",
   'sunos':   "lib",
   'win32':   ""
 };
@@ -16,6 +17,7 @@ const LIB_SUFFIX: Record<string, string> = {
   'darwin':  ".dylib",
   'freebsd': ".so",
   'linux':   ".so",
+  'openbsd': ".so",
   'sunos':   ".so",
   'win32':   ".dll"
 };

--- a/crates/neon-build/src/lib.rs
+++ b/crates/neon-build/src/lib.rs
@@ -22,14 +22,11 @@ cfg_if! {
             println!("cargo:rustc-link-search=native={}", &node_lib_path.display());
             println!("cargo:rustc-link-lib={}", &node_lib_file_path.file_stem().unwrap().to_str().unwrap());
 
-            // Link `win_delay_load_hook.obj` for windows electron
-            let node_runtime_env = "npm_config_runtime";
-            println!("cargo:rerun-if-env-changed={}", node_runtime_env);
-            if var(node_runtime_env).map(|s| s == "electron") == Ok(true) {
-                println!("cargo:rustc-cdylib-link-arg=win_delay_load_hook.obj");
-                println!("cargo:rustc-cdylib-link-arg=delayimp.lib");
-                println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:node.exe");
-            }
+            // Link `win_delay_load_hook.obj`
+            // Needed for electron, but okay for other environments
+            println!("cargo:rustc-cdylib-link-arg=win_delay_load_hook.obj");
+            println!("cargo:rustc-cdylib-link-arg=delayimp.lib");
+            println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:node.exe");
         }
     } else if #[cfg(windows)] {
         // ^ automatically not neon-sys


### PR DESCRIPTION
Currently, the cache will invalidate frequently on Windows when switching between `cargo check` and `electron-build-env neon build`. This is due to two issues:

* `neon-cli` *always* sets a `--target` flag on `cargo` under Windows. This is treated as different from no target, even when the default matches the explicit value. This causes `cargo check` and `neon build` not to share a cache on Windows.
* In order to prevent a module build for the user's node from being used for Electron, we set a `rerun-if-env-changed`. This requires users to `cargo check` under `electron-build-env`.

This diff reads a little nicer [ignoring whitespace](https://github.com/neon-bindings/neon/pull/627/files?diff=unified&w=1).