### PR TITLE
feat(neon): Update `try-catch` to match the RFC; return a `T: Sized` instead of `T: Value`

### DIFF
--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -542,10 +542,10 @@ extern "C" void Neon_EventHandler_Delete(void * thread_safe_cb) {
     cb->close();
 }
 
-extern "C" try_catch_control_t Neon_TryCatch_With(Neon_TryCatchGlue glue_fn, void *rust_thunk, void *cx, v8::Local<v8::Value> *result, void **unwind_value) {
+extern "C" try_catch_control_t Neon_TryCatch_With(Neon_TryCatchGlue glue_fn, void *rust_thunk, void *cx, void *ok, v8::Local<v8::Value> *err, void **unwind_value) {
   Nan::TryCatch try_catch;
 
-  try_catch_control_t ctrl = glue_fn(rust_thunk, cx, result, unwind_value);
+  try_catch_control_t ctrl = glue_fn(rust_thunk, cx, ok, unwind_value);
 
   if (ctrl == CONTROL_PANICKED) {
     return CONTROL_PANICKED;
@@ -560,7 +560,7 @@ extern "C" try_catch_control_t Neon_TryCatch_With(Neon_TryCatchGlue glue_fn, voi
     }
     return CONTROL_RETURNED;
   } else {
-    *result = try_catch.Exception();
+    *err = try_catch.Exception();
     return CONTROL_THREW;
   }
 }

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -152,13 +152,13 @@ extern "C" {
   // returns `CONTROL_RETURNED`.
   // The `unwind_value` out-parameter can be assumed to be initialized if and only if this
   // function returns `CONTROL_PANICKED`.
-  typedef try_catch_control_t (*Neon_TryCatchGlue)(void *rust_thunk, void *cx, v8::Local<v8::Value> *result, void **unwind_value);
+  typedef try_catch_control_t (*Neon_TryCatchGlue)(void *rust_thunk, void *cx, void *ok, void **unwind_value);
 
   // The `result` out-parameter can be assumed to be initialized if and only if this function
   // returns `CONTROL_RETURNED` or `CONTROL_THREW`.
   // The `unwind_value` out-parameter can be assumed to be initialized if and only if this
   // function returns `CONTROL_PANICKED`.
-  try_catch_control_t Neon_TryCatch_With(Neon_TryCatchGlue glue, void *rust_thunk, void *cx, v8::Local<v8::Value> *result, void **unwind_value);
+  try_catch_control_t Neon_TryCatch_With(Neon_TryCatchGlue glue, void *rust_thunk, void *cx, void *ok, v8::Local<v8::Value> *err, void **unwind_value);
 }
 
 #endif

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -148,14 +148,16 @@ extern "C" {
   void Neon_EventHandler_Schedule(void* thread_safe_cb, void* rust_callback, Neon_EventHandler handler);
   void Neon_EventHandler_Delete(void* thread_safe_cb);
 
-  // The `result` out-parameter can be assumed to be initialized if and only if this function
+  // The `ok` out-parameter can be assumed to be initialized if and only if this function
   // returns `CONTROL_RETURNED`.
   // The `unwind_value` out-parameter can be assumed to be initialized if and only if this
   // function returns `CONTROL_PANICKED`.
   typedef try_catch_control_t (*Neon_TryCatchGlue)(void *rust_thunk, void *cx, void *ok, void **unwind_value);
 
-  // The `result` out-parameter can be assumed to be initialized if and only if this function
-  // returns `CONTROL_RETURNED` or `CONTROL_THREW`.
+  // The `ok` out-parameter can be assumed to be initialized if and only if this function
+  // returns `CONTROL_RETURNED`.
+  // The `err` out-parameter can be assumed to be initialized if and only if this function
+  // returns `CONTROL_THREW`.
   // The `unwind_value` out-parameter can be assumed to be initialized if and only if this
   // function returns `CONTROL_PANICKED`.
   try_catch_control_t Neon_TryCatch_With(Neon_TryCatchGlue glue, void *rust_thunk, void *cx, void *ok, v8::Local<v8::Value> *err, void **unwind_value);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -97,7 +97,7 @@ pub struct InheritedHandleScope;
 /// glue function returns `TryCatchControl::Panicked`.
 pub type TryCatchGlue = extern fn(rust_thunk: *mut c_void,
                                   cx: *mut c_void,
-                                  result: *mut Local,
+                                  result: *mut c_void,
                                   unwind_value: *mut *mut c_void) -> TryCatchControl;
 
 extern "C" {
@@ -230,6 +230,7 @@ extern "C" {
     pub fn Neon_TryCatch_With(glue: TryCatchGlue,
                               rust_thunk: *mut c_void,
                               cx: *mut c_void,
-                              result: *mut Local,
+                              ok: *mut c_void,
+                              err: *mut Local,
                               unwind_value: *mut *mut c_void) -> TryCatchControl;
 }

--- a/src/context/internal.rs
+++ b/src/context/internal.rs
@@ -127,8 +127,7 @@ pub trait ContextInternal<'a>: Sized {
 
     #[cfg(feature = "legacy-runtime")]
     fn try_catch_internal<'b: 'a, T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
-        where T: Sized,
-              F: FnOnce(&mut Self) -> NeonResult<T>,
+        where F: FnOnce(&mut Self) -> NeonResult<T>,
     {
         // A closure does not have a guaranteed layout, so we need to box it in order to pass
         // a pointer to it across the boundary into C++.
@@ -167,8 +166,7 @@ pub trait ContextInternal<'a>: Sized {
 
     #[cfg(feature = "napi-runtime")]
     fn try_catch_internal<'b: 'a, T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
-        where T: Sized,
-              F: FnOnce(&mut Self) -> NeonResult<T>
+        where F: FnOnce(&mut Self) -> NeonResult<T>
     {
         let result = f(self);
         let mut local: MaybeUninit<raw::Local> = MaybeUninit::zeroed();
@@ -190,7 +188,6 @@ extern "C" fn try_catch_glue<'a, 'b: 'a, C, T, F>(rust_thunk: *mut c_void,
                                                   returned: *mut c_void,
                                                   unwind_value: *mut *mut c_void) -> TryCatchControl
     where C: ContextInternal<'a>,
-          T: Sized,
           F: FnOnce(&mut C) -> NeonResult<T>,
 {
     let f: F = *unsafe { Box::from_raw(rust_thunk as *mut F) };

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -242,18 +242,10 @@ pub trait Context<'a>: ContextInternal<'a> {
         result
     }
 
-    #[cfg(all(feature = "try-catch-api", feature = "napi-runtime"))]
-    fn try_catch<'b: 'a, T, F>(&mut self, f: F) -> Result<Handle<'a, T>, Handle<'a, JsValue>>
-        where T: Value,
-              F: FnOnce(&mut Self) -> JsResult<'b, T>
-    {
-        self.try_catch_internal(f)
-    }
-
-    #[cfg(all(feature = "try-catch-api", feature = "legacy-runtime"))]
-    fn try_catch<'b: 'a, T, F>(&mut self, f: F) -> Result<Handle<'a, T>, Handle<'a, JsValue>>
-        where T: Value,
-              F: UnwindSafe + FnOnce(&mut Self) -> JsResult<'b, T>
+    #[cfg(feature = "try-catch-api")]
+    fn try_catch<'b: 'a, T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
+        where T: Sized,
+              F: FnOnce(&mut Self) -> NeonResult<T>
     {
         self.try_catch_internal(f)
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -244,8 +244,7 @@ pub trait Context<'a>: ContextInternal<'a> {
 
     #[cfg(feature = "try-catch-api")]
     fn try_catch<'b: 'a, T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
-        where T: Sized,
-              F: FnOnce(&mut Self) -> NeonResult<T>
+        where F: FnOnce(&mut Self) -> NeonResult<T>
     {
         self.try_catch_internal(f)
     }

--- a/test/dynamic/lib/functions.js
+++ b/test/dynamic/lib/functions.js
@@ -49,6 +49,12 @@ describe('JsFunction', function() {
     assert.equal(addon.call_and_catch(() => { return 42 }), 42);
   });
 
+  it('can return Rust type from cx.try_catch', function() {
+    const n = Math.random();
+    assert.strictEqual(addon.get_number_or_default(n), n);
+    assert.strictEqual(addon.get_number_or_default(), 0);
+  });
+
   it('propagates a panic with cx.try_catch', function() {
     assert.throws(function() {
       addon.panic_and_catch();

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -103,10 +103,10 @@ pub fn compute_scoped(mut cx: FunctionContext) -> JsResult<JsNumber> {
 
 pub fn throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     let v = cx.argument_opt(0).unwrap_or_else(|| cx.undefined().upcast());
-    Ok(cx.try_catch(|cx| {
-        let _ = cx.throw(v)?;
-        Ok(cx.string("unreachable").upcast())
-    }).unwrap_or_else(|err| err))
+
+    cx.try_catch(|cx| cx.throw(v))
+        .map(|_: ()| Ok(cx.string("unreachable").upcast()))
+        .unwrap_or_else(|err| Ok(err))
 }
 
 pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -118,6 +118,13 @@ pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     }).unwrap_or_else(|err| err))
 }
 
+pub fn get_number_or_default(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let n = cx.try_catch(|cx| Ok(cx.argument::<JsNumber>(0)?.value()))
+        .unwrap_or(0.0);
+
+    Ok(cx.number(n))
+}
+
 pub fn panic_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     Ok(cx.try_catch(|_| { panic!("oh no") })
          .unwrap_or_else(|err| err))

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -74,6 +74,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("panic_after_throw", panic_after_throw)?;
     cx.export_function("throw_and_catch", throw_and_catch)?;
     cx.export_function("call_and_catch", call_and_catch)?;
+    cx.export_function("get_number_or_default", get_number_or_default)?;
     cx.export_function("panic_and_catch", panic_and_catch)?;
     cx.export_function("unexpected_throw_and_catch", unexpected_throw_and_catch)?;
     cx.export_function("downcast_error", downcast_error)?;

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -104,6 +104,12 @@ describe('JsFunction', function() {
     assert.equal(addon.call_and_catch(() => { return 42 }), 42);
   });
 
+  it('can return Rust type from cx.try_catch', function() {
+    const n = Math.random();
+    assert.strictEqual(addon.get_number_or_default(n), n);
+    assert.strictEqual(addon.get_number_or_default(), 0);
+  });
+
   it('distinguishes calls from constructs', function() {
     assert.equal(addon.is_construct.call({}).wasConstructed, false);
     assert.equal((new addon.is_construct()).wasConstructed, true);

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -119,6 +119,13 @@ pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     }).unwrap_or_else(|err| err))
 }
 
+pub fn get_number_or_default(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let n = cx.try_catch(|cx| Ok(cx.argument::<JsNumber>(0)?.value(cx)))
+        .unwrap_or(0.0);
+
+    Ok(cx.number(n))
+}
+
 pub fn is_construct(mut cx: FunctionContext) -> JsResult<JsObject> {
     let this = cx.this();
     let construct = match cx.kind() {

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -104,10 +104,10 @@ pub fn compute_scoped(mut cx: FunctionContext) -> JsResult<JsNumber> {
 
 pub fn throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     let v = cx.argument_opt(0).unwrap_or_else(|| cx.undefined().upcast());
-    Ok(cx.try_catch(|cx| {
-        let _ = cx.throw(v)?;
-        Ok(cx.string("unreachable").upcast())
-    }).unwrap_or_else(|err| err))
+
+    cx.try_catch(|cx| cx.throw(v))
+        .map(|_: ()| Ok(cx.string("unreachable").upcast()))
+        .unwrap_or_else(|err| Ok(err))
 }
 
 pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -168,6 +168,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
 
     cx.export_function("throw_and_catch", throw_and_catch)?;
     cx.export_function("call_and_catch", call_and_catch)?;
+    cx.export_function("get_number_or_default", get_number_or_default)?;
     cx.export_function("is_construct", is_construct)?;
 
     fn call_get_own_property_names(mut cx: FunctionContext) -> JsResult<JsArray> {


### PR DESCRIPTION
As requested by https://github.com/neon-bindings/neon/issues/630

* Removes unnecessary `UnwindSafe` bound
* Changes `T: Value` to `T: Sized`
* Updates a test to leverage a non-JavaScript `T` (`()`)