### PR TITLE
Version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "A safe abstraction layer for Node.js."
 readme = "README.md"
@@ -11,7 +11,7 @@ exclude = ["neon.jpg"]
 build = "build.rs"
 
 [build-dependencies]
-neon-build = { version = "=0.5.3", path = "crates/neon-build" }
+neon-build = { version = "=0.6.0", path = "crates/neon-build" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -22,8 +22,8 @@ semver = "0.9"
 cslice = "0.2"
 semver = "0.9.0"
 smallvec = "1.4.2"
-neon-runtime = { version = "=0.5.3", path = "crates/neon-runtime" }
-neon-macros = { version = "=0.5.3", path = "crates/neon-macros", optional = true }
+neon-runtime = { version = "=0.6.0", path = "crates/neon-runtime" }
+neon-macros = { version = "=0.6.0", path = "crates/neon-macros", optional = true }
 
 [features]
 default = ["legacy-runtime"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,12 @@
+# Version 0.6.0
+
+The `cx.try_catch(..)` API has been updated to return `T: Sized` instead of `T: Value` (https://github.com/neon-bindings/neon/pull/631). This API is strictly more powerful and allows users to return both JavaScript and Rust values from `try_catch` closures.
+
+## N-API
+
+* N-API symbols are now loaded dynamically (https://github.com/neon-bindings/neon/pull/646)
+* Build process for N-API is greatly simplified by leveraging dynamic loading (https://github.com/neon-bindings/neon/pull/647)
+
 # Version 0.5.3
 
 ## Bug Fixes

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Build and load native Rust/Neon modules.",
   "author": "Dave Herman <david.herman@gmail.com>",
   "repository": {

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-build"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Build logic required for Neon projects."
 repository = "https://github.com/neon-bindings/neon"
@@ -9,4 +9,4 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-neon-sys = { version = "=0.5.3", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.6.0", path = "../neon-sys", optional = true }

--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-macros"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Procedural macros supporting Neon"
 repository = "https://github.com/neon-bindings/neon"

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-runtime"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Bindings to the Node.js native addon API, used by the Neon implementation."
 repository = "https://github.com/neon-bindings/neon"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "0.1.9"
 libloading = { version = "0.6.5", optional = true }
-neon-sys = { version = "=0.5.3", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.6.0", path = "../neon-sys", optional = true }
 smallvec = "1.4.2"
 
 [dev-dependencies]

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-sys"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["David Herman <david.herman@gmail.com>"]
 description  = "Exposes the low-level V8/NAN C/C++ APIs. Will be superseded by N-API."
 edition = "2018"


### PR DESCRIPTION
# Version 0.6.0

The `cx.try_catch(..)` API has been updated to return `T: Sized` instead of `T: Value` (https://github.com/neon-bindings/neon/pull/631). This API is strictly more powerful and allows users to return both JavaScript and Rust values from `try_catch` closures.

## N-API

* N-API symbols are now loaded dynamically (https://github.com/neon-bindings/neon/pull/646)
* Build process for N-API is greatly simplified by leveraging dynamic loading (https://github.com/neon-bindings/neon/pull/647)