### PR TITLE
fix(neon): Do not panic when dropping a Root if the VM has shutdown

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: install g++-4.8
-      run: sudo apt-get install -y g++-4.8
+    - name: install build-essential
+      run: sudo apt-get install -y build-essential
     - name: run cargo test
       run: xvfb-run --auto-servernum cargo test --release -- --nocapture

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -138,8 +138,14 @@ impl EventQueue {
     }
 
     // Monomorphized trampoline funciton for calling the user provided closure
-    fn callback(env: Env, callback: Callback) {
-        callback(env)
+    fn callback(env: Option<Env>, callback: Callback) {
+        if let Some(env) = env {
+            callback(env);
+        } else {
+            crate::context::internal::IS_RUNNING.with(|v| {
+                *v.borrow_mut() = false;
+            });
+        }
     }
 }
 

--- a/src/handle/root.rs
+++ b/src/handle/root.rs
@@ -135,7 +135,11 @@ impl<T> Drop for Root<T> {
         // panic and instead prefer to leak.
         if std::thread::panicking() {
             eprintln!("Warning: neon::sync::Root leaked during a panic");
-        } else {
+            return;
+        }
+
+        // Only panic if the event loop is still running
+        if let Ok(true) = crate::context::internal::IS_RUNNING.try_with(|v| *v.borrow()) {
             panic!("Must call `into_inner` or `drop` on `Root` \
                 https://docs.rs/neon/latest/neon/sync/index.html#drop-safety");
         }


### PR DESCRIPTION
Currently, if a `Root` is inside an `EventQueue` task and the VM is stopped, the user will never have an opportunity to clean up the `Root`. In this case, it's not a leak because the value will be deleted as the VM exits.

This PR introduces a new `IS_RUNNING` thread local value. It is initialized as `true` during module initialization and set to `false` the first time an `EventQueue` callback receives a `None` for `Env`.

If the value is `false`, the `Drop` impl on `Root` will _not_ panic.