### PR TITLE
Don't assume pointer type in runtime casts

### DIFF
--- a/crates/neon-runtime/src/napi/error.rs
+++ b/crates/neon-runtime/src/napi/error.rs
@@ -94,7 +94,7 @@ pub unsafe fn throw_error_from_utf8(env: Env, msg: *const u8, len: i32) {
     let mut out = MaybeUninit::uninit();
     let status = napi::create_string_utf8(
         env,
-        msg as *const i8,
+        msg as *const _,
         len as usize,
         out.as_mut_ptr(),
     );

--- a/crates/neon-runtime/src/napi/object.rs
+++ b/crates/neon-runtime/src/napi/object.rs
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn get_string(env: Env, out: &mut Local, object: Local, ke
 
     // Not using `crate::string::new()` because it requires a _reference_ to a Local,
     // while we only have uninitialized memory.
-    if napi::create_string_utf8(env, key as *const i8, len as usize, key_val.as_mut_ptr())
+    if napi::create_string_utf8(env, key as *const _, len as usize, key_val.as_mut_ptr())
         != napi::Status::Ok
     {
         return false;
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn set_string(env: Env, out: &mut bool, object: Local, key
 
     *out = true;
 
-    if napi::create_string_utf8(env, key as *const i8, len as usize, key_val.as_mut_ptr())
+    if napi::create_string_utf8(env, key as *const _, len as usize, key_val.as_mut_ptr())
         != napi::Status::Ok
     {
         *out = false;

--- a/crates/neon-runtime/src/napi/string.rs
+++ b/crates/neon-runtime/src/napi/string.rs
@@ -7,7 +7,7 @@ use crate::napi::bindings as napi;
 pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool {
     let status = napi::create_string_utf8(
         env,
-        data as *const i8,
+        data as *const _,
         len as usize,
         out,
     );
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn data(env: Env, out: *mut u8, len: isize, value: Local) 
     let status = napi::get_value_string_utf8(
         env,
         value,
-        out as *mut i8,
+        out as *mut _,
         len as usize,
         read.as_mut_ptr(),
     );


### PR DESCRIPTION
Hi,

While attempting to cross compile a project that uses `neon` to `aarch64-unknown-linux-gnu`, I got a number of pointer casting type errors while building:
```
error[E0308]: mismatched types
  --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/neon-runtime-0.7.0/src/napi/error.rs:97:9
   |
97 |         msg as *const i8,
   |         ^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*const i8`
```

This PR removes the strongly typed casts in favor of `as *const _` and `*mut _` instead so the correct types are used per arch. To test, please try building a `neon` project with no C dependencies with the following:
```
cargo build  --target aarch64-unknown-linux-gnu 
```

This should work on this branch but fail on `main`.

This is my version and features:
```toml
[dependencies.neon]
version = "0.7.0"
default-features = false
features = ["napi-4", "try-catch-api", "event-queue-api"]
```
