### PR TITLE
Global drop queue for Root

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -257,6 +257,7 @@ mod napi5 {
 #[cfg(feature = "napi-6")]
 mod napi6 {
     use super::super::types::*;
+    use std::os::raw::c_void;
 
     generate!(
         extern "C" {
@@ -268,6 +269,15 @@ mod napi6 {
                 key_conversion: KeyConversion,
                 result: *mut Value,
             ) -> Status;
+
+            fn set_instance_data(
+                env: Env,
+                data: *mut c_void,
+                finalize_cb: Finalize,
+                finalize_hint: *mut c_void,
+            ) -> Status;
+
+            fn get_instance_data(env: Env, data: *mut *mut c_void) -> Status;
         }
     );
 }

--- a/crates/neon-runtime/src/napi/lifecycle.rs
+++ b/crates/neon-runtime/src/napi/lifecycle.rs
@@ -1,0 +1,39 @@
+use std::mem::MaybeUninit;
+use std::os::raw::c_void;
+use std::ptr;
+
+use crate::napi::bindings as napi;
+use crate::raw::Env;
+
+/// # Safety
+/// `env` must point to a valid `napi_env` for this thread
+pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T {
+    let data = Box::into_raw(Box::new(data));
+
+    assert_eq!(
+        napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut(),),
+        napi::Status::Ok,
+    );
+
+    data
+}
+
+/// # Safety
+/// * `T` must be the same type used in `set_instance_data`
+/// * Caller must ensure reference does not outlive `Env`
+/// * Return value may be `null`
+/// * `env` must point to a valid `napi_env` for this thread
+pub unsafe fn get_instance_data<T: Send + 'static>(env: Env) -> *mut T {
+    let mut data = MaybeUninit::uninit();
+
+    assert_eq!(
+        napi::get_instance_data(env, data.as_mut_ptr(),),
+        napi::Status::Ok,
+    );
+
+    data.assume_init().cast()
+}
+
+unsafe extern "C" fn drop_box<T>(_env: Env, data: *mut c_void, _hint: *mut c_void) {
+    Box::<T>::from_raw(data.cast());
+}

--- a/crates/neon-runtime/src/napi/lifecycle.rs
+++ b/crates/neon-runtime/src/napi/lifecycle.rs
@@ -1,3 +1,13 @@
+//! # Environment life cycle APIs
+//!
+//! These APIs map to the life cycle of a specific "Agent" or self-contained
+//! environment. If a Neon module is loaded multiple times (Web Workers, worker
+//! threads), these API will be handle data associated with a specific instance.
+//!
+//! See the [N-API Lifecycle][npai-docs] documentation for more details.
+//!
+//! [napi-docs]: https://nodejs.org/api/n-api.html#n_api_environment_life_cycle_apis
+
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 use std::ptr;

--- a/crates/neon-runtime/src/napi/mod.rs
+++ b/crates/neon-runtime/src/napi/mod.rs
@@ -8,6 +8,8 @@ pub mod date;
 pub mod error;
 pub mod external;
 pub mod fun;
+#[cfg(feature = "napi-6")]
+pub mod lifecycle;
 pub mod mem;
 pub mod object;
 pub mod primitive;

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod internal;
 
 #[cfg(feature = "napi-1")]
-mod root;
+pub(crate) mod root;
 
 #[cfg(feature = "napi-1")]
 pub use self::root::Root;

--- a/src/handle/root.rs
+++ b/src/handle/root.rs
@@ -3,23 +3,33 @@ use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 
 use neon_runtime::reference;
+#[cfg(feature = "napi-6")]
+use neon_runtime::tsfn::ThreadsafeFunction;
 
 use context::Context;
 use handle::Handle;
+#[cfg(feature = "napi-6")]
+use lifecycle::InstanceData;
 use object::Object;
 use types::boxed::Finalize;
 
 #[repr(transparent)]
 #[derive(Clone)]
-struct NapiRef(*mut c_void);
+pub(crate) struct NapiRef(*mut c_void);
+
+// # Safety
+// `NapiRef` are intended to be `Send` and `Sync`
+unsafe impl Send for NapiRef {}
+unsafe impl Sync for NapiRef {}
 
 /// `Root<T>` holds a reference to a `JavaScript` object and prevents it from
 /// being garbage collected. `Root<T>` may be sent across threads, but the
 /// referenced objected may only be accessed on the JavaScript thread that
 /// created it.
