### PR TITLE
CI: Add Windows Arm64 target

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12, 14, 15]
         rust-toolchain: [stable, beta]
         rust-target: [x86_64-pc-windows-msvc, aarch64-pc-windows-msvc]
 
@@ -28,11 +28,11 @@ jobs:
         toolchain: ${{ matrix.rust-toolchain }}
         target: ${{ matrix.rust-target }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - name: Use npm v6
-      if: ${{ matrix.node-version == '15.x' }}
+      if: ${{ matrix.node-version == '15' }}
       run: npm install -g npm@6
     - name: Install libclang
       uses: KyleMayes/install-llvm-action@01144dc97b1e2693196c3056414a44f15180648b

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,8 +16,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
-        rust-toolchain: [stable, beta, nightly]
+        node-version: [12.x, 14.x, 15.x]
+        rust-toolchain: [stable, beta]
+        rust-target: [x86_64-pc-windows-msvc, aarch64-pc-windows-msvc]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +26,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust-toolchain }}
-        target: x86_64-pc-windows-msvc
+        target: ${{ matrix.rust-target }}
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -43,7 +44,7 @@ jobs:
     #   run: npm install -g node-gyp@latest
     - run: npm config set msvs_version 2019
     - name: run cargo test
-      run: cargo test --release
+      run: cargo test --release --target=${{ matrix.rust-target }}
       env:
         LIBCLANG_PATH: ${{ runner.temp }}/llvm/bin
     - name: run CLI test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         target: ${{ matrix.rust-target }}
+        override: true 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
-    fail-fast: false
+      fail-fast: false
       matrix:
         node-version: [12, 14, 15]
         rust-toolchain: [stable, beta]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+    fail-fast: false
       matrix:
         node-version: [12, 14, 15]
         rust-toolchain: [stable, beta]
@@ -27,7 +28,8 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         target: ${{ matrix.rust-target }}
-        override: true 
+        default: true
+        override: true
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
Adds the `aarch64-pc-windows-msvc` target to the build matrix of the Windows job.