### PR TITLE
JsSymbol primitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ event-queue-api = []
 # Feature flag to include procedural macros
 proc-macros = ["neon-macros"]
 
+# Feature flag to enable the `JsSymbol` API of RFC 38
+# https://github.com/neon-bindings/rfcs/pull/38
+symbol-primitive-api = []
+
 [package.metadata.docs.rs]
 features = ["docs-only", "event-handler-api", "proc-macros", "try-catch-api"]
 

--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -198,6 +198,8 @@ mod napi1 {
             ) -> Status;
 
             fn run_script(env: Env, script: Value, result: *mut Value) -> Status;
+
+            fn create_symbol(env: Env, description: Value, result: *mut Value) -> Status;
         }
     );
 }

--- a/crates/neon-runtime/src/napi/primitive.rs
+++ b/crates/neon-runtime/src/napi/primitive.rs
@@ -43,3 +43,9 @@ pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     );
     value
 }
+
+/// Mutates the `out` argument provided to refer to a newly created `Local` containing a
+/// JavaScript symbol.
+pub unsafe fn symbol(out: &mut Local, env: Env, desc: Local) {
+    napi::create_symbol(env, desc, out as *mut Local);
+}

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -34,6 +34,11 @@ pub unsafe fn is_string(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::String)
 }
 
+/// Is `val` a JavaScript symbol?
+pub unsafe fn is_symbol(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::ValueType::Symbol)
+}
+
 pub unsafe fn is_object(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Object)
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -168,6 +168,8 @@ use crate::types::{
     JsArray, JsBoolean, JsFunction, JsNull, JsNumber, JsObject, JsString, JsUndefined, JsValue,
     StringResult, Value,
 };
+#[cfg(all(feature = "napi-1", feature = "symbol-primitive-api"))]
+use crate::types::symbol::JsSymbol;
 use neon_runtime;
 use neon_runtime::raw;
 #[cfg(feature = "napi-1")]
@@ -436,6 +438,14 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// If the string exceeds the limits of the JS engine, this method returns an `Err` value.
     fn try_string<S: AsRef<str>>(&mut self, s: S) -> StringResult<'a> {
         JsString::try_new(self, s)
+    }
+
+    /// Convenience method for creating a `JsSymbol` value.
+    ///
+    /// If the string exceeds the limits of the JS engine, this method panics.
+    #[cfg(all(feature = "napi-1", feature = "symbol-primitive-api"))]
+    fn symbol<S: AsRef<str>>(&mut self, s: S) -> Handle<'a, JsSymbol> {
+        JsSymbol::with_description(self, s)
     }
 
     /// Convenience method for creating a `JsNull` value.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -31,3 +31,5 @@ pub use crate::{
     handle::Root,
     types::boxed::{Finalize, JsBox},
 };
+#[cfg(all(feature = "napi-1", feature = "symbol-primitive-api"))]
+pub use crate::types::symbol::JsSymbol;

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -1,0 +1,86 @@
+use crate::context::Context;
+use crate::handle::{Handle, Managed};
+use crate::types::internal::ValueInternal;
+use crate::types::utf8::Utf8;
+use crate::types::{Env, JsString, Value};
+
+use neon_runtime::raw;
+
+/// A JavaScript symbol primitive value.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct JsSymbol(raw::Local);
+
+impl JsSymbol {
+    /// Create a new symbol.
+    /// Equivalent to calling `Symbol()` in JavaScript
+    pub fn new<'a, C: Context<'a>>(cx: &mut C) -> Handle<'a, JsSymbol> {
+        JsSymbol::new_internal(cx.env(), None::<&str>)
+    }
+
+    /// Create a new symbol with a description.
+    /// Equivalent to calling `Symbol(desc)` in JavaScript
+    pub fn with_description<'a, C: Context<'a>, S: AsRef<str>>(
+        cx: &mut C,
+        desc: S,
+    ) -> Handle<'a, JsSymbol> {
+        JsSymbol::new_internal(cx.env(), Some(desc))
+    }
+
+    /// Get the optional symbol description, where `None` represents an undefined description.
+    pub fn description<'a, C: Context<'a>>(self, cx: &mut C) -> Option<String> {
+        let env = cx.env().to_raw();
+        let (desc_ptr, desc_len) = Utf8::from("description").into_small_unwrap().lower();
+
+        unsafe {
+            let mut local = std::mem::zeroed();
+            if !neon_runtime::object::get_string(env, &mut local, self.to_raw(), desc_ptr, desc_len)
+            {
+                return None;
+            }
+
+            if neon_runtime::tag::is_string(env, local) {
+                Some(JsString::value_internal(env, local))
+            } else {
+                None
+            }
+        }
+    }
+
+    pub(crate) fn new_internal<'a, S: AsRef<str>>(
+        env: Env,
+        desc: Option<S>,
+    ) -> Handle<'a, JsSymbol> {
+        unsafe {
+            let desc_local = desc
+                .and_then(|d| JsString::new_internal(env, d.as_ref()))
+                .map_or_else(|| std::mem::zeroed(), |h| h.to_raw());
+
+            let mut sym_local = std::mem::zeroed();
+            neon_runtime::primitive::symbol(&mut sym_local, env.to_raw(), desc_local);
+            Handle::new_internal(JsSymbol(sym_local))
+        }
+    }
+}
+
+impl Value for JsSymbol {}
+
+impl Managed for JsSymbol {
+    fn to_raw(self) -> raw::Local {
+        self.0
+    }
+
+    fn from_raw(_: Env, h: raw::Local) -> Self {
+        JsSymbol(h)
+    }
+}
+
+impl ValueInternal for JsSymbol {
+    fn name() -> String {
+        "symbol".to_string()
+    }
+
+    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+        unsafe { neon_runtime::tag::is_symbol(env.to_raw(), other.to_raw()) }
+    }
+}

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 version = "*"
 path = "../.."
 default-features = false