-#[repr(transparent)]
 pub struct Root<T> {
     internal: NapiRef,
+    #[cfg(feature = "napi-6")]
+    drop_queue: &'static ThreadsafeFunction<NapiRef>,
     _phantom: PhantomData<T>,
 }
 
@@ -40,15 +50,19 @@ impl<T: Object> Root<T> {
     /// garbage collected until the `Root` is dropped. A `Root<T>` may only
     /// be dropped on the JavaScript thread that created it.
     ///
-    /// The caller _must_ ensure `Root::into_inner` or `Root::drop` is called
+    /// The caller _should_ ensure `Root::into_inner` or `Root::drop` is called
     /// to properly dispose of the `Root<T>`. If the value is dropped without
-    /// calling one of these methods, it will *panic*.
+    /// calling one of these methods:
+    /// * N-API < 6, Neon will `panic` to notify of the leak
+    /// * N-API >= 6, Neon will drop from a global queue at a runtime cost
     pub fn new<'a, C: Context<'a>>(cx: &mut C, value: &T) -> Self {
         let env = cx.env().to_raw();
         let internal = unsafe { reference::new(env, value.to_raw()) };
 
         Self {
             internal: NapiRef(internal as *mut _),
+            #[cfg(feature = "napi-6")]
+            drop_queue: InstanceData::drop_queue(cx),
             _phantom: PhantomData,
         }
     }
@@ -75,6 +89,8 @@ impl<T: Object> Root<T> {
 
         Self {
             internal: self.internal.clone(),
+            #[cfg(feature = "napi-6")]
+            drop_queue: self.drop_queue,
             _phantom: PhantomData,
         }
     }
@@ -124,6 +140,7 @@ impl<T: Object> Finalize for Root<T> {
 }
 
 impl<T> Drop for Root<T> {
+    #[cfg(not(feature = "napi-6"))]
     fn drop(&mut self) {
         // Destructors are called during stack unwinding, prevent a double
         // panic and instead prefer to leak.
@@ -139,5 +156,10 @@ impl<T> Drop for Root<T> {
                 https://docs.rs/neon/latest/neon/sync/index.html#drop-safety"
             );
         }
+    }
+
+    #[cfg(feature = "napi-6")]
+    fn drop(&mut self) {
+        let _ = self.drop_queue.call(self.internal.clone(), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ pub mod macro_internal;
 #[cfg(feature = "proc-macros")]
 pub use neon_macros::*;
 
+#[cfg(feature = "napi-6")]
+mod lifecycle;
+
 #[cfg(all(feature = "legacy-runtime", feature = "napi-1"))]
 compile_error!("Cannot enable both `legacy-runtime` and `napi-*` features.\n\nTo use `napi-*`, disable `legacy-runtime` by setting `default-features` to `false` in Cargo.toml\nor with cargo's --no-default-features flag.");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod handle;
 pub mod meta;
 pub mod object;
 pub mod prelude;
+#[cfg(feature = "napi-1")]
 pub mod reflect;
 pub mod result;
 #[cfg(feature = "legacy-runtime")]

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -1,0 +1,50 @@
+use std::mem;
+
+use neon_runtime::raw::Env;
+use neon_runtime::reference;
+use neon_runtime::tsfn::ThreadsafeFunction;
+
+use crate::context::Context;
+use crate::handle::root::NapiRef;
+
+pub(crate) struct InstanceData {
+    drop_queue: &'static ThreadsafeFunction<NapiRef>,
+}
+
+fn drop_napi_ref(env: Option<Env>, data: NapiRef) {
+    if let Some(env) = env {
+        unsafe {
+            reference::unreference(env, mem::transmute(data));
+        }
+    }
+}
+
+impl InstanceData {
+    pub(crate) fn get<'a, C: Context<'a>>(cx: &mut C) -> &'a mut InstanceData {
+        let env = cx.env().to_raw();
+        let data =
+            unsafe { neon_runtime::lifecycle::get_instance_data::<InstanceData>(env).as_mut() };
+
+        if let Some(data) = data {
+            return data;
+        }
+
+        let drop_queue = Box::new(unsafe {
+            let mut queue = ThreadsafeFunction::new(env, drop_napi_ref);
+            queue.unref(env);
+            queue
+        });
+
+        let data = InstanceData {
+            drop_queue: Box::leak(drop_queue),
+        };
+
+        unsafe { &mut *neon_runtime::lifecycle::set_instance_data(env, data) }
+    }
+
+    pub(crate) fn drop_queue<'a, C: Context<'a>>(
+        cx: &mut C,
+    ) -> &'static ThreadsafeFunction<NapiRef> {
+        &InstanceData::get(cx).drop_queue
+    }
+}

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -3,7 +3,6 @@ use handle::{Handle, Managed};
 use result::JsResult;
 use types::{build, JsString, JsValue};
 
-#[cfg(feature = "napi-1")]
 pub fn eval<'a, 'b, C: Context<'a>>(
     cx: &mut C,
     script: Handle<'b, JsString>,

--- a/src/types/boxed.rs
+++ b/src/types/boxed.rs
@@ -7,6 +7,7 @@ use neon_runtime::raw;
 use crate::context::internal::Env;
 use crate::context::{Context, FinalizeContext};
 use crate::handle::{Handle, Managed};
+use crate::object::Object;
 use crate::types::internal::ValueInternal;
 use crate::types::Value;
 
@@ -158,6 +159,8 @@ impl<T: Send + 'static> Clone for JsBox<T> {
         }
     }
 }
