### PR TITLE
v0.5.2 RC

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ Neon owes its existence to the contributions of these fine people.
 * [Eduard-Mihai Burtescu](https://github.com/eddyb)
 * [Gabriel Castro](https://github.com/GabrielCastro)
 * [Lin Clark](https://github.com/linclark)
+* [Nathaniel Daniel](https://github.com/adumbidiot)
 * [Joey Ezechiëls](https://github.com/jjpe)
 * [Cory Forsyth](https://github.com/bantic)
 * [Dave Herman](https://github.com/dherman)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "A safe abstraction layer for Node.js."
 readme = "README.md"
@@ -11,7 +11,7 @@ exclude = ["neon.jpg"]
 build = "build.rs"
 
 [build-dependencies]
-neon-build = { version = "=0.5.1", path = "crates/neon-build" }
+neon-build = { version = "=0.5.2", path = "crates/neon-build" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -22,7 +22,7 @@ semver = "0.9"
 cslice = "0.2"
 semver = "0.9.0"
 smallvec = "1.4.2"
-neon-runtime = { version = "=0.5.1", path = "crates/neon-runtime" }
+neon-runtime = { version = "=0.5.2", path = "crates/neon-runtime" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["minwindef", "libloaderapi", "ntdef"] }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,18 @@
+# Version 0.5.2
+
+## CLI
+
+Added support for [additional arguments](https://github.com/neon-bindings/neon/pull/633) passed to `cargo build`. Resolves https://github.com/neon-bindings/neon/issues/471.
+
+```sh
+neon build --release -- --features awesome
+```
+
+## N-API
+
+* Improved [arguments performance](https://github.com/neon-bindings/neon/pull/610)
+* Add [redirect and `NPM_CONFIG_DISTURL`](https://github.com/neon-bindings/neon/pull/620) support
+
 # Version 0.5.1
 
 ## Performance

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Build and load native Rust/Neon modules.",
   "author": "Dave Herman <david.herman@gmail.com>",
   "repository": {
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "bin": {
-    "neon": "./bin/cli.js"
+    "neon": "bin/cli.js"
   },
   "license": "SEE LICENSE IN LICENSE-*",
   "dependencies": {

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-build"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Build logic required for Neon projects."
 repository = "https://github.com/neon-bindings/neon"
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-neon-sys = { version = "=0.5.1", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.5.2", path = "../neon-sys", optional = true }
 cfg-if = "0.1.9"
 
 [build-dependencies]

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-runtime"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Bindings to the Node.js native addon API, used by the Neon implementation."
 repository = "https://github.com/neon-bindings/neon"
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 cfg-if = "0.1.9"
-neon-sys = { version = "=0.5.1", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.5.2", path = "../neon-sys", optional = true }
 nodejs-sys = { version = "0.7.0", optional = true }
 smallvec = "1.4.2"
 

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-sys"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["David Herman <david.herman@gmail.com>"]
 description  = "Exposes the low-level V8/NAN C/C++ APIs. Will be superseded by N-API."
 edition = "2018"


### PR DESCRIPTION
# Version 0.5.2

## CLI

Added support for [additional arguments](https://github.com/neon-bindings/neon/pull/633) passed to `cargo build`. Resolves https://github.com/neon-bindings/neon/issues/471.

```sh
neon build --release -- --features awesome
```

## N-API

* Improved [arguments performance](https://github.com/neon-bindings/neon/pull/610)
* Add [redirect and `NPM_CONFIG_DISTURL`](https://github.com/neon-bindings/neon/pull/620) support