### PR TITLE
Fix build with node 16

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         rust-toolchain: [stable, beta, nightly]
 
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         rust-toolchain: [stable, beta, nightly]
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         rust-toolchain: [stable, beta, nightly]
 
     steps:
@@ -31,7 +31,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Use npm v6
-      if: ${{ matrix.node-version == '15.x' }}
+      if: ${{ matrix.node-version == '16.x' }}
       run: npm install -g npm@6
     - name: Install libclang
       uses: KyleMayes/install-llvm-action@01144dc97b1e2693196c3056414a44f15180648b

--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -205,6 +205,14 @@ mod build {
             .output()
             .expect("Failed to run \"node-gyp build\" for neon-sys!");
 
+        if !build_output.status.success() {
+            panic!(
+                "Failed to run \"node-gyp build\" for neon-sys!\n Out: {}\n Err: {}",
+                String::from_utf8_lossy(&build_output.stdout),
+                String::from_utf8_lossy(&build_output.stderr)
+            );
+        }
+
         let node_gyp_build_output = String::from_utf8_lossy(&build_output.stderr);
         println!(
             "cargo:node_arch={}",

--- a/crates/neon-sys/native/src/neon.cc
+++ b/crates/neon-sys/native/src/neon.cc
@@ -332,7 +332,7 @@ extern "C" void Neon_Class_SetClassMap(v8::Isolate *isolate, void *map, Neon_Dro
   neon::ClassMapHolder *holder = new neon::ClassMapHolder(map, drop_map);
   isolate->SetData(NEON_ISOLATE_SLOT, holder);
   // ISSUE(#77): When workers land in node, this will need to be generalized to a per-worker version.
-  node::AtExit(cleanup_class_map, holder);
+  node::AtExit(node::GetCurrentEnvironment(isolate->GetCurrentContext()), cleanup_class_map, holder);
 }
 
 extern "C" void *Neon_Class_GetCallKernel(void *wrapper) {


### PR DESCRIPTION
After archlinux upgraded to the newer version of node, neon-sys stoped building with this error:

```
warning: ar: target/debug/build/neon-sys-e960e2d326235d28/out/native/build/Debug/obj.target/neon/src/neon.o: No such file or directory
error: failed to run custom build command for `neon-sys v0.8.0`
```
After investigation, the real error is: (this PR also make sure to print compilation errors, if any)
```
../src/neon.cc: In function 'void Neon_Class_SetClassMap(v8::Isolate*, void*, Neon_DropCallback)':
  ../src/neon.cc:335:16: error: cannot convert 'void (*)(void*)' to 'node::Environment*'
    335 |   node::AtExit(cleanup_class_map, holder);
        |                ^~~~~~~~~~~~~~~~~
        |                |
        |                void (*)(void*)
```

It turns out that the overload taking 2 arguments was removed in the latest version of node: https://github.com/nodejs/node/commit/dfc288e7fdbe888f4e134772de421684247f0bea#diff-4acdf5a5c11188763423b746a9a43917c90546f3b48b9aa6f6eeb60e157ae2a7

This PR calls the remaining overload which have been there before.

I'd appreciate a release on crates.io with this change, thanks!
