### PR TITLE
v0.9.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 clippy-legacy = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,try-catch-api,legacy-runtime -- -A clippy::missing_safety_doc"
 clippy-napi = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features proc-macros,try-catch-api,napi-experimental -- -A clippy::missing_safety_doc"
 neon-test = "test --no-default-features --features napi-experimental"
-neon-doc = "doc --no-default-features --features channel-api,napi-experimental,proc-macros,try-catch-api"
+neon-doc = "rustdoc --no-default-features --features=channel-api,napi-experimental,proc-macros,try-catch-api -- --cfg docsrs"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,4 @@
 clippy-legacy = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,try-catch-api,legacy-runtime -- -A clippy::missing_safety_doc"
 clippy-napi = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features proc-macros,try-catch-api,napi-experimental -- -A clippy::missing_safety_doc"
 neon-test = "test --no-default-features --features napi-experimental"
+neon-doc = "doc --no-default-features --features event-queue-api,napi-experimental,proc-macros,try-catch-api"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 clippy-legacy = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,try-catch-api,legacy-runtime -- -A clippy::missing_safety_doc"
 clippy-napi = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features proc-macros,try-catch-api,napi-experimental -- -A clippy::missing_safety_doc"
 neon-test = "test --no-default-features --features napi-experimental"
-neon-doc = "doc --no-default-features --features event-queue-api,napi-experimental,proc-macros,try-catch-api"
+neon-doc = "doc --no-default-features --features channel-api,napi-experimental,proc-macros,try-catch-api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "A safe abstraction layer for Node.js."
 readme = "README.md"
@@ -12,7 +12,7 @@ build = "build.rs"
 edition = "2018"
 
 [build-dependencies]
