### PR TITLE
feat(cli): Add `--crate` option to specify the Rust crate

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -167,6 +167,7 @@ const spec: Spec = {
 
   build: {
     args: [{ name: "release", alias: "r", type: Boolean },
+           { name: "crate", alias: "c", type: String, defaultValue: "native" },
            { name: "path", alias: "p", type: Boolean },
            { name: "modules", type: String, multiple: true, defaultOption: true },
            { name: "help", alias: "h", type: Boolean }],
@@ -185,6 +186,11 @@ const spec: Spec = {
         type: Boolean,
         description: "Release build."
       }, {
+        name: "crate",
+        alias: "c",
+        type: String,
+        description: "Specify the path of the Rust crate."
+      }, {
         name: "path",
         alias: "p",
         type: Boolean,
@@ -197,6 +203,7 @@ const spec: Spec = {
         return;
       }
 
+      const crate = (options.crate || 'native') as string;
       let extra = options.extra as string[];
       let { modules, multiple } = parseModules(this.cwd,
                                                (options.modules || []) as string[],
@@ -205,13 +212,14 @@ const spec: Spec = {
       for (let module of modules) {
         logIf(multiple, "building", this.cwd, module);
 
-        await neon_build(module, this.toolchain, !!options.release, extra);
+        await neon_build(module, this.toolchain, crate, !!options.release, extra);
       }
     }
   },
 
   clean: {
-    args: [{ name: "path", alias: "p", type: Boolean },
+    args: [{ name: "crate", alias: "c", type: String, defaultValue: "native" },
+           { name: "path", alias: "p", type: Boolean },
            { name: "modules", type: String, multiple: true, defaultOption: true },
            { name: "help", alias: "h", type: Boolean }],
     usage: [{
@@ -224,6 +232,11 @@ const spec: Spec = {
     }, {
       header: "Options",
       optionList: [{
+        name: "crate",
+        alias: "c",
+        type: String,
+        description: "Specify the path of the Rust crate."
+      }, {
         name: "path",
         alias: "p",
         type: Boolean,
@@ -236,6 +249,7 @@ const spec: Spec = {
         return;
       }
 
+      const crate = (options.crate || 'native') as string;
       let { modules, multiple } = parseModules(this.cwd,
                                                (options.modules || []) as string[],
                                                !!options.path);
@@ -243,7 +257,7 @@ const spec: Spec = {
       for (let module of modules) {
         logIf(multiple, "cleaning", this.cwd, module);
 
-        await neon_clean(module);
+        await neon_clean(module, crate);
       }
     }
   },

--- a/cli/src/ops/neon_build.ts
+++ b/cli/src/ops/neon_build.ts
@@ -3,8 +3,9 @@ import * as rust from '../rust';
 
 export default async function neon_build(root: string,
                                          toolchain: rust.Toolchain = 'default',
+                                         crate: string = 'native',
                                          release: boolean,
                                          args: string[]) {
-  let project = await Project.create(root);
+  let project = await Project.create(root, {crate});
   await project.build(toolchain, release, args);
 }

--- a/cli/src/ops/neon_clean.ts
+++ b/cli/src/ops/neon_clean.ts
@@ -1,6 +1,6 @@
 import Project from '../project';
 
-export default async function neon_clean(root: string) {
-  let project = await Project.create(root);
+export default async function neon_clean(root: string, crate: string = 'native') {
+  let project = await Project.create(root, {crate});
   await project.clean();
 }


### PR DESCRIPTION
This commit adds a new option to the `build` and `clean` commands: `--crate`. This option allows to manually configure the directory containing the Rust crate.

By default, the CLI always looks into the `native` sub-directory to find the Rust crate. Using this flag, you can easily change this directory. In particular, it allows to place the `Cargo.toml` next to the `package.json` and use `neon build --path . --crate .`.