### PR TITLE
ci: upgrade install-llvm-action to v1.1.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install libclang
-      uses: KyleMayes/install-llvm-action@7770802
+      uses: KyleMayes/install-llvm-action@01144dc
       with:
         version: "10"
         directory: ${{ runner.temp }}/llvm


### PR DESCRIPTION
Fixes the issue that causes all the warnings in check runs, like here:
https://github.com/neon-bindings/neon/actions/runs/361710689

cause described here: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/