-neon-build = { version = "=0.8.3", path = "crates/neon-build" }
+neon-build = { version = "=0.9.0", path = "crates/neon-build" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -25,8 +25,8 @@ failure = "0.1.5" # used for a doc example
 cslice = "0.2"
 semver = "0.9.0"
 smallvec = "1.4.2"
-neon-runtime = { version = "=0.8.3", path = "crates/neon-runtime" }
-neon-macros = { version = "=0.8.3", path = "crates/neon-macros", optional = true }
+neon-runtime = { version = "=0.9.0", path = "crates/neon-runtime" }
+neon-macros = { version = "=0.9.0", path = "crates/neon-macros", optional = true }
 
 [features]
 default = ["legacy-runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,12 @@ event-queue-api = []
 proc-macros = ["neon-macros"]
 
 [package.metadata.docs.rs]
-features = ["docs-only", "event-handler-api", "proc-macros", "try-catch-api"]
+features = [
+    "event-queue-api",
+    "napi-experimental",
+    "proc-macros",
+    "try-catch-api",
+]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,10 @@ try-catch-api = []
 
 # Feature flag to enable the `EventQueue` API of RFC 33.
 # https://github.com/neon-bindings/rfcs/pull/32
-event-queue-api = []
+channel-api = []
+
+# Deprecated name for `channel-api`
+event-queue-api = ["channel-api"]
 
 # Feature flag to include procedural macros
 proc-macros = ["neon-macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,10 @@ event-queue-api = ["channel-api"]
 proc-macros = ["neon-macros"]
 
 [package.metadata.docs.rs]
+no-default-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 features = [
-    "event-queue-api",
+    "channel-api",
     "napi-experimental",
     "proc-macros",
     "try-catch-api",

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -41,7 +41,7 @@ As a rule, you should choose the **oldest version of N-API that has the APIs you
 
 ```toml
 [dependencies.neon]
-version = "0.8.3"
+version = "0.9.0"
 default-features = false
 features = ["napi-4"]
 ```
@@ -189,13 +189,13 @@ class User {
 
 ### Concurrency
 
-The supported mechanism for concurrency is the Event Queue API (`neon::event::EventQueue`). This feature has not yet stabilized, so to use this API, you'll also need to enable the `"event-queue-api"` feature flag as well:
+The supported mechanism for concurrency is the Channel API (`neon::event::Channel`). This feature has not yet stabilized, so to use this API, you'll also need to enable the `"channel-api"` feature flag as well:
 
 ```toml
 [dependencies.neon]
-version = "0.8.1"
+version = "0.9.0"
 default-features = false
-features = ["napi-4", "event-queue-api"]
+features = ["napi-6", "channel-api"]
 ```
 
 #### Deprecated: Task API

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,24 @@
+# Version 0.9.0
+
+## Performance
+
+`Channel`, formerly `EventQueue`, are now cloneable. Clones share a backing queue to take advantage of an [optimization](https://github.com/nodejs/node/pull/38506) in Node threadsafe functions. Additionally, when specifying Node API 6 or higher (`napi-6`), calling `cx.channel()` will return a shared queue (https://github.com/neon-bindings/neon/pull/739).
+
+The change may cause a performance regression in some pathological use cases (https://github.com/neon-bindings/neon/issues/762).
+
+## Deprecation
+
+`EventQueue` and `EventQueueError` have been renamed to `Channel` and `ChannelError` respectively to clarify their function and similarity to Rust channels. The types are available as deprecated aliases (https://github.com/neon-bindings/neon/pull/752).
+
+## Docs
+
+* Document error causes for `Channel::try_send` docs (https://github.com/neon-bindings/neon/pull/767)
+* Document `neon::object` (https://github.com/neon-bindings/neon/pull/740)
+
+## Fixes
+
+* Fix usage of a removed API in legacy buffers (https://github.com/neon-bindings/neon/pull/769)
+
 # Version 0.8.3
 
 * Fix crash caused by non-thread safety in napi_threadsafefunction on early termination (https://github.com/neon-bindings/neon/pull/744)

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Build and load native Rust/Neon modules.",
   "author": "Dave Herman <david.herman@gmail.com>",
   "repository": {

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-build"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Build logic required for Neon projects."
 repository = "https://github.com/neon-bindings/neon"
@@ -9,4 +9,4 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-neon-sys = { version = "=0.8.3", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.9.0", path = "../neon-sys", optional = true }

--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-macros"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Procedural macros supporting Neon"
 repository = "https://github.com/neon-bindings/neon"

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-runtime"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Bindings to the Node.js native addon API, used by the Neon implementation."
 repository = "https://github.com/neon-bindings/neon"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0.0"
 libloading = { version = "0.6.5", optional = true }
-neon-sys = { version = "=0.8.3", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.9.0", path = "../neon-sys", optional = true }
 smallvec = "1.4.2"
 
 [dev-dependencies]

--- a/crates/neon-runtime/src/napi/convert.rs
+++ b/crates/neon-runtime/src/napi/convert.rs
@@ -1,7 +1,7 @@
 use crate::napi::bindings as napi;
 use crate::raw::{Env, Local};
 
-/// This API is currently unused, see https://github.com/neon-bindings/neon/issues/572
+/// This API is currently unused, see <https://github.com/neon-bindings/neon/issues/572>
 pub unsafe fn to_object(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::coerce_to_object(env, value, out as *mut _);
 

--- a/crates/neon-runtime/src/napi/external.rs
+++ b/crates/neon-runtime/src/napi/external.rs
@@ -24,7 +24,7 @@ extern "C" fn finalize_external<T: Send + 'static>(
 /// Safety: `deref` must only be called with `napi_external` created by that
 /// module. Calling `deref` with an external created by another native module,
 /// even another neon module, is undefined behavior.
-/// https://github.com/neon-bindings/neon/issues/591
+/// <https://github.com/neon-bindings/neon/issues/591>
 pub unsafe fn deref<T: Send + 'static>(env: Env, local: Local) -> Option<*const T> {
     let mut result = MaybeUninit::uninit();
     let status = napi::typeof_value(env, local, result.as_mut_ptr());

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-sys"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["David Herman <david.herman@gmail.com>"]
 description  = "Exposes the low-level V8/NAN C/C++ APIs. Will be superseded by N-API."
 edition = "2018"

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -151,10 +151,10 @@ pub(crate) mod internal;
 use crate::borrow::internal::Ledger;
 use crate::borrow::{Borrow, BorrowMut, Ref, RefMut};
 use crate::context::internal::Env;
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
 use crate::event::Channel;
 use crate::handle::{Handle, Managed};
-#[cfg(all(feature = "napi-6", feature = "event-queue-api"))]
+#[cfg(all(feature = "napi-6", feature = "channel-api"))]
 use crate::lifecycle::InstanceData;
 #[cfg(feature = "legacy-runtime")]
 use crate::object::class::Class;
@@ -552,8 +552,8 @@ pub trait Context<'a>: ContextInternal<'a> {
         JsBox::new(self, v)
     }
 
-    #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "event-queue-api"))))]
+    #[cfg(all(feature = "napi-4", feature = "channel-api"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
     /// Returns an unbounded channel for scheduling events to be executed on the JavaScript thread.
     ///
     /// When using N-API >= 6,the channel returned by this method is backed by a shared queue.
@@ -568,7 +568,7 @@ pub trait Context<'a>: ContextInternal<'a> {
         channel
     }
 
-    #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+    #[cfg(all(feature = "napi-4", feature = "channel-api"))]
     #[deprecated(since = "0.9.0", note = "Please use the channel() method instead")]
     #[doc(hidden)]
     fn queue(&mut self) -> Channel {
@@ -817,7 +817,7 @@ impl<'a> TaskContext<'a> {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }
 
-    #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+    #[cfg(all(feature = "napi-4", feature = "channel-api"))]
     pub(crate) fn with_context<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: Env, f: F) -> T {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -409,6 +409,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(feature = "try-catch-api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "try-catch-api")))]
     fn try_catch<T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
     where
         F: FnOnce(&mut Self) -> NeonResult<T>,
@@ -552,6 +553,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "event-queue-api"))))]
     /// Returns an unbounded channel for scheduling events to be executed on the JavaScript thread.
     ///
     /// When using N-API >= 6,the channel returned by this method is backed by a shared queue.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -479,6 +479,7 @@ pub trait Context<'a>: ContextInternal<'a> {
 
     /// Convenience method for creating a `JsDate` value.
     #[cfg(feature = "napi-5")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
     fn date(&mut self, value: impl Into<f64>) -> Result<Handle<'a, JsDate>, DateError> {
         JsDate::new(self, value)
     }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -123,19 +123,19 @@
 //! [psd-crate]: https://crates.io/crates/psd
 //! [psd-file]: https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/
 
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
 mod event_queue;
 
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "event-queue-api"))))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
 pub use self::event_queue::{Channel, SendError};
 
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
 #[deprecated(since = "0.9.0", note = "Please use the Channel type instead")]
 #[doc(hidden)]
 pub type EventQueue = self::event_queue::Channel;
 
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
 #[deprecated(since = "0.9.0", note = "Please use the SendError type instead")]
 #[doc(hidden)]
 pub type EventQueueError = self::event_queue::SendError;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -127,6 +127,7 @@
 mod event_queue;
 
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "event-queue-api"))))]
 pub use self::event_queue::{Channel, SendError};
 
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -127,7 +127,6 @@
 mod event_queue;
 
 #[cfg(all(feature = "napi-4", feature = "channel-api"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
 pub use self::event_queue::{Channel, SendError};
 
 #[cfg(all(feature = "napi-4", feature = "channel-api"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,13 +83,13 @@ pub mod borrow;
 pub mod context;
 #[cfg(any(
     feature = "event-handler-api",
-    all(feature = "napi-4", feature = "event-queue-api")
+    all(feature = "napi-4", feature = "channel-api")
 ))]
 #[cfg_attr(
     docsrs,
     doc(cfg(any(
         feature = "event-handler-api",
-        all(feature = "napi-4", feature = "event-queue-api")
+        all(feature = "napi-4", feature = "channel-api")
     )))
 )]
 pub mod event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,13 @@ pub mod context;
     feature = "event-handler-api",
     all(feature = "napi-4", feature = "event-queue-api")
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "event-handler-api",
+        all(feature = "napi-4", feature = "event-queue-api")
+    )))
+)]
 pub mod event;
 pub mod handle;
 pub mod meta;
