### PR TITLE
Reuse ThreadsafeFunction in EventQueue

### DIFF
--- a/crates/neon-runtime/src/napi/tsfn.rs
+++ b/crates/neon-runtime/src/napi/tsfn.rs
@@ -153,20 +153,26 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
 
     /// References a threadsafe function to prevent exiting the event loop until it has been dropped. (Default)
     /// Safety: `Env` must be valid for the current thread
-    pub unsafe fn reference(&mut self, env: Env) {
-        assert_eq!(
-            napi::ref_threadsafe_function(env, self.tsfn.0,),
-            napi::Status::Ok,
-        );
+    pub unsafe fn reference(&mut self, env: Env) -> Result<(), napi::Status> {
+        let status = napi::ref_threadsafe_function(env, self.tsfn.0);
+
+        if status == napi::Status::Ok {
+            Ok(())
+        } else {
+            Err(status)
+        }
     }
 
     /// Unreferences a threadsafe function to allow exiting the event loop before it has been dropped.
     /// Safety: `Env` must be valid for the current thread
-    pub unsafe fn unref(&mut self, env: Env) {
-        assert_eq!(
-            napi::unref_threadsafe_function(env, self.tsfn.0,),
-            napi::Status::Ok,
-        );
+    pub unsafe fn unref(&mut self, env: Env) -> Result<(), napi::Status> {
+        let status = napi::unref_threadsafe_function(env, self.tsfn.0);
+
+        if status == napi::Status::Ok {
+            Ok(())
+        } else {
+            Err(status)
+        }
     }
 
     // Provides a C ABI wrapper for a napi callback notifying us about tsfn

--- a/crates/neon-runtime/src/napi/tsfn.rs
+++ b/crates/neon-runtime/src/napi/tsfn.rs
@@ -156,7 +156,7 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     pub unsafe fn reference(&self, env: Env) {
         assert_eq!(
             napi::ref_threadsafe_function(env, self.tsfn.0),
-            napi::Status::Ok
+            napi::Status::Ok,
         );
     }
 
@@ -165,7 +165,7 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     pub unsafe fn unref(&self, env: Env) {
         assert_eq!(
             napi::unref_threadsafe_function(env, self.tsfn.0),
-            napi::Status::Ok
+            napi::Status::Ok,
         );
     }
 

--- a/crates/neon-runtime/src/napi/tsfn.rs
+++ b/crates/neon-runtime/src/napi/tsfn.rs
@@ -155,7 +155,7 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     /// Safety: `Env` must be valid for the current thread
     pub unsafe fn reference(&self, env: Env) {
         assert_eq!(
-            napi::ref_threadsafe_function(env, self.tsfn.0),
+            napi::ref_threadsafe_function(env, self.tsfn.0,),
             napi::Status::Ok,
         );
     }
@@ -164,7 +164,7 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     /// Safety: `Env` must be valid for the current thread
     pub unsafe fn unref(&self, env: Env) {
         assert_eq!(
-            napi::unref_threadsafe_function(env, self.tsfn.0),
+            napi::unref_threadsafe_function(env, self.tsfn.0,),
             napi::Status::Ok,
         );
     }

--- a/crates/neon-runtime/src/napi/tsfn.rs
+++ b/crates/neon-runtime/src/napi/tsfn.rs
@@ -153,26 +153,20 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
 
     /// References a threadsafe function to prevent exiting the event loop until it has been dropped. (Default)
     /// Safety: `Env` must be valid for the current thread
-    pub unsafe fn reference(&mut self, env: Env) -> Result<(), napi::Status> {
-        let status = napi::ref_threadsafe_function(env, self.tsfn.0);
-
-        if status == napi::Status::Ok {
-            Ok(())
-        } else {
-            Err(status)
-        }
+    pub unsafe fn reference(&self, env: Env) {
+        assert_eq!(
+            napi::ref_threadsafe_function(env, self.tsfn.0),
+            napi::Status::Ok
+        );
     }
 
     /// Unreferences a threadsafe function to allow exiting the event loop before it has been dropped.
     /// Safety: `Env` must be valid for the current thread
-    pub unsafe fn unref(&mut self, env: Env) -> Result<(), napi::Status> {
-        let status = napi::unref_threadsafe_function(env, self.tsfn.0);
-
-        if status == napi::Status::Ok {
-            Ok(())
-        } else {
-            Err(status)
-        }
+    pub unsafe fn unref(&self, env: Env) {
+        assert_eq!(
+            napi::unref_threadsafe_function(env, self.tsfn.0),
+            napi::Status::Ok
+        );
     }
 
     // Provides a C ABI wrapper for a napi callback notifying us about tsfn

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -154,6 +154,8 @@ use crate::context::internal::Env;
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
 use crate::event::Channel;
 use crate::handle::{Handle, Managed};
+#[cfg(feature = "napi-6")]
+use crate::lifecycle::InstanceData;
 #[cfg(feature = "legacy-runtime")]
 use crate::object::class::Class;
 use crate::object::{Object, This};
@@ -551,8 +553,17 @@ pub trait Context<'a>: ContextInternal<'a> {
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
     /// Creates an unbounded channel for scheduling events to be executed on the JavaScript thread.
+    ///
+    /// When using N-API >= 6,the channel returned by this method is backed by a shared queue.
+    /// To create a channel backed by a _new_ queue see [`Channel`](crate::event::Channel).
     fn channel(&mut self) -> Channel {
-        Channel::new(self)
+        #[cfg(feature = "napi-6")]
+        let channel = InstanceData::channel(self);
+
+        #[cfg(not(feature = "napi-6"))]
+        let channel = Channel::new(self);
+
+        channel
     }
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -154,7 +154,7 @@ use crate::context::internal::Env;
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
 use crate::event::Channel;
 use crate::handle::{Handle, Managed};
-#[cfg(feature = "napi-6")]
+#[cfg(all(feature = "napi-6", feature = "event-queue-api"))]
 use crate::lifecycle::InstanceData;
 #[cfg(feature = "legacy-runtime")]
 use crate::object::class::Class;
@@ -552,7 +552,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-    /// Creates an unbounded channel for scheduling events to be executed on the JavaScript thread.
+    /// Clones a shared unbounded channel for scheduling events to be executed on the JavaScript thread.
     ///
     /// When using N-API >= 6,the channel returned by this method is backed by a shared queue.
     /// To create a channel backed by a _new_ queue see [`Channel`](crate::event::Channel).

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -552,7 +552,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-    /// Clones a shared unbounded channel for scheduling events to be executed on the JavaScript thread.
+    /// Returns an unbounded channel for scheduling events to be executed on the JavaScript thread.
     ///
     /// When using N-API >= 6,the channel returned by this method is backed by a shared queue.
     /// To create a channel backed by a _new_ queue see [`Channel`](crate::event::Channel).

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -170,15 +170,15 @@ impl Clone for Channel {
 
 impl Drop for Channel {
     fn drop(&mut self) {
+        // Not a referenced event queue
+        if !self.has_ref {
+            return;
+        }
+
         // It was only us who kept the `ChannelState` alive. No need to unref
         // the `tsfn`, because it is going to be dropped once this function
         // returns.
         if Arc::strong_count(&self.state) == 1 {
-            return;
-        }
-
-        // Not a referenced event queue
-        if !self.has_ref {
             return;
         }
 

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -56,9 +56,6 @@ type Callback = Box<dyn FnOnce(Env) + Send + 'static>;
 /// ```
 
 pub struct Channel {
-    // We hold an extra reference to `state` in `try_send` so that we could
-    // unref the tsfn during the same UV tick if the state is guaranteed to be
-    // dropped before the `try_send`'s closure invocation.
     state: Arc<ChannelState>,
     has_ref: bool,
 }

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -180,7 +180,7 @@ struct ChannelState {
 }
 
 impl ChannelState {
-    fn reference<'a, C: Context<'a>>(self: &Self, cx: &mut C) {
+    fn reference<'a, C: Context<'a>>(&self, cx: &mut C) {
         // Already referenced
         if self.has_ref.swap(true, Ordering::Relaxed) {
             return;
@@ -189,7 +189,7 @@ impl ChannelState {
         self.shared.reference(cx);
     }
 
-    fn unref<'a, C: Context<'a>>(self: &Self, cx: &mut C) {
+    fn unref<'a, C: Context<'a>>(&self, cx: &mut C) {
         // Already unreferenced
         if !self.has_ref.swap(false, Ordering::Relaxed) {
             return;
@@ -273,7 +273,7 @@ impl ChannelSharedState {
         }
     }
 
-    fn reference<'a, C: Context<'a>>(self: &Self, cx: &mut C) {
+    fn reference<'a, C: Context<'a>>(&self, cx: &mut C) {
         if self.ref_count.fetch_add(1, Ordering::Relaxed) != 0 {
             return;
         }
@@ -286,7 +286,7 @@ impl ChannelSharedState {
         .unwrap();
     }
 
-    fn unref<'a, C: Context<'a>>(self: &Self, cx: &mut C) {
+    fn unref<'a, C: Context<'a>>(&self, cx: &mut C) {
         if self.ref_count.fetch_sub(1, Ordering::Relaxed) != 1 {
             return;
         }

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -232,6 +232,8 @@ impl ChannelState {
     }
 
     fn reference<'a, C: Context<'a>>(&self, cx: &mut C) {
+        // We can use relaxed ordering because `reference()` can only be called
+        // on the Event-Loop thread.
         if self.ref_count.fetch_add(1, Ordering::Relaxed) != 0 {
             return;
         }
@@ -242,6 +244,8 @@ impl ChannelState {
     }
 
     fn unref<'a, C: Context<'a>>(&self, cx: &mut C) {
+        // We can use relaxed ordering because `unref()` can only be called
+        // on the Event-Loop thread.
         if self.ref_count.fetch_sub(1, Ordering::Relaxed) != 1 {
             return;
         }

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -16,6 +16,7 @@ use neon_runtime::reference;
 use neon_runtime::tsfn::ThreadsafeFunction;
 
 use crate::context::Context;
+use crate::event::Channel;
 use crate::handle::root::NapiRef;
 
 /// `InstanceData` holds Neon data associated with a particular instance of a
@@ -30,6 +31,9 @@ pub(crate) struct InstanceData {
     /// given the cost of FFI, this optimization is omitted until the cost of an
     /// `Arc` is demonstrated as significant.
     drop_queue: Arc<ThreadsafeFunction<NapiRef>>,
+
+    /// Shared `Channel` that is cloned to be returned by the `cx.channel()` method
+    shared_channel: Channel,
 }
 
 fn drop_napi_ref(env: Option<Env>, data: NapiRef) {
@@ -58,12 +62,19 @@ impl InstanceData {
 
         let drop_queue = unsafe {
             let mut queue = ThreadsafeFunction::new(env, drop_napi_ref);
-            queue.unref(env);
+            queue.unref(env).unwrap();
             queue
+        };
+
+        let shared_channel = {
+            let mut channel = Channel::new(cx);
+            channel.unref(cx);
+            channel
         };
 
         let data = InstanceData {
             drop_queue: Arc::new(drop_queue),
+            shared_channel,
         };
 
         unsafe { &mut *neon_runtime::lifecycle::set_instance_data(env, data) }
@@ -72,5 +83,13 @@ impl InstanceData {
     /// Helper to return a reference to the `drop_queue` field of `InstanceData`
     pub(crate) fn drop_queue<'a, C: Context<'a>>(cx: &mut C) -> Arc<ThreadsafeFunction<NapiRef>> {
         Arc::clone(&InstanceData::get(cx).drop_queue)
+    }
+
+    /// Clones the shared channel and references it since new channels should start
+    /// referenced, but the shared channel is unreferenced.
+    pub(crate) fn channel<'a, C: Context<'a>>(cx: &mut C) -> Channel {
+        let mut channel = InstanceData::get(cx).shared_channel.clone();
+        channel.reference(cx);
+        channel
     }
 }

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -63,8 +63,8 @@ impl InstanceData {
         }
 
         let drop_queue = unsafe {
-            let mut queue = ThreadsafeFunction::new(env, drop_napi_ref);
-            queue.unref(env).unwrap();
+            let queue = ThreadsafeFunction::new(env, drop_napi_ref);
+            queue.unref(env);
             queue
         };
 

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -16,6 +16,7 @@ use neon_runtime::reference;
 use neon_runtime::tsfn::ThreadsafeFunction;
 
 use crate::context::Context;
+#[cfg(all(feature = "event-queue-api"))]
 use crate::event::Channel;
 use crate::handle::root::NapiRef;
 
@@ -33,6 +34,7 @@ pub(crate) struct InstanceData {
     drop_queue: Arc<ThreadsafeFunction<NapiRef>>,
 
     /// Shared `Channel` that is cloned to be returned by the `cx.channel()` method
+    #[cfg(all(feature = "event-queue-api"))]
     shared_channel: Channel,
 }
 
@@ -66,6 +68,7 @@ impl InstanceData {
             queue
         };
 
+        #[cfg(all(feature = "event-queue-api"))]
         let shared_channel = {
             let mut channel = Channel::new(cx);
             channel.unref(cx);
@@ -74,6 +77,7 @@ impl InstanceData {
 
         let data = InstanceData {
             drop_queue: Arc::new(drop_queue),
+            #[cfg(all(feature = "event-queue-api"))]
             shared_channel,
         };
 
@@ -87,6 +91,7 @@ impl InstanceData {
 
     /// Clones the shared channel and references it since new channels should start
     /// referenced, but the shared channel is unreferenced.
+    #[cfg(all(feature = "event-queue-api"))]
     pub(crate) fn channel<'a, C: Context<'a>>(cx: &mut C) -> Channel {
         let mut channel = InstanceData::get(cx).shared_channel.clone();
         channel.reference(cx);


### PR DESCRIPTION
Node.js optimizes subsequent ThreadsafeFunction invocations to happen
during the same event loop tick, but only if the same instance of
ThreadsafeFunction is used. The performance improvement is most
noticeable when used in Electron, because scheduling a new UV tick in
Electron is very costly.

With this change EventQueue will use an
existing instance of ThreadsafeTrampoline (wrapper around
ThreadsafeFunction) if compiled with napi-6 feature, or it will fallback
to creating a new ThreadsafeFunction per EventQueue instance.

Fix: #727