### PR TITLE
N-API: deprecate PartialEq and add strict_equals method

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -205,6 +205,13 @@ mod napi1 {
             reference: Ref,
             result: *mut Value,
         ) -> Status;
+
+        fn strict_equals(
+            env: Env,
+            lhs: Value,
+            rhs: Value,
+            result: *mut bool
+        ) -> Status;
     });
 }
 

--- a/crates/neon-runtime/src/napi/mem.rs
+++ b/crates/neon-runtime/src/napi/mem.rs
@@ -1,10 +1,6 @@
 use crate::raw::{Env, Local};
 use crate::napi::bindings as napi;
 
-pub unsafe extern "C" fn same_handle(_lhs: Local, _rhs: Local) -> bool {
-    panic!("PartialEq is deprecated with N-API backend");
-}
-
 pub unsafe extern "C" fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
     let mut result = false;
     assert_eq!(napi::strict_equals(env, lhs, rhs, &mut result as *mut _), napi::Status::Ok);

--- a/crates/neon-runtime/src/napi/mem.rs
+++ b/crates/neon-runtime/src/napi/mem.rs
@@ -1,3 +1,12 @@
-use crate::raw::Local;
+use crate::raw::{Env, Local};
+use crate::napi::bindings as napi;
 
-pub unsafe extern "C" fn same_handle(_h1: Local, _h2: Local) -> bool { unimplemented!() }
+pub unsafe extern "C" fn same_handle(_lhs: Local, _rhs: Local) -> bool {
+    panic!("PartialEq is deprecated with N-API backend");
+}
+
+pub unsafe extern "C" fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
+    let mut result = false;
+    assert_eq!(napi::strict_equals(env, lhs, rhs, &mut result as *mut _), napi::Status::Ok);
+    result
+}

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -181,6 +181,12 @@ impl<'a, T: Value> Handle<'a, T> {
         self.downcast(cx).or_throw(cx)
     }
 
+    #[cfg(feature = "napi-1")]
+    pub fn strict_equals<'b, U: Value, C: Context<'b>>(&self, cx: &mut C, other: Handle<'b, U>) -> bool {
+        unsafe {
+            neon_runtime::mem::strict_equals(cx.env().to_raw(), self.to_raw(), other.to_raw())
+        }
+    }
 }
 
 impl<'a, T: Managed> Deref for Handle<'a, T> {

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -35,12 +35,14 @@ pub struct Handle<'a, T: Managed + 'a> {
     phantom: PhantomData<&'a T>
 }
 
+#[cfg(feature = "legacy-runtime")]
 impl<'a, T: Managed + 'a> PartialEq for Handle<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { neon_runtime::mem::same_handle(self.to_raw(), other.to_raw()) }
     }
 }
 
+#[cfg(feature = "legacy-runtime")]
 impl<'a, T: Managed + 'a> Eq for Handle<'a, T> { }
 
 impl<'a, T: Managed + 'a> Handle<'a, T> {

--- a/test/napi/lib/types.js
+++ b/test/napi/lib/types.js
@@ -75,4 +75,14 @@ describe('type checks', function() {
     assert(!addon.is_undefined(null));
     assert(!addon.is_undefined('anything other than undefined'));
   });
+
+  it('strict_equals', function () {
+    assert(addon.strict_equals(17, 17));
+    assert(!addon.strict_equals(17, 18));
+    let o1 = {};
+    let o2 = {};
+    assert(addon.strict_equals(o1, o1));
+    assert(!addon.strict_equals(o1, o2));
+    assert(!addon.strict_equals(o1, 17));
+  });
 });

--- a/test/napi/src/js/types.rs
+++ b/test/napi/src/js/types.rs
@@ -59,3 +59,10 @@ pub fn is_undefined(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let is_string = val.is_a::<JsUndefined, _>(&mut cx);
     Ok(cx.boolean(is_string))
 }
+
+pub fn strict_equals(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let v1: Handle<JsValue> = cx.argument(0)?;
+    let v2: Handle<JsValue> = cx.argument(1)?;
+    let eq = v1.strict_equals(&mut cx, v2);
+    Ok(cx.boolean(eq))
+}

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -159,6 +159,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("is_object", is_object)?;
     cx.export_function("is_string", is_string)?;
     cx.export_function("is_undefined", is_undefined)?;
+    cx.export_function("strict_equals", strict_equals)?;
 
     cx.export_function("new_error", new_error)?;
     cx.export_function("new_type_error", new_type_error)?;


### PR DESCRIPTION
Deprecates `PartialEq` for the N-API backend and adds a `strict_equals` method for handles.