@@ -101,6 +108,7 @@ pub mod types;
 pub mod macro_internal;
 
 #[cfg(feature = "proc-macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "proc-macros")))]
 pub use neon_macros::*;
 
 #[cfg(feature = "napi-6")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@
 //! [neon]: https://www.neon-bindings.com/
 //! [addons]: https://nodejs.org/api/addons.html
 //! [supported]: https://github.com/neon-bindings/neon#platform-support
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod borrow;
 pub mod context;
@@ -85,13 +86,7 @@ pub mod context;
     feature = "event-handler-api",
     all(feature = "napi-4", feature = "channel-api")
 ))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(
-        feature = "event-handler-api",
-        all(feature = "napi-4", feature = "channel-api")
-    )))
-)]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
 pub mod event;
 pub mod handle;
 pub mod meta;

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -16,7 +16,7 @@ use neon_runtime::reference;
 use neon_runtime::tsfn::ThreadsafeFunction;
 
 use crate::context::Context;
-#[cfg(all(feature = "event-queue-api"))]
+#[cfg(all(feature = "channel-api"))]
 use crate::event::Channel;
 use crate::handle::root::NapiRef;
 
@@ -34,7 +34,7 @@ pub(crate) struct InstanceData {
     drop_queue: Arc<ThreadsafeFunction<NapiRef>>,
 
     /// Shared `Channel` that is cloned to be returned by the `cx.channel()` method
-    #[cfg(all(feature = "event-queue-api"))]
+    #[cfg(all(feature = "channel-api"))]
     shared_channel: Channel,
 }
 
