### PR TITLE
Dynamic loading sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ legacy-runtime = ["neon-runtime/neon-sys", "neon-build/neon-sys"]
 
 # Feature flag to enable the experimental N-API runtime. For now, this feature
 # is disabled by default.
-napi-runtime = ["proc-macros", "neon-macros/napi", "neon-runtime/nodejs-sys"]
+napi-runtime = ["proc-macros", "neon-macros/napi", "neon-runtime/napi"]
 
 # Feature flag to disable external dependencies on docs build
 docs-only = ["neon-runtime/docs-only"]

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.9"
+libloading = { version = "0.6.5", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 neon-sys = { version = "=0.5.3", path = "../neon-sys", optional = true }
 nodejs-sys = { version = "0.7.0", optional = true }
 smallvec = "1.4.2"
@@ -16,6 +18,7 @@ smallvec = "1.4.2"
 [features]
 default = []
 docs-only = ["neon-sys/docs-only"]
+napi = ["nodejs-sys", "lazy_static", "libloading"]
 
 [package.metadata.docs.rs]
 features = ["docs-only"]

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 [dependencies]
 cfg-if = "0.1.9"
 libloading = { version = "0.6.5", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 neon-sys = { version = "=0.5.3", path = "../neon-sys", optional = true }
 nodejs-sys = { version = "0.7.0", optional = true }
 smallvec = "1.4.2"
@@ -18,7 +17,7 @@ smallvec = "1.4.2"
 [features]
 default = []
 docs-only = ["neon-sys/docs-only"]
-napi = ["nodejs-sys", "lazy_static", "libloading"]
+napi = ["nodejs-sys", "libloading"]
 
 [package.metadata.docs.rs]
 features = ["docs-only"]

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Bindings to the Node.js native addon API, used by the Neon implementation."
 repository = "https://github.com/neon-bindings/neon"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.9"

--- a/crates/neon-runtime/src/lib.rs
+++ b/crates/neon-runtime/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate cfg_if;
-extern crate smallvec;
-
 #[cfg(all(not(feature = "neon-sys"), not(feature = "nodejs-sys")))]
 compile_error!("The Neon runtime must have at least one of the `neon-sys` or `nodejs-sys` backends enabled.");
 
@@ -8,14 +5,13 @@ use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(feature = "nodejs-sys")] {
-        pub extern crate nodejs_sys;
+        pub use nodejs_sys;
         pub mod napi;
     }
 }
 
 cfg_if! {
     if #[cfg(feature = "neon-sys")] {
-        extern crate neon_sys;
         pub mod nan;
         // The legacy variant is the default API as long as it's present.
         pub use nan::*;

--- a/crates/neon-runtime/src/nan/error.rs
+++ b/crates/neon-runtime/src/nan/error.rs
@@ -1,6 +1,6 @@
 //! Facilities for creating and throwing JS errors.
 
-use raw::{Isolate, Local};
+use crate::raw::{Isolate, Local};
 
 /// Throws an `Error` object in the current context.
 pub unsafe fn throw(_: Isolate, val: Local) {

--- a/crates/neon-runtime/src/nan/scope.rs
+++ b/crates/neon-runtime/src/nan/scope.rs
@@ -1,11 +1,11 @@
 //! Facilities for working with `v8::HandleScope`s and `v8::EscapableHandleScope`s.
 
-use raw::{HandleScope, EscapableHandleScope, InheritedHandleScope, Isolate};
+use crate::raw::{HandleScope, EscapableHandleScope, InheritedHandleScope, Isolate};
 
 pub trait Root {
     unsafe fn allocate() -> Self;
-    unsafe fn enter(&mut self, Isolate);
-    unsafe fn exit(&mut self, Isolate);
+    unsafe fn enter(&mut self, isolate: Isolate);
+    unsafe fn exit(&mut self, isolate: Isolate);
 }
 
 impl Root for HandleScope {

--- a/crates/neon-runtime/src/napi/array.rs
+++ b/crates/neon-runtime/src/napi/array.rs
@@ -1,6 +1,6 @@
 //! Facilities for working with Array `napi_value`s.
 
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 use nodejs_sys as napi;
 

--- a/crates/neon-runtime/src/napi/arraybuffer.rs
+++ b/crates/neon-runtime/src/napi/arraybuffer.rs
@@ -1,4 +1,4 @@
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 use std::os::raw::c_void;
 use std::ptr::null_mut;
 

--- a/crates/neon-runtime/src/napi/bindings.rs
+++ b/crates/neon-runtime/src/napi/bindings.rs
@@ -1,0 +1,144 @@
+use std::mem::MaybeUninit;
+use lazy_static::lazy_static;
+use libloading::{Library, Symbol};
+
+/* Later we should do:
+#[repr(C)]
+struct NapiEnvStruct {}
+
+#[repr(C)]
+struct NapiValueStruct {}
+
+pub(crate) type NapiEnv = *mut NapiEnvStruct;
+pub(crate) type NapiValue = *mut NapiValueStruct;
+
+But in this sample we still rely on nodejs_sys's types
+*/
+
+pub(crate) type NapiEnv = nodejs_sys::napi_env;
+pub(crate) type NapiValue = nodejs_sys::napi_value;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+pub(crate) enum NapiStatus {
+    napi_ok,
+    napi_invalid_arg,
+    napi_object_expected,
+    napi_string_expected,
+    napi_name_expected,
+    napi_function_expected,
+    napi_number_expected,
+    napi_boolean_expected,
+    napi_array_expected,
+    napi_generic_failure,
+    napi_pending_exception,
+    napi_cancelled,
+    napi_escape_called_twice,
+    napi_handle_scope_mismatch,
+    napi_callback_scope_mismatch,
+    napi_queue_full,
+    napi_closing,
+    napi_bigint_expected,
+    napi_date_expected,
+    napi_arraybuffer_expected,
+    napi_detachable_arraybuffer_expected,
+    napi_would_deadlock,
+}
+
+/* Maybe we can make a macro like this:
+ *
+ * declare_napi_functions! {
+ *     fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus;
+ *     fn napi_get_null(env: NapiEnv, out: *mut NapiValue) -> NapiStatus;
+ *
+ *     fn napi_get_boolean(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus;
+ *     fn napi_get_value_bool(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus;
+ *
+ *     fn napi_create_double(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus;
+ *     fn napi_get_value_double(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus;
+ * }
+ *
+ * I think it would have to be a proc macro, since we need to output those declarations several
+ * times in different shapes. It would allow generating both the property declarations in the Napi
+ * struct, and the `library.get()` calls in the `from_host` constructor. It could also generate
+ * trampoline functions so we don't have to use an `napi!()` macro wrapper for napi function calls:
+ *
+ * pub unsafe fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus {
+ *     ((*NAPI).napi_get_undefined)(env, out)
+ * }
+ *
+ * Then our code wouldn't look any different compared to using nodejs-sys.
+ */
+
+pub(crate) struct Napi<'a> {
+    pub napi_get_undefined: Symbol<'a, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
+    pub napi_get_null: Symbol<'a, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
+
+    pub napi_get_boolean:
+        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus>,
+    pub napi_get_value_bool:
+        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus>,
+
+    pub napi_create_double:
+        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus>,
+    pub napi_get_value_double:
+        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus>,
+}
+
+#[cfg(not(windows))]
+fn get_host_library() -> Library {
+    use libloading::os::unix::Library;
+    Library::this().into()
+}
+
+#[cfg(windows)]
+fn get_host_library() -> Library {
+    use libloading::os::windows::Library;
+    Library::this().into()
+}
+
+lazy_static! {
+    static ref HOST: Library = get_host_library();
+}
+
+impl Napi<'_> {
+    fn try_from_host() -> Result<Self, libloading::Error> {
+        let host = &HOST;
+
+        Ok(unsafe {
+            Self {
+                napi_get_undefined: host.get(b"napi_get_undefined")?,
+                napi_get_null: host.get(b"napi_get_null")?,
+                napi_get_boolean: host.get(b"napi_get_boolean")?,
+                napi_get_value_bool: host.get(b"napi_get_value_bool")?,
+                napi_create_double: host.get(b"napi_create_double")?,
+                napi_get_value_double: host.get(b"napi_get_value_double")?,
+            }
+        })
+    }
+
+    pub fn from_host() -> Self {
+        Self::try_from_host().unwrap()
+    }
+}
+
+pub(crate) static mut NAPI: MaybeUninit<Napi> = MaybeUninit::uninit();
+
+/// Load the N-API symbols we need.
+pub(crate) unsafe fn load() {
+    NAPI.as_mut_ptr().write(Napi::from_host());
+}
+
+macro_rules! napi {
+    ( $name:ident ( $($args:expr),* ) ) => {
+        {
+            let bindings = $crate::napi::bindings::NAPI.as_ptr();
+            let result: $crate::napi::bindings::NapiStatus = ((*bindings).$name)(
+                $($args),*
+            );
+            result
+        }
+    }
+}

--- a/crates/neon-runtime/src/napi/bindings.rs
+++ b/crates/neon-runtime/src/napi/bindings.rs
@@ -70,7 +70,7 @@ fn get_host_library() -> Library {
 #[cfg(windows)]
 fn get_host_library() -> Library {
     use libloading::os::windows::Library;
-    Library::this().into()
+    Library::this().unwrap().into()
 }
 
 impl Napi {

--- a/crates/neon-runtime/src/napi/bindings.rs
+++ b/crates/neon-runtime/src/napi/bindings.rs
@@ -47,19 +47,19 @@ pub(crate) enum NapiStatus {
     napi_would_deadlock,
 }
 
-pub(crate) struct Napi<'a> {
-    pub napi_get_undefined: Symbol<'a, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
-    pub napi_get_null: Symbol<'a, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
+pub(crate) struct Napi {
+    pub napi_get_undefined: Symbol<'static, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
+    pub napi_get_null: Symbol<'static, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
 
     pub napi_get_boolean:
-        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus>,
+        Symbol<'static, unsafe extern "C" fn(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus>,
     pub napi_get_value_bool:
-        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus>,
+        Symbol<'static, unsafe extern "C" fn(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus>,
 
     pub napi_create_double:
-        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus>,
+        Symbol<'static, unsafe extern "C" fn(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus>,
     pub napi_get_value_double:
-        Symbol<'a, unsafe extern "C" fn(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus>,
+        Symbol<'static, unsafe extern "C" fn(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus>,
 }
 
 #[cfg(not(windows))]
@@ -78,7 +78,7 @@ lazy_static! {
     static ref HOST: Library = get_host_library();
 }
 
-impl Napi<'_> {
+impl Napi {
     fn try_from_host() -> Result<Self, libloading::Error> {
         let host = &HOST;
 

--- a/crates/neon-runtime/src/napi/bindings.rs
+++ b/crates/neon-runtime/src/napi/bindings.rs
@@ -106,14 +106,32 @@ pub(crate) unsafe fn load() {
     NAPI.as_mut_ptr().write(Napi::from_host());
 }
 
-macro_rules! napi {
-    ( $name:ident ( $($args:expr),* ) ) => {
-        {
-            let bindings = $crate::napi::bindings::NAPI.as_ptr();
-            let result: $crate::napi::bindings::NapiStatus = ((*bindings).$name)(
-                $($args),*
-            );
-            result
-        }
-    }
+#[inline(always)]
+pub(crate) unsafe fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus {
+    ((*NAPI.as_ptr()).napi_get_undefined)(env, out)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn napi_get_null(env: NapiEnv, out: *mut NapiValue) -> NapiStatus {
+    ((*NAPI.as_ptr()).napi_get_null)(env, out)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn napi_get_boolean(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus {
+    ((*NAPI.as_ptr()).napi_get_boolean)(env, value, out)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn napi_get_value_bool(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus {
+    ((*NAPI.as_ptr()).napi_get_value_bool)(env, value, out)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn napi_create_double(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus {
+    ((*NAPI.as_ptr()).napi_create_double)(env, value, out)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn napi_get_value_double(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus {
+    ((*NAPI.as_ptr()).napi_get_value_double)(env, value, out)
 }

--- a/crates/neon-runtime/src/napi/bindings.rs
+++ b/crates/neon-runtime/src/napi/bindings.rs
@@ -47,31 +47,6 @@ pub(crate) enum NapiStatus {
     napi_would_deadlock,
 }
 
-/* Maybe we can make a macro like this:
- *
- * declare_napi_functions! {
- *     fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus;
- *     fn napi_get_null(env: NapiEnv, out: *mut NapiValue) -> NapiStatus;
- *
- *     fn napi_get_boolean(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus;
- *     fn napi_get_value_bool(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus;
- *
- *     fn napi_create_double(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus;
- *     fn napi_get_value_double(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus;
- * }
- *
- * I think it would have to be a proc macro, since we need to output those declarations several
- * times in different shapes. It would allow generating both the property declarations in the Napi
- * struct, and the `library.get()` calls in the `from_host` constructor. It could also generate
- * trampoline functions so we don't have to use an `napi!()` macro wrapper for napi function calls:
- *
- * pub unsafe fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus {
- *     ((*NAPI).napi_get_undefined)(env, out)
- * }
- *
- * Then our code wouldn't look any different compared to using nodejs-sys.
- */
-
 pub(crate) struct Napi<'a> {
     pub napi_get_undefined: Symbol<'a, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,
     pub napi_get_null: Symbol<'a, unsafe extern "C" fn(env: NapiEnv, out: *mut NapiValue) -> NapiStatus>,

--- a/crates/neon-runtime/src/napi/buffer.rs
+++ b/crates/neon-runtime/src/napi/buffer.rs
@@ -1,4 +1,4 @@
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 use std::os::raw::c_void;
 use std::ptr::null_mut;
 

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 use std::ptr::null_mut;
-use raw::{FunctionCallbackInfo, Env, Local};
+use crate::raw::{FunctionCallbackInfo, Env, Local};
 use smallvec::{smallvec, SmallVec};
 use nodejs_sys as napi;
 

--- a/crates/neon-runtime/src/napi/class.rs
+++ b/crates/neon-runtime/src/napi/class.rs
@@ -1,6 +1,6 @@
 use std::os::raw::c_void;
-use call::CCallback;
-use raw::{Env, Local};
+use crate::call::CCallback;
+use crate::raw::{Env, Local};
 
 pub unsafe extern "C" fn get_class_map(_isolate: Env) -> *mut c_void { unimplemented!() }
 

--- a/crates/neon-runtime/src/napi/convert.rs
+++ b/crates/neon-runtime/src/napi/convert.rs
@@ -1,6 +1,6 @@
 use nodejs_sys as napi;
 
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 /// This API is currently unused, see https://github.com/neon-bindings/neon/issues/572
 pub unsafe extern "C" fn to_object(out: &mut Local, env: Env, value: Local) -> bool {

--- a/crates/neon-runtime/src/napi/error.rs
+++ b/crates/neon-runtime/src/napi/error.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 use nodejs_sys as napi;
 
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 pub unsafe fn is_throwing(env: Env) -> bool {
     let mut b: MaybeUninit<bool> = MaybeUninit::zeroed();

--- a/crates/neon-runtime/src/napi/external.rs
+++ b/crates/neon-runtime/src/napi/external.rs
@@ -1,6 +1,6 @@
 use std::mem::MaybeUninit;
 
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 use nodejs_sys as napi;
 

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -1,7 +1,7 @@
 //! Facilities for working with JS functions.
 
-use call::CCallback;
-use raw::{Env, Local};
+use crate::call::CCallback;
+use crate::raw::{Env, Local};
 use std::os::raw::c_void;
 use std::ptr::null;
 

--- a/crates/neon-runtime/src/napi/handler.rs
+++ b/crates/neon-runtime/src/napi/handler.rs
@@ -1,4 +1,4 @@
-use raw::Local;
+use crate::raw::Local;
 use std::os::raw::c_void;
 
 pub unsafe extern "C" fn new(_isolate: *mut c_void, _this: Local, _callback: Local) -> *mut c_void { unimplemented!() }

--- a/crates/neon-runtime/src/napi/mem.rs
+++ b/crates/neon-runtime/src/napi/mem.rs
@@ -1,3 +1,3 @@
-use raw::Local;
+use crate::raw::Local;
 
 pub unsafe extern "C" fn same_handle(_h1: Local, _h2: Local) -> bool { unimplemented!() }

--- a/crates/neon-runtime/src/napi/mod.rs
+++ b/crates/neon-runtime/src/napi/mod.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+pub(crate) mod bindings;
+
 pub mod array;
 pub mod arraybuffer;
 pub mod buffer;
@@ -16,3 +19,9 @@ pub mod string;
 pub mod tag;
 pub mod task;
 pub mod handler;
+
+/// # Safety
+/// Must only be called once.
+pub unsafe fn setup() {
+    bindings::load();
+}

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -2,7 +2,7 @@ use std::mem::MaybeUninit;
 
 use nodejs_sys as napi;
 
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 /// Mutates the `out` argument to refer to a `napi_value` containing a newly created JavaScript Object.
 pub unsafe extern "C" fn new(out: &mut Local, env: Env) {

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -1,10 +1,10 @@
 use crate::raw::{Local, Env};
-use crate::bindings::NapiStatus;
+use crate::bindings::{self as napi, NapiStatus};
 
 /// Mutates the `out` argument provided to refer to the global `undefined` object.
 pub unsafe extern "C" fn undefined(out: &mut Local, env: Env) {
     assert_eq!(
-        napi!(napi_get_undefined(env, out as *mut Local)),
+        napi::napi_get_undefined(env, out as *mut Local),
         NapiStatus::napi_ok,
     );
 }
@@ -12,7 +12,7 @@ pub unsafe extern "C" fn undefined(out: &mut Local, env: Env) {
 /// Mutates the `out` argument provided to refer to the global `null` object.
 pub unsafe extern "C" fn null(out: &mut Local, env: Env) {
     assert_eq!(
-        napi!(napi_get_null(env, out as *mut Local)),
+        napi::napi_get_null(env, out as *mut Local),
         NapiStatus::napi_ok,
     );
 }
@@ -20,7 +20,7 @@ pub unsafe extern "C" fn null(out: &mut Local, env: Env) {
 /// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
 pub unsafe extern "C" fn boolean(out: &mut Local, env: Env, b: bool) {
     assert_eq!(
-        napi!(napi_get_boolean(env, b, out as *mut Local)),
+        napi::napi_get_boolean(env, b, out as *mut Local),
         NapiStatus::napi_ok,
     );
 }
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn boolean(out: &mut Local, env: Env, b: bool) {
 pub unsafe extern "C" fn boolean_value(env: Env, p: Local) -> bool {
     let mut value = false;
     assert_eq!(
-        napi!(napi_get_value_bool(env, p, &mut value as *mut bool)),
+        napi::napi_get_value_bool(env, p, &mut value as *mut bool),
         NapiStatus::napi_ok,
     );
     value
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn integer_value(_p: Local) -> i64 { unimplemented!() }
 /// JavaScript number.
 pub unsafe extern "C" fn number(out: &mut Local, env: Env, v: f64) {
     assert_eq!(
-        napi!(napi_create_double(env, v, out as *mut Local)),
+        napi::napi_create_double(env, v, out as *mut Local),
         NapiStatus::napi_ok,
     );
 }
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn number(out: &mut Local, env: Env, v: f64) {
 pub unsafe extern "C" fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
     assert_eq!(
-        napi!(napi_get_value_double(env, p, &mut value as *mut f64)),
+        napi::napi_get_value_double(env, p, &mut value as *mut f64),
         NapiStatus::napi_ok,
     );
     return value;

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -1,4 +1,4 @@
-use raw::{Local, Env};
+use crate::raw::{Local, Env};
 
 use nodejs_sys as napi;
 

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -1,27 +1,38 @@
 use crate::raw::{Local, Env};
-
-use nodejs_sys as napi;
+use crate::bindings::NapiStatus;
 
 /// Mutates the `out` argument provided to refer to the global `undefined` object.
 pub unsafe extern "C" fn undefined(out: &mut Local, env: Env) {
-    napi::napi_get_undefined(env, out as *mut Local);
+    assert_eq!(
+        napi!(napi_get_undefined(env, out as *mut Local)),
+        NapiStatus::napi_ok,
+    );
 }
 
 /// Mutates the `out` argument provided to refer to the global `null` object.
 pub unsafe extern "C" fn null(out: &mut Local, env: Env) {
-    napi::napi_get_null(env, out as *mut Local);
+    assert_eq!(
+        napi!(napi_get_null(env, out as *mut Local)),
+        NapiStatus::napi_ok,
+    );
 }
 
 /// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
 pub unsafe extern "C" fn boolean(out: &mut Local, env: Env, b: bool) {
-    napi::napi_get_boolean(env, b, out as *mut Local);
+    assert_eq!(
+        napi!(napi_get_boolean(env, b, out as *mut Local)),
+        NapiStatus::napi_ok,
+    );
 }
 
 /// Get the boolean value out of a `Local` object. If the `Local` object does not contain a
 /// boolean, this function panics.
 pub unsafe extern "C" fn boolean_value(env: Env, p: Local) -> bool {
     let mut value = false;
-    assert_eq!(napi::napi_get_value_bool(env, p, &mut value as *mut bool), napi::napi_status::napi_ok);
+    assert_eq!(
+        napi!(napi_get_value_bool(env, p, &mut value as *mut bool)),
+        NapiStatus::napi_ok,
+    );
     value
 }
 
@@ -38,13 +49,19 @@ pub unsafe extern "C" fn integer_value(_p: Local) -> i64 { unimplemented!() }
 /// Mutates the `out` argument provided to refer to a newly created `Local` containing a
 /// JavaScript number.
 pub unsafe extern "C" fn number(out: &mut Local, env: Env, v: f64) {
-    napi::napi_create_double(env, v, out as *mut Local);
+    assert_eq!(
+        napi!(napi_create_double(env, v, out as *mut Local)),
+        NapiStatus::napi_ok,
+    );
 }
 
 /// Gets the underlying value of an `Local` object containing a JavaScript number. Panics if
 /// the given `Local` is not a number.
 pub unsafe extern "C" fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    assert_eq!(napi::napi_get_value_double(env, p, &mut value as *mut f64), napi::napi_status::napi_ok);
+    assert_eq!(
+        napi!(napi_get_value_double(env, p, &mut value as *mut f64)),
+        NapiStatus::napi_ok,
+    );
     return value;
 }

--- a/crates/neon-runtime/src/napi/scope.rs
+++ b/crates/neon-runtime/src/napi/scope.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 
 use nodejs_sys as napi;
 
-use raw::{Env, HandleScope, EscapableHandleScope, InheritedHandleScope};
+use crate::raw::{Env, HandleScope, EscapableHandleScope, InheritedHandleScope};
 
 type Local = napi::napi_value;
 

--- a/crates/neon-runtime/src/napi/string.rs
+++ b/crates/neon-runtime/src/napi/string.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 use nodejs_sys as napi;
 
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool {
     let status = napi::napi_create_string_utf8(

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -1,4 +1,4 @@
-use raw::{Env, Local};
+use crate::raw::{Env, Local};
 
 use nodejs_sys as napi;
 

--- a/crates/neon-runtime/src/napi/task.rs
+++ b/crates/neon-runtime/src/napi/task.rs
@@ -1,4 +1,4 @@
-use raw::Local;
+use crate::raw::Local;
 use std::os::raw::c_void;
 
 pub unsafe extern "C" fn schedule(_task: *mut c_void,

--- a/src/context/internal.rs
+++ b/src/context/internal.rs
@@ -233,6 +233,12 @@ pub fn initialize_module(exports: Handle<JsObject>, init: fn(ModuleContext) -> N
 
 #[cfg(feature = "napi-runtime")]
 pub fn initialize_module(env: raw::Env, exports: Handle<JsObject>, init: fn(ModuleContext) -> NeonResult<()>) {
+    // SAFETY: initialize_module() is only called once by Neon during startup, before any user code
+    // runs.
+    unsafe {
+        neon_runtime::setup();
+    }
+
     ModuleContext::with(Env(env), exports, |cx| {
         let _ = init(cx);
     });


### PR DESCRIPTION
This PR implements the approach described in #584, and uses it in the functions in `neon_runtime::napi::primitive`.

The N-API symbols are loaded from the host process, which could be Node.js or Electron. We have to provide our own N-API type declarations with this approach. Since N-API is ABI-stable, that should not require a lot of maintenance.

Here, we use `libloading` to retrieve symbols from the host executable. We store raw function pointers, bypassing some `libloading` safety features. This is OK for us because we run as a module inside the host executable: the executable will not be unloaded before we are, so the pointers will not become invalid at any point while we are running. Currently, this sample uses hand-written trampoline functions to call the actual function pointers. The original PR used a macro (described below).

## Original PR description
Some changes were made to the approach. This was the original description:

> The gist of the system is:
> ```rust
> struct Napi<'a> {
>   napi_functionname: Symbol<'a, unsafe extern "C" fn(argtypes...) -> NapiStatus>,
> }
> impl Napi<'_> {
>   pub fn from_host() -> Self {
>     Self {
>       napi_functionname: load_host_library().get("napi_functionname").unwrap(),
>     }
>   }
> }
> ```
> 
> An instance of this `Napi` struct is initialized when the Neon module loads. Calls to N-API functions are made  > like:
> ```rust
> let status = napi!(napi_functionname(args...));
> ```
> Which translates to something like
> ```rust
> let status = ((*crate::bindings::NAPI).napi_functionname)(args...);
> ```

<details>
<summary>
Silly(?) macro idea
</summary>

Maybe we can make a macro like this to ease future maintenance:
```rust
declare_napi_functions! {
    fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus;
    fn napi_get_null(env: NapiEnv, out: *mut NapiValue) -> NapiStatus;

    fn napi_get_boolean(env: NapiEnv, value: bool, out: *mut NapiValue) -> NapiStatus;
    fn napi_get_value_bool(env: NapiEnv, value: NapiValue, out: *mut bool) -> NapiStatus;

    fn napi_create_double(env: NapiEnv, value: f64, out: *mut NapiValue) -> NapiStatus;
    fn napi_get_value_double(env: NapiEnv, value: NapiValue, out: *mut f64) -> NapiStatus;
}
```

I think it would have to be a proc macro, since we need to output those declarations several
times in different shapes. It would allow generating both the property declarations in the Napi
struct, and the `library.get()` calls in the `from_host` constructor. It could also generate
trampoline functions so we don't have to use an `napi!()` macro wrapper for napi function calls:

```rust
pub unsafe fn napi_get_undefined(env: NapiEnv, out: *mut NapiValue) -> NapiStatus {
    ((*NAPI).napi_get_undefined)(env, out)
}
```

Might well be a case where writing the abstraction would be a lot more work than just doing it by hand, though.

</details>