### PR TITLE
Rename `EventQueue` to `Channel`

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -152,7 +152,7 @@ use crate::borrow::internal::Ledger;
 use crate::borrow::{Borrow, BorrowMut, Ref, RefMut};
 use crate::context::internal::Env;
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-use crate::event::EventQueue;
+use crate::event::Channel;
 use crate::handle::{Handle, Managed};
 #[cfg(feature = "legacy-runtime")]
 use crate::object::class::Class;
@@ -550,9 +550,19 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-    /// Creates an unbounded queue of events to be executed on a JavaScript thread
-    fn queue(&mut self) -> EventQueue {
-        EventQueue::new(self)
+    /// Creates an unbounded channel for scheduling events to be executed on the JavaScript thread.
+    fn channel(&mut self) -> Channel {
+        Channel::new(self)
+    }
+
+    #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+    #[deprecated(
+        since = "0.9.0",
+        note = "Please use the channel() method instead"
+    )]
+    #[doc(hidden)]
+    fn queue(&mut self) -> Channel {
+        self.channel()
     }
 }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -556,10 +556,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-    #[deprecated(
-        since = "0.9.0",
-        note = "Please use the channel() method instead"
-    )]
+    #[deprecated(since = "0.9.0", note = "Please use the channel() method instead")]
     #[doc(hidden)]
     fn queue(&mut self) -> Channel {
         self.channel()

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -127,7 +127,23 @@
 mod event_queue;
 
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-pub use self::event_queue::{EventQueue, EventQueueError};
+pub use self::event_queue::{Channel, SendError};
+
+#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[deprecated(
+    since = "0.9.0",
+    note = "Please use the Channel type instead"
+)]
+#[doc(hidden)]
+pub type EventQueue = self::event_queue::Channel;
+
+#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[deprecated(
+    since = "0.9.0",
+    note = "Please use the SendError type instead"
+)]
+#[doc(hidden)]
+pub type EventQueueError = self::event_queue::SendError;
 
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 mod event_handler;
@@ -138,5 +154,5 @@ pub use self::event_handler::EventHandler;
 #[cfg(all(feature = "napi-1", feature = "event-handler-api"))]
 compile_error!(
     "The `EventHandler` API is not supported with the N-API \
-    backend. Use `EventQueue` instead."
+    backend. Use `Channel` instead."
 );

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -32,20 +32,20 @@
 //! # #[cfg(feature = "napi-1")] {
 //! # use neon::prelude::*;
 //! #
-//! # fn parse(filename: String, callback: Root<JsFunction>, queue: EventQueue) { }
+//! # fn parse(filename: String, callback: Root<JsFunction>, channel: Channel) { }
 //! #
 //! fn parse_async(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-//!     // The types `String`, `Root<JsFunction>`, and `EventQueue` can all be
+//!     // The types `String`, `Root<JsFunction>`, and `Channel` can all be
 //!     // sent across threads.
 //!     let filename = cx.argument::<JsString>(0)?.value(&mut cx);
 //!     let callback = cx.argument::<JsFunction>(1)?.root(&mut cx);
-//!     let queue = cx.queue();
+//!     let channel = cx.channel();
 //!
-//!     // Spawn a thread to complete the execution. This will _not_ block the
-//!     // JavaScript event loop.
+//!     // Spawn a background thread to complete the execution. The background
+//!     // execution will _not_ block the JavaScript event loop.
 //!     std::thread::spawn(move || {
 //!         // Do the heavy lifting inside the background thread.
-//!         parse(filename, callback, queue);
+//!         parse(filename, callback, channel);
 //!     });
 //!
 //!     Ok(cx.undefined())
@@ -58,7 +58,7 @@
 //! thread.)
 //!
 //! Upon completion of its task, the background thread can use the JavaScript
-//! callback and the event queue to notify the main thread of the result:
+//! callback and the channel to notify the main thread of the result:
 //!
 //! ```
 //! # #[cfg(feature = "napi-1")] {
@@ -70,12 +70,12 @@
 //!     Psd::from_bytes(&std::fs::read(&filename)?)
 //! }
 //!
