### PR TITLE
Add "napi-embedding" feature to allow statically linked N-API symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ napi-3 = ["napi-2", "neon-runtime/napi-3"]
 napi-4 = ["napi-3", "neon-runtime/napi-4"]
 napi-5 = ["napi-4", "neon-runtime/napi-5"]
 napi-6 = ["napi-5", "neon-runtime/napi-6"]
+napi-embedding = [ "neon-runtime/napi-embedding" ]
 napi-latest = ["napi-6"]
 napi-experimental = ["napi-6", "neon-runtime/napi-experimental"]
 

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -12,6 +12,7 @@ cfg-if = "1.0.0"
 libloading = { version = "0.6.5", optional = true }
 neon-sys = { version = "=0.7.1", path = "../neon-sys", optional = true }
 smallvec = "1.4.2"
+paste = "1.0.4"
 
 [dev-dependencies]
 nodejs-sys = "0.7.0" # Not strictly needed; just here for easy manual copying
@@ -25,6 +26,7 @@ napi-4 = ["napi-3"]
 napi-5 = ["napi-4"]
 napi-6 = ["napi-5"]
 napi-experimental = ["napi-6"]
+napi-embedding = [ ]
 docs-only = ["neon-sys/docs-only"]
 
 [package.metadata.docs.rs]

--- a/crates/neon-runtime/src/napi/bindings/mod.rs
+++ b/crates/neon-runtime/src/napi/bindings/mod.rs
@@ -41,7 +41,7 @@ macro_rules! napi_name {
 /// ```
 /// extern "C" {
 ///     fn get_undefined(env: Env, result: *mut Value) -> Status;
-///     /* Additional functions may be included */  
+///     /* Additional functions may be included */
 /// }
 /// ```
 ///
@@ -109,60 +109,68 @@ macro_rules! generate {
     (extern "C" {
         $(fn $name:ident($($param:ident: $ptype:ty$(,)?)*) -> $rtype:ty;)+
     }) => {
-        pub(crate) struct Napi {
-            $(
-                $name: unsafe extern "C" fn(
-                    $($param: $ptype,)*
-                ) -> $rtype,
-            )*
-        }
 
-        #[inline(never)]
-        fn panic_load<T>() -> T {
-            panic!("Must load N-API bindings")
-        }
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "napi-embedding")] {
 
-        static mut NAPI: Napi = {
-            $(
-                unsafe extern "C" fn $name($(_: $ptype,)*) -> $rtype {
-                    panic_load()
+            }
+            else {
+                pub(crate) struct Napi {
+                    $(
+                        $name: unsafe extern "C" fn(
+                            $($param: $ptype,)*
+                        ) -> $rtype,
+                    )*
                 }
-            )*
 
-            Napi {
+                #[inline(never)]
+                fn panic_load<T>() -> T {
+                    panic!("Must load N-API bindings")
+                }
+
+                static mut NAPI: Napi = {
+                    $(
+                        unsafe extern "C" fn $name($(_: $ptype,)*) -> $rtype {
+                            panic_load()
+                        }
+                    )*
+
+                    Napi {
+                        $(
+                            $name,
+                        )*
+                    }
+                };
+
+                pub(crate) unsafe fn load(
+                    host: &libloading::Library,
+                    actual_napi_version: u32,
+                    expected_napi_version: u32,
+                ) -> Result<(), libloading::Error> {
+                    assert!(
+                        actual_napi_version >= expected_napi_version,
+                        "Minimum required N-API version {}, found {}.",
+                        expected_napi_version,
+                        actual_napi_version,
+                    );
+
+                    NAPI = Napi {
+                        $(
+                            $name: *host.get(napi_name!($name).as_bytes())?,
+                        )*
+                    };
+
+                    Ok(())
+                }
+
                 $(
-                    $name,
+                    #[inline]
+                    pub(crate) unsafe fn $name($($param: $ptype,)*) -> $rtype {
+                        (NAPI.$name)($($param,)*)
+                    }
                 )*
             }
-        };
-
-        pub(crate) unsafe fn load(
-            host: &libloading::Library,
-            actual_napi_version: u32,
-            expected_napi_version: u32,
-        ) -> Result<(), libloading::Error> {
-            assert!(
-                actual_napi_version >= expected_napi_version,
-                "Minimum required N-API version {}, found {}.",
-                expected_napi_version,
-                actual_napi_version,
-            );
-
-            NAPI = Napi {
-                $(
-                    $name: *host.get(napi_name!($name).as_bytes())?,
-                )*
-            };
-
-            Ok(())
         }
-
-        $(
-            #[inline]
-            pub(crate) unsafe fn $name($($param: $ptype,)*) -> $rtype {
-                (NAPI.$name)($($param,)*)
-            }
-        )*
     };
 }
 
@@ -174,12 +182,14 @@ pub(crate) use types::*;
 mod types;
 mod functions;
 
-static SETUP: Once = Once::new();
-
 /// Loads N-API symbols from host process.
 /// Must be called at least once before using any functions in `neon-runtime` or
 /// they will panic.
 /// Safety: `env` must be a valid `napi_env` for the current thread
 pub unsafe fn setup(env: Env) {
-    SETUP.call_once(|| load(env).expect("Failed to load N-API symbols"));
+    #[cfg(not(feature = "napi-embedding"))]
+    {
+        static SETUP: Once = Once::new();
+        SETUP.call_once(|| load(env).expect("Failed to load N-API symbols"));
+    }
 }


### PR DESCRIPTION
This PR adds a new feature `napi-embedding`. When enabled, it loads N-API symbols using `extern "C" { ... }` declarations instead of `libloading`.

## Why?

I am working on [rust-nodejs](https://github.com/patr0nus/rust-nodejs) which embeds Node.js in Rust. The general idea is to build and link Node.js as a static library, and use N-API to communicate between Rust and Node.js.

Neon fits perfectly for the latter part, expect that it tries to load N-API symbols dynamically (https://github.com/neon-bindings/neon/pull/646). This doesn't work in the case of rust-nodejs, because all N-API symbols are statically linked.

