### PR TITLE
finish up scopes for n-api

### DIFF
--- a/crates/neon-runtime/src/napi/scope.rs
+++ b/crates/neon-runtime/src/napi/scope.rs
@@ -55,7 +55,11 @@ impl Root for InheritedHandleScope {
     unsafe fn exit(&mut self, _: Env) { }
 }
 
-pub unsafe extern "C" fn escape(_out: &mut Local, _scope: *mut EscapableHandleScope, _value: Local) { unimplemented!() }
+pub unsafe extern "C" fn escape(env: Env, out: &mut Local, scope: *mut EscapableHandleScope, value: Local) {
+    let status = napi::napi_escape_handle(env, (*scope).word, value, out as *mut _);
+
+    assert_eq!(status, napi::napi_status::napi_ok);
+}
 
 pub unsafe extern "C" fn chained(_out: *mut c_void, _closure: *mut c_void, _callback: extern fn(&mut c_void, *mut c_void, *mut c_void, *mut c_void), _parent_scope: *mut c_void) { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/scope.rs
+++ b/crates/neon-runtime/src/napi/scope.rs
@@ -11,8 +11,8 @@ type Local = napi::napi_value;
 // implementation for N-API.
 pub trait Root {
     unsafe fn allocate() -> Self;
-    unsafe fn enter(&mut self, Env);
-    unsafe fn exit(&mut self, Env);
+    unsafe fn enter(&mut self, env: Env);
+    unsafe fn exit(&mut self, env: Env);
 }
 
 impl Root for HandleScope {

--- a/crates/neon-runtime/src/napi/scope.rs
+++ b/crates/neon-runtime/src/napi/scope.rs
@@ -61,18 +61,6 @@ pub unsafe extern "C" fn escape(env: Env, out: &mut Local, scope: *mut Escapable
     assert_eq!(status, napi::napi_status::napi_ok);
 }
 
-pub unsafe extern "C" fn chained(_out: *mut c_void, _closure: *mut c_void, _callback: extern fn(&mut c_void, *mut c_void, *mut c_void, *mut c_void), _parent_scope: *mut c_void) { unimplemented!() }
-
-pub unsafe extern "C" fn nested(_out: *mut c_void, _closure: *mut c_void, _callback: extern fn(&mut c_void, *mut c_void, *mut c_void), _realm: *mut c_void) { unimplemented!() }
-
-pub unsafe extern "C" fn size() -> usize { unimplemented!() }
-
-pub unsafe extern "C" fn alignment() -> usize { unimplemented!() }
-
-pub unsafe extern "C" fn escapable_size() -> usize { unimplemented!() }
-
-pub unsafe extern "C" fn escapable_alignment() -> usize { unimplemented!() }
-
 pub unsafe extern "C" fn get_global(env: Env, out: &mut Local) {
     assert_eq!(napi::napi_get_global(env, out as *mut _), napi::napi_status::napi_ok);
 }

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -231,7 +231,7 @@ extern "C" bool Neon_Tag_IsArrayBuffer(v8::Isolate *isolate, v8::Local<v8::Value
   return value->IsArrayBuffer();
 }
 
-extern "C" void Neon_Scope_Escape(v8::Local<v8::Value> *out, Nan::EscapableHandleScope *scope, v8::Local<v8::Value> value) {
+extern "C" void Neon_Scope_Escape(v8::Isolate *isolate, v8::Local<v8::Value> *out, Nan::EscapableHandleScope *scope, v8::Local<v8::Value> value) {
   *out = scope->Escape(value);
 }
 

--- a/crates/neon-sys/native/src/neon.h
+++ b/crates/neon-sys/native/src/neon.h
@@ -68,7 +68,7 @@ extern "C" {
   typedef void(*Neon_NestedScopeCallback)(void *, void *, void *);
   typedef void(*Neon_RootScopeCallback)(void *, void *, void *);
 
-  void Neon_Scope_Escape(v8::Local<v8::Value> *out, Nan::EscapableHandleScope *scope, v8::Local<v8::Value> value);
+  void Neon_Scope_Escape(v8::Isolate *isolate, v8::Local<v8::Value> *out, Nan::EscapableHandleScope *scope, v8::Local<v8::Value> value);
   void Neon_Scope_Nested(void *out, void *closure, Neon_NestedScopeCallback callback, void *realm);
   void Neon_Scope_Chained(void *out, void *closure, Neon_ChainedScopeCallback callback, void *parent_scope);
   void Neon_Scope_Enter(v8::HandleScope *scope, v8::Isolate *isolate);

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -183,7 +183,7 @@ extern "C" {
     pub fn Neon_Primitive_Number(out: &mut Local, isolate: Isolate, v: f64);
     pub fn Neon_Primitive_NumberValue(p: Local) -> f64;
 
-    pub fn Neon_Scope_Escape(out: &mut Local, scope: *mut EscapableHandleScope, value: Local);
+    pub fn Neon_Scope_Escape(isolate: Isolate, out: &mut Local, scope: *mut EscapableHandleScope, value: Local);
     pub fn Neon_Scope_Chained(out: *mut c_void, closure: *mut c_void, callback: extern fn(&mut c_void, *mut c_void, *mut c_void, *mut c_void), parent_scope: *mut c_void);
     pub fn Neon_Scope_Nested(out: *mut c_void, closure: *mut c_void, callback: extern fn(&mut c_void, *mut c_void, *mut c_void), realm: *mut c_void);
     pub fn Neon_Scope_Enter(scope: &mut HandleScope, isolate: Isolate);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -213,7 +213,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     {
         self.check_active();
         self.deactivate();
-        let result = ExecuteContext::with(f);
+        let result = ExecuteContext::with(self, f);
         self.activate();
         result
     }
@@ -229,7 +229,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     {
         self.check_active();
         self.deactivate();
-        let result = ComputeContext::with(|cx| {
+        let result = ComputeContext::with(self, |cx| {
             unsafe {
                 let escapable_handle_scope = cx.scope.handle_scope as *mut raw::EscapableHandleScope;
                 let escapee = f(cx)?;
@@ -455,9 +455,8 @@ pub struct ExecuteContext<'a> {
 }
 
 impl<'a> ExecuteContext<'a> {
-    pub(crate) fn with<T, F: for<'b> FnOnce(ExecuteContext<'b>) -> T>(f: F) -> T {
-        let env = Env::current();
-        Scope::with(env, |scope| {
+    pub(crate) fn with<T, C: Context<'a>, F: for<'b> FnOnce(ExecuteContext<'b>) -> T>(cx: &C, f: F) -> T {
+        Scope::with(cx.env(), |scope| {
             f(ExecuteContext { scope })
         })
     }
@@ -479,9 +478,8 @@ pub struct ComputeContext<'a, 'outer> {
 }
 
 impl<'a, 'b> ComputeContext<'a, 'b> {
-    pub(crate) fn with<T, F: for<'c, 'd> FnOnce(ComputeContext<'c, 'd>) -> T>(f: F) -> T {
-        let env = Env::current();
-        Scope::with(env, |scope| {
+    pub(crate) fn with<T, C: Context<'a>, F: for<'c, 'd> FnOnce(ComputeContext<'c, 'd>) -> T>(cx: &C, f: F) -> T {
+        Scope::with(cx.env(), |scope| {
             f(ComputeContext {
                 scope,
                 phantom_inner: PhantomData,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -234,7 +234,7 @@ pub trait Context<'a>: ContextInternal<'a> {
                 let escapable_handle_scope = cx.scope.handle_scope as *mut raw::EscapableHandleScope;
                 let escapee = f(cx)?;
                 let mut result_local: raw::Local = std::mem::zeroed();
-                neon_runtime::scope::escape(&mut result_local, escapable_handle_scope, escapee.to_raw());
+                neon_runtime::scope::escape(self.env().to_raw(), &mut result_local, escapable_handle_scope, escapee.to_raw());
                 Ok(Handle::new_internal(V::from_raw(self.env(), result_local)))
             }
         });

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -77,13 +77,11 @@ describe('JsFunction', function() {
     assert.throws(function() { addon.require_argument_zero_string(17) }, TypeError);
   });
 
-  // The N-API runtime does not support scoped computation yet.
-  it.skip('executes a scoped computation', function() {
+  it('executes a scoped computation', function() {
     assert.equal(addon.execute_scoped(), 99);
   });
 
-  // The N-API runtime does not support scoped computation yet.
-  it.skip('computes a value in a scoped computation', function() {
+  it('computes a value in a scoped computation', function() {
     assert.equal(addon.compute_scoped(), 99);
   });
 


### PR DESCRIPTION
Turned out to be quite simple in the end—we just had a couple uses of `Env::current()` and a missing implementation for napi_escape_handle. The other unimplemented functions are unused for n-api so i got rid of them here.