-//! fn parse(filename: String, callback: Root<JsFunction>, queue: EventQueue) {
+//! fn parse(filename: String, callback: Root<JsFunction>, channel: Channel) {
 //!     let result = psd_from_filename(filename);
 //!
 //!     // Send a closure as a task to be executed by the JavaScript event
-//!     // queue. This _will_ block the event queue while executing.
-//!     queue.send(move |mut cx| {
+//!     // loop. This _will_ block the event loop while executing.
+//!     channel.send(move |mut cx| {
 //!         let callback = callback.into_inner(&mut cx);
 //!         let this = cx.undefined();
 //!         let null = cx.null();

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -130,18 +130,12 @@ mod event_queue;
 pub use self::event_queue::{Channel, SendError};
 
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-#[deprecated(
-    since = "0.9.0",
-    note = "Please use the Channel type instead"
-)]
+#[deprecated(since = "0.9.0", note = "Please use the Channel type instead")]
 #[doc(hidden)]
 pub type EventQueue = self::event_queue::Channel;
 
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-#[deprecated(
-    since = "0.9.0",
-    note = "Please use the SendError type instead"
-)]
+#[deprecated(since = "0.9.0", note = "Please use the SendError type instead")]
 #[doc(hidden)]
 pub type EventQueueError = self::event_queue::SendError;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::declare_types;
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 pub use crate::event::EventHandler;
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-pub use crate::event::{EventQueue, EventQueueError};
+pub use crate::event::{Channel, SendError};
 pub use crate::handle::Handle;
 #[cfg(feature = "legacy-runtime")]
 pub use crate::object::Class;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,6 +11,9 @@ pub use crate::declare_types;
 pub use crate::event::EventHandler;
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
 pub use crate::event::{Channel, SendError};
+#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[allow(deprecated)]
+pub use crate::event::{EventQueue, EventQueueError};
 pub use crate::handle::Handle;
 #[cfg(feature = "legacy-runtime")]
 pub use crate::object::Class;

--- a/test/napi/lib/threads.js
+++ b/test/napi/lib/threads.js
@@ -6,7 +6,7 @@ const assert = require('chai').assert;
   return typeof global.gc === 'function' ? describe : describe.skip;
 })()('sync', function() {
   afterEach(() => {
-    // Force garbage collection to shutdown `EventQueue`
+    // Force garbage collection to shutdown `Channel`
     global.gc();
   });
 
@@ -60,9 +60,9 @@ const assert = require('chai').assert;
     global.gc();
   });
 
-  it('should be able to unref event queue', function () {
-    // If the EventQueue is not unreferenced, the test runner will not cleanly exit
-    addon.leak_event_queue();
+  it('should be able to unref channel', function () {
+    // If the Channel is not unreferenced, the test runner will not cleanly exit
+    addon.leak_channel();
   });
 
   it('should drop leaked Root from the global queue', function (cb) {

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -255,7 +255,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("multi_threaded_callback", multi_threaded_callback)?;
     cx.export_function("greeter_new", greeter_new)?;
     cx.export_function("greeter_greet", greeter_greet)?;
-    cx.export_function("leak_event_queue", leak_event_queue)?;
+    cx.export_function("leak_channel", leak_channel)?;
     cx.export_function("drop_global_queue", drop_global_queue)?;
 
     Ok(())


### PR DESCRIPTION
This PR experiments with renaming the event queue API:

- `neon::event::EventQueue` -> `neon::event::Channel`
- `neon::event::EventQueueError` -> `neon::event::SendError`

This is based on an insight @kjvalencik made recently: a clone/copy/sync-able data structure that gives access across multiple threads to the Node.js runtime's internal event queue by a `send` operation that communicates across threads is much closer conceptually to Rust's idiomatic concept of channels than it is to being an abstraction of the JS event queue itself.

The PR attempts to make the change conservatively, preserving the previous names as aliases for the new names but adding deprecation attributes and hiding them from API docs. This allows us to ship the new name without breaking existing customers and eventually remove the deprecated names in a future release.

Here's a [preview of updated `neon::event` docs with code examples](https://neon-event-apidocs.surge.sh/neon/event/index.html) where you can see how the code looks with the renamed API.