### PR TITLE
feat: Allow additional arguments to be passed to `cargo build`

### DIFF
--- a/cli/src/ops/neon_build.ts
+++ b/cli/src/ops/neon_build.ts
@@ -3,7 +3,8 @@ import * as rust from '../rust';
 
 export default async function neon_build(root: string,
                                          toolchain: rust.Toolchain = 'default',
-                                         release: boolean) {
+                                         release: boolean,
+                                         args: string[]) {
   let project = await Project.create(root);
-  await project.build(toolchain, release);
+  await project.build(toolchain, release, args);
 }

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -38,7 +38,7 @@ export default class Project {
     });
   }
 
-  async build(toolchain: rust.Toolchain, release: boolean) {
+  async build(toolchain: rust.Toolchain, release: boolean, args: string[]) {
     let target = new Target(this.crate, { release: release });
     let settings = BuildSettings.current(toolchain);
 
@@ -50,7 +50,7 @@ export default class Project {
 
     // 2. Build the dylib.
     log("running cargo");
-    await target.build(toolchain, settings);
+    await target.build(toolchain, settings, args);
 
     // 3. Copy the dylib as the main addon file.
     log("generating " + path.join(this.crate.subdirectory, this.crate.nodefile));

--- a/cli/src/target.ts
+++ b/cli/src/target.ts
@@ -75,12 +75,13 @@ export default class Target {
   }
 
   async build(toolchain: rust.Toolchain,
-              settings: BuildSettings)
+              settings: BuildSettings,
+              additionalArgs: string[])
   {
     let releaseFlags = this.release ? ["--release"] : [];
     let targetFlags = this.triple ? ["--target=" + this.triple] : [];
 
-    let args = ['build'].concat(releaseFlags, targetFlags);
+    let args = ['build'].concat(releaseFlags, targetFlags, additionalArgs);
 
     try {
       let result = await rust.spawn("cargo", args, toolchain, {


### PR DESCRIPTION
Resolves https://github.com/neon-bindings/neon/issues/471

Instead of adding a special case to `features` and needing to keep up with `cargo`, all arguments after a bare `--` will be passed to cargo.

```sh
neon build -- --features awesome
```