+
+impl<T: Send + 'static> Object for JsBox<T> {}
 
 impl<T: Send + 'static> Copy for JsBox<T> {}
 

--- a/test/napi/lib/threads.js
+++ b/test/napi/lib/threads.js
@@ -64,4 +64,11 @@ const assert = require('chai').assert;
     // If the EventQueue is not unreferenced, the test runner will not cleanly exit
     addon.leak_event_queue();
   });
+
+  it('should drop leaked Root from the global queue', function (cb) {
+    addon.drop_global_queue(cb);
+
+    // Asynchronously GC to give the task queue a chance to execute
+    setTimeout(() => global.gc(), 10);
+  });
 });

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -256,6 +256,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("greeter_new", greeter_new)?;
     cx.export_function("greeter_greet", greeter_greet)?;
     cx.export_function("leak_event_queue", leak_event_queue)?;
+    cx.export_function("drop_global_queue", drop_global_queue)?;
 
     Ok(())
 }


### PR DESCRIPTION
# Why

Currently, dropping a `Root` will cause a `panic` instead of leaking the data. This can be problematic for users since there are _many_ ways to accidentally leak a `Root`. Consider the following example:

* A channel accepts closures to execute
* A `Root` is created and captured by a closure
* The closure is sent across the channel
* The channel is closed

In this case, even though the user _knows_ the `Root` won't be used, there's no easy way to get it back out to safely drop it.

# What

This feature is flagged with `napi-6`. The existing `panic` behavior continues for older versions.

## `InstanceData`

A private `InstanceData` type is added that uses `napi_get_instance_data` and `napi_set_instance_data`. This provides a place to stash module specific context for Neon.

## Global drop queue

A global drop queue is added as a `ThreadsafeFunction`.

* `ThreadsafeFunction` is used instead of `EventQueue` since we only need a static callback. Closures would require unnecessary overhead.
* `ThreadsafeFunction` is maintained in an `Arc` to ensure it can outlive an unloaded module
* The queue is unreferenced to prevent it from keeping the event loop running. Hanging references will be freed when the VM drops.

## Additional

Added `impl Object for JsBox` that was missing.

## Testing

It was really fun finding a creative way to test this behavior!

* Create a `struct Wrapper` for holding a callback and an event queue
* The wrapper is put in a `JsBox` which is then rooted and immediately leaked (dropped)
* Instead of an idiomatic `Finalize` implementation, `Wrapper` has a `Drop` implementation that calls the callback. If this is called, we know that the `Root` reference count was dropped, allowing our struct to be dropped.
* We force run the garbage collector after giving the drop queue an opportunity to execute