### PR TITLE
Update nan package

### DIFF
--- a/crates/neon-sys/native/package-lock.json
+++ b/crates/neon-sys/native/package-lock.json
@@ -397,9 +397,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "node-gyp": {
       "version": "7.1.2",

--- a/crates/neon-sys/native/package.json
+++ b/crates/neon-sys/native/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "^2.14.0",
+    "nan": "^2.15.0",
     "node-gyp": "^7.1.2"
   }
 }


### PR DESCRIPTION
This PR updates the nan package to fix compatibility issues when building with Electron 13.

With version 2.14.0 of `nan` package you encounter this error when trying to use `electron-build-env`:
``` 
In file included from ../src/neon.cc:2:
  In file included from ../node_modules/nan/nan.h:2884:
  ../node_modules/nan/nan_typedarray_contents.h:34:43: error: no member named 'GetContents' in 'v8::ArrayBuffer'
        data   = static_cast<char*>(buffer->GetContents().Data()) + byte_offset;
                                    ~~~~~~  ^
  In file included from ../src/neon.cc:8:
  ../src/neon_string.h:28:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
      maybe.ToLocal(&result);
      ^~~~~~~~~~~~~ ~~~~~~~
  1 warning and 1 error generated.
  make: *** [Release/obj.target/neon/src/neon.o] Error 1
```

This is fixed when upgrading the `nan` package to version 2.15.0

This is related to this issue: https://github.com/neon-bindings/neon/issues/760 and PR: https://github.com/neon-bindings/neon/pull/769