@@ -68,7 +68,7 @@ impl InstanceData {
             queue
         };
 
-        #[cfg(all(feature = "event-queue-api"))]
+        #[cfg(all(feature = "channel-api"))]
         let shared_channel = {
             let mut channel = Channel::new(cx);
             channel.unref(cx);
@@ -77,7 +77,7 @@ impl InstanceData {
 
         let data = InstanceData {
             drop_queue: Arc::new(drop_queue),
-            #[cfg(all(feature = "event-queue-api"))]
+            #[cfg(all(feature = "channel-api"))]
             shared_channel,
         };
 
@@ -91,7 +91,7 @@ impl InstanceData {
 
     /// Clones the shared channel and references it since new channels should start
     /// referenced, but the shared channel is unreferenced.
-    #[cfg(all(feature = "event-queue-api"))]
+    #[cfg(all(feature = "channel-api"))]
     pub(crate) fn channel<'a, C: Context<'a>>(cx: &mut C) -> Channel {
         let mut channel = InstanceData::get(cx).shared_channel.clone();
         channel.reference(cx);

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -246,6 +246,7 @@ mod traits {
         }
 
         #[cfg(feature = "napi-6")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
         fn get_own_property_names<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsArray> {
             let env = cx.env();
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,33 +1,45 @@
 //! Convenience module for the most common Neon imports.
 
+#[doc(no_inline)]
 pub use crate::borrow::{Borrow, BorrowMut};
+#[doc(no_inline)]
 pub use crate::context::{
     CallContext, CallKind, ComputeContext, Context, ExecuteContext, FunctionContext, MethodContext,
     ModuleContext, TaskContext,
 };
 #[cfg(feature = "legacy-runtime")]
+#[doc(no_inline)]
 pub use crate::declare_types;
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
+#[doc(no_inline)]
 pub use crate::event::EventHandler;
 #[cfg(all(feature = "napi-4", feature = "channel-api"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
+#[doc(no_inline)]
 pub use crate::event::{Channel, SendError};
 #[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[doc(no_inline)]
 #[allow(deprecated)]
 pub use crate::event::{EventQueue, EventQueueError};
+#[doc(no_inline)]
 pub use crate::handle::Handle;
 #[cfg(feature = "legacy-runtime")]
+#[doc(no_inline)]
 pub use crate::object::Class;
+#[doc(no_inline)]
 pub use crate::object::Object;
+#[doc(no_inline)]
 pub use crate::register_module;
+#[doc(no_inline)]
 pub use crate::result::{JsResult, JsResultExt, NeonResult};
 #[cfg(feature = "legacy-runtime")]
 pub use crate::task::Task;
+#[doc(no_inline)]
 pub use crate::types::{
     BinaryData, JsArray, JsArrayBuffer, JsBoolean, JsBuffer, JsError, JsFunction, JsNull, JsNumber,
     JsObject, JsString, JsUndefined, JsValue, Value,
 };
 #[cfg(feature = "napi-1")]
+#[doc(no_inline)]
 pub use crate::{
     handle::Root,
     types::boxed::{Finalize, JsBox},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,10 +9,10 @@ pub use crate::context::{
 pub use crate::declare_types;
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 pub use crate::event::EventHandler;
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "event-queue-api"))))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
 pub use crate::event::{Channel, SendError};
-#[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg(all(feature = "napi-4", feature = "channel-api"))]
 #[allow(deprecated)]
 pub use crate::event::{EventQueue, EventQueueError};
 pub use crate::handle::Handle;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,7 @@ pub use crate::declare_types;
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 pub use crate::event::EventHandler;
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "event-queue-api"))))]
 pub use crate::event::{Channel, SendError};
 #[cfg(all(feature = "napi-4", feature = "event-queue-api"))]
 #[allow(deprecated)]

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -69,9 +69,9 @@ impl<'a, T: Value> JsResultExt<'a, T> for Result<Handle<'a, T>, DateError> {
 }
 
 impl JsDate {
-    /// The smallest possible Date value, defined by ECMAScript. See https://www.ecma-international.org/ecma-262/5.1/#sec-15.7.3.3
+    /// The smallest possible Date value, defined by ECMAScript. See <https://www.ecma-international.org/ecma-262/5.1/#sec-15.7.3.3>
     pub const MIN_VALUE: f64 = -8.64e15;
-    /// The largest possible Date value, defined by ECMAScript. See https://www.ecma-international.org/ecma-262/5.1/#sec-15.7.3.2
+    /// The largest possible Date value, defined by ECMAScript. See <https://www.ecma-international.org/ecma-262/5.1/#sec-15.7.3.2>
     pub const MAX_VALUE: f64 = 8.64e15;
 
     /// Creates a new Date. It errors when `value` is outside the range of valid JavaScript Date values. When `value`

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -13,6 +13,7 @@ use std::fmt::Debug;
 /// A JavaScript Date object
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
 pub struct JsDate(raw::Local);
 
 impl Value for JsDate {}
@@ -29,6 +30,7 @@ impl Managed for JsDate {
 
 /// The Error struct for a Date
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
 pub struct DateError(DateErrorKind);
 
 impl DateError {
@@ -47,6 +49,7 @@ impl Error for DateError {}
 
 /// The error kinds corresponding to `DateError`
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
 pub enum DateErrorKind {
     Overflow,
     Underflow,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -103,6 +103,7 @@ pub use self::binary::{BinaryData, BinaryViewType, JsArrayBuffer, JsBuffer};
 #[cfg(feature = "napi-1")]
 pub use self::boxed::JsBox;
 #[cfg(feature = "napi-5")]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
 pub use self::date::{DateError, DateErrorKind, JsDate};
 pub use self::error::JsError;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -103,7 +103,6 @@ pub use self::binary::{BinaryData, BinaryViewType, JsArrayBuffer, JsBuffer};
 #[cfg(feature = "napi-1")]
 pub use self::boxed::JsBox;
 #[cfg(feature = "napi-5")]
-#[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
 pub use self::date::{DateError, DateErrorKind, JsDate};
 pub use self::error::JsError;
 

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 version = "*"
 path = "../.."
 default-features = false
-features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api"]
+features = ["default-panic-hook", "napi-6", "try-catch-api", "channel-api"]


### PR DESCRIPTION
This includes a few odds and ends in addition to the v0.9.0 tag:

* Changes the default backend for `docs.rs` to Node-API
* Add `docsrs` attributes to mark items that require feature flags (e.g., `try_catch`)
* Rename the `event-queue-api` feature flag to `channel-api` (keeping the former as an alias)