### PR TITLE
Upgrade cfg-if

### DIFF
--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-cfg-if = "0.1.9"
+cfg-if = "1.0.0"
 libloading = { version = "0.6.5", optional = true }
 neon-sys = { version = "=0.6.0", path = "../neon-sys", optional = true }
 smallvec = "1.4.2"


### PR DESCRIPTION
libloading uses cfg-if 1.x. neon-runtime was also pulling in 0.1.x.

So this change shaves one whole (vanishingly small) crate off our users' compile times!