-features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api"]
+features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api", "symbol-primitive-api"]

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -22,6 +22,15 @@ describe('JsObject', function() {
     assert.deepEqual({number: 9000, string: 'hello node'}, addon.return_js_object_with_mixed_content());
   });
 
+  it('return a JsObject with a symbol property key', function () {
+    const obj = addon.return_js_object_with_symbol_property_key();
+    const propertySymbols = Object.getOwnPropertySymbols(obj);
+    assert.equal(propertySymbols.length, 1);
+    const sym = propertySymbols[0];
+    assert.equal(typeof sym, "symbol");
+    assert.equal(obj[sym], sym);
+  })
+
   it('gets a 16-byte, zeroed ArrayBuffer', function() {
     var b = addon.return_array_buffer();
     assert.equal(b.byteLength, 16);

--- a/test/napi/lib/symbols.js
+++ b/test/napi/lib/symbols.js
@@ -1,0 +1,31 @@
+const addon = require('..');
+const { assert } = require('chai');
+
+describe('JsSymbol', function() {
+    it('should return a JsSymbol with a description built in Rust', function () {
+        const sym = addon.return_js_symbol_with_description();
+        assert.equal(typeof sym, 'symbol');
+        assert.equal(sym.description, "neon:description");
+    });
+    it('should return a JsSymbol without a description built in Rust', function () {
+        const sym = addon.return_js_symbol();
+        assert.equal(typeof sym, 'symbol');
+        assert.equal(sym.description, undefined);
+    });
+    it('should read the description property in Rust', function () {
+        const sym = Symbol('neon:description');
+        const description = addon.read_js_symbol_description(sym);
+        assert.equal(description, 'neon:description');
+    });
+    it('should read an undefined description property in Rust', function () {
+        const sym = Symbol();
+        const description = addon.read_js_symbol_description(sym);
+        assert.equal(description, undefined);
+    });
+    it('accepts and returns symbols', function () {
+        const symDesc = Symbol('neon:description');
+        const symNoDesc = Symbol();
+        assert.equal(addon.accept_and_return_js_symbol(symDesc), symDesc);
+        assert.equal(addon.accept_and_return_js_symbol(symNoDesc), symNoDesc);
+    });
+});

--- a/test/napi/lib/types.js
+++ b/test/napi/lib/types.js
@@ -70,6 +70,15 @@ describe('type checks', function() {
     assert(!addon.is_string(new String('1')));
   });
 
+  it('is_symbol', function () {
+    assert(addon.is_symbol(Symbol()));
+    assert(addon.is_symbol(Symbol("unique symbol")));
+    assert(addon.is_symbol(Symbol.for('neon:description')));
+    assert(addon.is_symbol(Symbol.toStringTag));
+    assert(!addon.is_symbol(undefined));
+    assert(!addon.is_symbol("anything other than symbol"));
+  });
+
   it('is_undefined', function () {
     assert(addon.is_undefined(undefined));
     assert(!addon.is_undefined(null));
@@ -84,5 +93,9 @@ describe('type checks', function() {
     assert(addon.strict_equals(o1, o1));
     assert(!addon.strict_equals(o1, o2));
     assert(!addon.strict_equals(o1, 17));
+    let s1 = Symbol();
+    let s2 = Symbol();
+    assert(addon.strict_equals(s1, s1));
+    assert(!addon.strict_equals(s1, s2));
   });
 });

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -31,6 +31,13 @@ pub fn return_js_object_with_string(mut cx: FunctionContext) -> JsResult<JsObjec
     Ok(js_object)
 }
 
+pub fn return_js_object_with_symbol_property_key(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let js_object: Handle<JsObject> = cx.empty_object();
+    let s = cx.symbol("neon:description");
+    js_object.set(&mut cx, s, s)?;
+    Ok(js_object)
+}
+
 pub fn return_array_buffer(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
     let b: Handle<JsArrayBuffer> = cx.array_buffer(16)?;
     Ok(b)

--- a/test/napi/src/js/symbols.rs
+++ b/test/napi/src/js/symbols.rs
@@ -1,0 +1,22 @@
+use neon::prelude::*;
+
+pub fn return_js_symbol_with_description(mut cx: FunctionContext) -> JsResult<JsSymbol> {
+    Ok(cx.symbol("neon:description"))
+}
+
+pub fn return_js_symbol(mut cx: FunctionContext) -> JsResult<JsSymbol> {
+    Ok(JsSymbol::new(&mut cx))
+}
+
+pub fn read_js_symbol_description(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let symbol: Handle<JsSymbol> = cx.argument(0)?;
+    match symbol.description(&mut cx) {
+        None => Ok(cx.undefined().upcast()),
+        Some(s) => Ok(cx.string(s).upcast()),
+    }
+}
+
+pub fn accept_and_return_js_symbol(mut cx: FunctionContext) -> JsResult<JsSymbol> {
+    let sym: Handle<JsSymbol> = cx.argument(0)?;
+    Ok(sym)
+}

--- a/test/napi/src/js/types.rs
+++ b/test/napi/src/js/types.rs
@@ -54,6 +54,12 @@ pub fn is_object(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     Ok(cx.boolean(result))
 }
 
+pub fn is_symbol(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsSymbol,_>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
 pub fn is_undefined(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let val: Handle<JsValue> = cx.argument(0)?;
     let is_string = val.is_a::<JsUndefined, _>(&mut cx);

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -10,6 +10,7 @@ mod js {
     pub mod numbers;
     pub mod objects;
     pub mod strings;
+    pub mod symbols;
     pub mod threads;
     pub mod types;
 }
@@ -23,6 +24,7 @@ use js::functions::*;
 use js::numbers::*;
 use js::objects::*;
 use js::strings::*;
+use js::symbols::*;
 use js::threads::*;
 use js::types::*;
 
@@ -165,6 +167,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("return_js_object_with_number", return_js_object_with_number)?;
     cx.export_function("return_js_object_with_string", return_js_object_with_string)?;
     cx.export_function(
+        "return_js_object_with_symbol_property_key",
+        return_js_object_with_symbol_property_key
+    )?;
+    cx.export_function(
         "return_js_object_with_mixed_content",
         return_js_object_with_mixed_content,
     )?;
@@ -218,6 +224,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("is_number", is_number)?;
     cx.export_function("is_object", is_object)?;
     cx.export_function("is_string", is_string)?;
+    cx.export_function("is_symbol", is_symbol)?;
     cx.export_function("is_undefined", is_undefined)?;
     cx.export_function("strict_equals", strict_equals)?;
 
@@ -257,6 +264,11 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("greeter_greet", greeter_greet)?;
     cx.export_function("leak_channel", leak_channel)?;
     cx.export_function("drop_global_queue", drop_global_queue)?;
+
+    cx.export_function("return_js_symbol_with_description", return_js_symbol_with_description)?;
+    cx.export_function("return_js_symbol", return_js_symbol)?;
+    cx.export_function("read_js_symbol_description", read_js_symbol_description)?;
+    cx.export_function("accept_and_return_js_symbol", accept_and_return_js_symbol)?;
 
     Ok(())
 }


### PR DESCRIPTION
Addresses #502 and [JsSymbol RFC](https://github.com/neon-bindings/rfcs/pull/38). 

A few thoughts from playing with the implementation:

In JS, the `Symbol()` [function spec](https://tc39.es/ecma262/#sec-symbol-description) allows for non-string values that can be coerced to string, e.g. 
`Symbol(null).description === 'null'`.

Should `JsSymbol::with_description()` accept some trait that allows it to accept both `Handle` and `&str` (along the lines of `PropertyKey`)? I don't know how other folks utilize the description property. When using them in JS, I personally only use string literals since I use the description to convey meaning to other developers in the source code. I don't think I've ever used the description itself as a value, but I could see someone else using it as such.

Along that same line of thought, if people do use the description as a value, should `JsSymbol::description()` return an `Option<Handle<'a, JsString>>` instead of `Option<String>` (or even `Handle<'a, JsValue>` that could be either `JsUndefined` or `JsString`)?