### PR TITLE
feat(neon-macros): Add `neon::main` proc attr macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cslice = "0.2"
 semver = "0.9.0"
 smallvec = "1.4.2"
 neon-runtime = { version = "=0.5.2", path = "crates/neon-runtime" }
+neon-macros = { version = "=0.5.2", path = "crates/neon-macros", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["minwindef", "libloaderapi", "ntdef"] }
@@ -46,7 +47,7 @@ legacy-runtime = ["neon-runtime/neon-sys", "neon-build/neon-sys"]
 
 # Feature flag to enable the experimental N-API runtime. For now, this feature
 # is disabled by default.
-napi-runtime = ["neon-runtime/nodejs-sys"]
+napi-runtime = ["proc-macros", "neon-macros/napi", "neon-runtime/nodejs-sys"]
 
 # Feature flag to disable external dependencies on docs build
 docs-only = ["neon-runtime/docs-only"]
@@ -54,12 +55,16 @@ docs-only = ["neon-runtime/docs-only"]
 # Feature flag to enable the try_catch API of RFC 29.
 try-catch-api = []
 
+# Feature flag to include procedural macros
+proc-macros = ["neon-macros"]
+
 [package.metadata.docs.rs]
-features = ["docs-only", "event-handler-api", "try-catch-api"]
+features = ["docs-only", "event-handler-api", "proc-macros", "try-catch-api"]
 
 [workspace]
 members = [
     "crates/neon-build",
+    "crates/neon-macros",
     "crates/neon-runtime",
     "crates/neon-sys",
     "test/static",

--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "neon-macros"
+version = "0.5.2"
+authors = ["Dave Herman <david.herman@gmail.com>"]
+description = "Build logic required for Neon projects."
+repository = "https://github.com/neon-bindings/neon"
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[features]
+napi = []
+
+[dependencies]
+quote = "1"
+syn = { version = "1", features = ["full"] }
+
+[dev-dependencies.neon]
+version = "*"
+path = "../.."
+features = ["proc-macros"]

--- a/crates/neon-macros/LICENSE-APACHE
+++ b/crates/neon-macros/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/neon-macros/LICENSE-MIT
+++ b/crates/neon-macros/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2015 David Herman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/crates/neon-macros/src/legacy.rs
+++ b/crates/neon-macros/src/legacy.rs
@@ -1,0 +1,81 @@
+pub(crate) fn main(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let block = &input.block;
+    let name = &sig.ident;
+
+    quote::quote!(
+        #(#attrs) *
+        #vis #sig {
+            // Mark this function as a global constructor (like C++).
+            #[allow(improper_ctypes)]
+            #[cfg_attr(target_os = "linux", link_section = ".ctors")]
+            #[cfg_attr(target_os = "android", link_section = ".ctors")]
+            #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
+            #[cfg_attr(target_os = "ios", link_section = "__DATA,__mod_init_func")]
+            #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
+            #[used]
+            static __LOAD_NEON_MODULE: extern "C" fn() = {
+                extern "C" fn __load_neon_module() {
+                    // Put everything else in the ctor fn so the user fn can't see it.
+                    #[repr(C)]
+                    struct __NodeModule {
+                        version: i32,
+                        flags: u32,
+                        dso_handle: *mut u8,
+                        filename: *const u8,
+                        register_func: Option<extern "C" fn(
+                            ::neon::handle::Handle<::neon::types::JsObject>, *mut u8, *mut u8)>,
+                        context_register_func: Option<extern "C" fn(
+                            ::neon::handle::Handle<::neon::types::JsObject>, *mut u8, *mut u8, *mut u8)>,
+                        modname: *const u8,
+                        priv_data: *mut u8,
+                        link: *mut __NodeModule
+                    }
+
+                    // Mark as used during tests to suppress warnings
+                    #[cfg_attr(test, used)]
+                    static mut __NODE_MODULE: __NodeModule = __NodeModule {
+                        version: 0,
+                        flags: 0,
+                        dso_handle: 0 as *mut _,
+                        filename: b"neon_source.rs\0" as *const u8,
+                        register_func: Some(__register_neon_module),
+                        context_register_func: None,
+                        modname: b"neon_module\0" as *const u8,
+                        priv_data: 0 as *mut _,
+                        link: 0 as *mut _
+                    };
+
+                    extern "C" fn __register_neon_module(
+                            m: ::neon::handle::Handle<::neon::types::JsObject>, _: *mut u8, _: *mut u8) {
+                        ::neon::macro_internal::initialize_module(m, #name);
+                    }
+
+                    extern "C" {
+                        fn node_module_register(module: *mut __NodeModule);
+                    }
+
+                    // During tests, node is not available. Skip module registration.
+                    #[cfg(not(test))]
+                    unsafe {
+                        // Set the ABI version based on the NODE_MODULE_VERSION constant provided by the current node headers.
+                        __NODE_MODULE.version = ::neon::macro_internal::runtime::module::get_version();
+                        node_module_register(&mut __NODE_MODULE);
+                    }
+                }
+
+                __load_neon_module
+            };
+
+            #block
+        }
+    )
+    .into()
+}

--- a/crates/neon-macros/src/lib.rs
+++ b/crates/neon-macros/src/lib.rs
@@ -1,0 +1,43 @@
+//! Procedural macros supporting [Neon](https://docs.rs/neon/latest/neon/)
+
+#[cfg(feature = "napi")]
+mod napi;
+#[cfg(feature = "napi")]
+use napi as macros;
+
+#[cfg(not(feature = "napi"))]
+mod legacy;
+#[cfg(not(feature = "napi"))]
+use legacy as macros;
+
+// Proc macro definitions must be in the root of the crate
+// Implementations are in the backend dependent module
+
+#[proc_macro_attribute]
+/// Marks a method as the main entrypoint for initialization in a Neon
+/// module. This attribute should only be used _once_ in a module and will
+/// be called each time the module is initialized in a context.
+///
+/// ```no_run
+/// # use neon::prelude::*;
+/// #[neon::main]
+/// fn my_module(mut cx: ModuleContext) -> NeonResult<()> {
+///     let version = cx.string("1.0.0");
+/// 
+///     cx.export_value("version", version)?;
+/// 
+///     Ok(())
+/// }
+/// ```
+///
+/// If multiple functions are marked with `#[neon::main]`, there may be a compile error:
+///
+/// ```sh
+/// error: symbol `napi_register_module_v1` is already defined
+/// ```
+pub fn main(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    macros::main(attr, item)
+}

--- a/crates/neon-macros/src/napi.rs
+++ b/crates/neon-macros/src/napi.rs
@@ -1,0 +1,34 @@
+pub(crate) fn main(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let block = &input.block;
+    let name = &sig.ident;
+
+    quote::quote!(
+        #(#attrs) *
+        #vis #sig {
+            #[no_mangle]
+            unsafe extern "C" fn napi_register_module_v1(
+                env: ::neon::macro_internal::runtime::nodejs_sys::napi_env,
+                m: ::neon::macro_internal::runtime::nodejs_sys::napi_value,
+            ) -> ::neon::macro_internal::runtime::nodejs_sys::napi_value {
+                ::neon::macro_internal::initialize_module(
+                    env,
+                    ::std::mem::transmute(m),
+                    #name,
+                );
+    
+                m
+            }
+
+            #block
+        }
+    )
+    .into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ extern crate cslice;
 extern crate semver;
 extern crate smallvec;
 
+#[cfg(feature = "proc-macros")]
+extern crate neon_macros;
+
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
@@ -30,6 +33,9 @@ pub mod prelude;
 
 #[doc(hidden)]
 pub mod macro_internal;
+
+#[cfg(feature = "proc-macros")]
+pub use neon_macros::*;
 
 #[cfg(all(feature = "legacy-runtime", feature = "napi-runtime"))]
 compile_error!("Cannot enable both `legacy-runtime` and `napi-runtime` features.\n\nTo use `napi-runtime`, disable `legacy-runtime` by setting `default-features` to `false` in Cargo.toml\nor with cargo's --no-default-features flag.");

--- a/test/dynamic/native/Cargo.toml
+++ b/test/dynamic/native/Cargo.toml
@@ -13,5 +13,7 @@ crate-type = ["cdylib"]
 [build-dependencies]
 neon-build = {version = "*", path = "../../../crates/neon-build"}
 
-[dependencies]
-neon = {version = "*", path = "../../../", features = ["event-handler-api", "try-catch-api"]}
+[dependencies.neon]
+version = "*"
+path = "../../../"
+features = ["event-handler-api", "proc-macros", "try-catch-api"]

--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -20,7 +20,8 @@ use js::classes::*;
 use js::tasks::*;
 use js::eventhandler::*;
 
-register_module!(mut cx, {
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("return_js_string", return_js_string)?;
 
     cx.export_function("return_js_number", return_js_number)?;
@@ -84,4 +85,4 @@ register_module!(mut cx, {
     cx.export_class::<JsPanickyConstructor>("PanickyConstructor")?;
 
     Ok(())
-});
+}

--- a/test/electron/native/Cargo.toml
+++ b/test/electron/native/Cargo.toml
@@ -13,5 +13,7 @@ crate-type = ["cdylib"]
 [build-dependencies]
 neon-build = {version = "*", path = "../../../crates/neon-build"}
 
-[dependencies]
-neon = {version = "*", path = "../../../"}
+[dependencies.neon]
+version = "*"
+path = "../../../"
+features = ["proc-macros"]

--- a/test/electron/native/src/lib.rs
+++ b/test/electron/native/src/lib.rs
@@ -1,12 +1,12 @@
 use neon::prelude::*;
-use neon::register_module;
 
 fn hello(mut cx: FunctionContext) -> JsResult<JsString> {
     Ok(cx.string("Hello, World!"))
 }
 
-register_module!(mut cx, {
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("hello", hello)?;
 
     Ok(())
-});
+}

--- a/test/napi/native/src/lib.rs
+++ b/test/napi/native/src/lib.rs
@@ -22,7 +22,8 @@ use js::objects::*;
 use js::types::*;
 use js::strings::*;
 
-register_module!(|mut cx| {
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
     let greeting = cx.string("Hello, World!");
     let greeting_copy = greeting.value(&mut cx);
     let greeting_copy = cx.string(greeting_copy);
@@ -185,4 +186,4 @@ register_module!(|mut cx| {
     cx.export_function("external_unit", external_unit)?;
 
     Ok(())
-});
+}


### PR DESCRIPTION
## Summary

Adds a `#[neon::main]` proc macro.

## tl;dr

Use an attribute to initialize either a `legacy` or `napi` neon module. The `fn` doesn't even need to be `pub`!

```rust
use neon::prelude::*;

#[neon::main]
fn main(mut cx: ModuleContext) -> NeonResult<()> {
    Ok(())
}
```

### Migration

```diff
diff --git a/test/dynamic/native/src/lib.rs b/test/dynamic/native/src/lib.rs
index 3f2c937..409ab55 100644
--- a/test/dynamic/native/src/lib.rs
+++ b/test/dynamic/native/src/lib.rs
@@ -20,7 +20,8 @@ use js::classes::*;
 use js::tasks::*;
 use js::eventhandler::*;

-register_module!(mut cx, {
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("return_js_string", return_js_string)?;

     cx.export_function("return_js_number", return_js_number)?;
@@ -84,4 +85,4 @@ register_module!(mut cx, {
     cx.export_class::<JsPanickyConstructor>("PanickyConstructor")?;

     Ok(())
-});
+}
```

## Thought Process

### `neon-macros`

Procedural macros must be in their own crate. A new crate, `neon-macros`, is created. The crate has a single feature flag, `napi` for toggling between `legacy` and `napi` implementations.

Proc macros must be at the root of a crate. To keep the structure clean, actual implementations are in `napi.rs` and `legacy.rs` modules that are conditionally imported to `lib.rs`. The `lib.rs` has thin glue code for delegating to the correct implementation.

### Re-export

Proc macros are re-exported from `neon` to keep users from needing to specify another crate.

### Feature Flags

Proc macros can have a negative impact on compile time. A new feature flag, `proc-macros` is added to enable the feature. It is default disabled since most legacy users will continue to use the normal macros.

It is planned for proc macros to be the recommended way to use N-API. Therefore, the `napi-runtime` feature flag _automatically_ enables the `proc-macros` feature flag.

## Open Questions

1. ~Should we keep the panic hook? I think it should be removed. In my opinion, it's more harmful than helpful; especially since it is global.~ The hook is a holdover from earlier implementations and is no longer necessary. It will be removed.
1. ~Naming. I like `neon::init` because it initializes and can be called multiple times (once per context). However, `neon::main` is another option.~ Consensus on `neon::main`.
1. ~Should we try to protect against using `#[neon::init]` multiple times? I think we shouldn't because it would be complicated and brittle for limited value.~ This can be a follow-up.