### PR TITLE
Memory leak in `Root`

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -173,6 +173,8 @@ mod napi1 {
 
             fn reference_unref(env: Env, reference: Ref, result: *mut u32) -> Status;
 
+            fn delete_reference(env: Env, reference: Ref) -> Status;
+
             fn get_reference_value(env: Env, reference: Ref, result: *mut Value) -> Status;
 
             fn strict_equals(env: Env, lhs: Value, rhs: Value, result: *mut bool) -> Status;

--- a/crates/neon-runtime/src/napi/reference.rs
+++ b/crates/neon-runtime/src/napi/reference.rs
@@ -26,7 +26,7 @@ pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     result.assume_init() as usize
 }
 
-pub unsafe fn unreference(env: Env, value: napi::Ref) -> usize {
+pub unsafe fn unreference(env: Env, value: napi::Ref) {
     let mut result = MaybeUninit::uninit();
 
     assert_eq!(
@@ -34,7 +34,9 @@ pub unsafe fn unreference(env: Env, value: napi::Ref) -> usize {
         napi::Status::Ok,
     );
 
-    result.assume_init() as usize
+    if result.assume_init() == 0 {
+        assert_eq!(napi::delete_reference(env, value), napi::Status::Ok);
+    }
 }
 
 pub unsafe fn get(env: Env, value: napi::Ref) -> Local {


### PR DESCRIPTION
Fixes a memory leak in `Root` reported in https://github.com/neon-bindings/neon/issues/746.

This PR includes two commits:

* Delete N-API references when the count hits `0`.
  This is the bug referenced above. It stems from a misunderstanding of N-API. It's not sufficient to decrement the reference count to `0`, the reference must also be deleted.
* Use an `Option` to store the reference instead of using `ManuallyDrop`.
   While not as extreme, the global event queue reference counter was always incrementing. It would never be freed, event after the context ended.