### PR TITLE
docs: account for n-api rename to node-api, suggest new headline structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="neon.png" alt="neon" width="100%" />
+# <img src="neon.png" alt="neon" width="100%" />
 
 [![Cargo](http://meritbadge.herokuapp.com/neon)](https://crates.io/crates/neon)
 [![npm](https://img.shields.io/npm/v/neon-cli.svg)](https://www.npmjs.com/package/neon-cli)
@@ -8,7 +8,7 @@
 
 Rust bindings for writing safe and fast native Node.js modules.
 
-# Getting started
+## Getting started
 
 Once you have the [platform dependencies](https://neon-bindings.com/docs/getting-started#install-node-build-tools/) installed, getting started is as simple as:
 
@@ -20,17 +20,17 @@ Then see the [Hello World guide](https://neon-bindings.com/docs/hello-world/) fo
 
 _**Note:** This will create a new project with the `napi-backend` and some documentation may not be up to date._
 
-# Docs
+## Docs
 
 See our [Neon fundamentals docs](https://neon-bindings.com/docs/intro) and our [API docs](https://docs.rs/neon/latest/neon).
 
-# N-API Migration Guide
+## Node-API (formerly N-API) Migration Guide
 
-We've ported Neon to a new backend based on [N-API](https://nodejs.org/api/n-api.html), which will be the basis for Neon 1.0.
+We've ported Neon to a new backend based on [Node-API (formerly N-API)](https://nodejs.org/api/n-api.html), which will be the basis for Neon 1.0.
 
 **Read the new [migration guide](https://github.com/neon-bindings/neon/blob/main/MIGRATION_GUIDE.md)** to learn how to port your Neon projects to N-API!
 
-# Platform Support
+## Platform Support
 
 ### Operating Systems
 
@@ -50,7 +50,7 @@ Support for [LTS versions of Node](https://github.com/nodejs/LTS#release-schedul
 
 Neon supports Rust stable version 1.18 and higher. We test on the latest stable, beta, and nightly versions of Rust.
 
-# A Taste...
+## A Taste...
 
 ```rust
 fn make_an_array(mut cx: FunctionContext) -> JsResult<JsArray> {
@@ -78,13 +78,13 @@ register_module!(mut cx, {
 
 For more examples, see our [examples repo](https://github.com/neon-bindings/examples).
 
-# Get Involved
+## Get Involved
 
 The Neon community is just getting started and there's tons of fun to be had. Come play! :)
 
 The [Rust Bindings community Slack](https://rust-bindings.slack.com) is open to all; use [the Slackin app](https://rust-bindings-slackin.herokuapp.com) to receive an invitation.
 
-# License
+## License
 
 Licensed under either of
 


### PR DESCRIPTION
- https://nodejs.medium.com/renaming-n-api-to-node-api-27aa8ca30ed8
- Rework headline hierarchy