### PR TITLE
v0.9.1

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,6 +3,7 @@
 Neon owes its existence to the contributions of these fine people.
 
 * [Reza Akhavan](https://github.com/jedireza)
+* [andiliu-gh](https://github.com/andiliu-gh)
 * [Nerijus Arlauskas](https://github.com/Nercury)
 * [Igor Artamonov](https://github.com/splix)
 * [Peter Atashian](https://github.com/retep998)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "A safe abstraction layer for Node.js."
 readme = "README.md"
@@ -12,7 +12,7 @@ build = "build.rs"
 edition = "2018"
 
 [build-dependencies]
-neon-build = { version = "=0.9.0", path = "crates/neon-build" }
+neon-build = { version = "=0.9.1", path = "crates/neon-build" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -25,8 +25,8 @@ failure = "0.1.5" # used for a doc example
 cslice = "0.2"
 semver = "0.9.0"
 smallvec = "1.4.2"
-neon-runtime = { version = "=0.9.0", path = "crates/neon-runtime" }
-neon-macros = { version = "=0.9.0", path = "crates/neon-macros", optional = true }
+neon-runtime = { version = "=0.9.1", path = "crates/neon-runtime" }
+neon-macros = { version = "=0.9.1", path = "crates/neon-macros", optional = true }
 
 [features]
 default = ["legacy-runtime"]

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -41,7 +41,7 @@ As a rule, you should choose the **oldest version of N-API that has the APIs you
 
 ```toml
 [dependencies.neon]
-version = "0.9.0"
+version = "0.9.1"
 default-features = false
 features = ["napi-4"]
 ```
@@ -193,7 +193,7 @@ The supported mechanism for concurrency is the Channel API (`neon::event::Channe
 
 ```toml
 [dependencies.neon]
-version = "0.9.0"
+version = "0.9.1"
 default-features = false
 features = ["napi-6", "channel-api"]
 ```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,10 @@
+# Version 0.9.1
+
+* Expose the `Finalize` trait as `neon::types::Finalize` so that docs are visible
+* Improved docs and build scripts in `create-neon` to make release builds more
+  discoverable (https://github.com/neon-bindings/neon/pull/771)
+* Update `nan` to fix an Electron 13 incompatibility (https://github.com/neon-bindings/neon/pull/778)
+
 # Version 0.9.0
 
 ## Performance

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Build and load native Rust/Neon modules.",
   "author": "Dave Herman <david.herman@gmail.com>",
   "repository": {

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-build"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Build logic required for Neon projects."
 repository = "https://github.com/neon-bindings/neon"
@@ -9,4 +9,4 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-neon-sys = { version = "=0.9.0", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.9.1", path = "../neon-sys", optional = true }

--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-macros"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Procedural macros supporting Neon"
 repository = "https://github.com/neon-bindings/neon"

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-runtime"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Bindings to the Node.js native addon API, used by the Neon implementation."
 repository = "https://github.com/neon-bindings/neon"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0.0"
 libloading = { version = "0.6.5", optional = true }
-neon-sys = { version = "=0.9.0", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.9.1", path = "../neon-sys", optional = true }
 smallvec = "1.4.2"
 
 [dev-dependencies]

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-sys"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["David Herman <david.herman@gmail.com>"]
 description  = "Exposes the low-level V8/NAN C/C++ APIs. Will be superseded by N-API."
 edition = "2018"

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -101,7 +101,7 @@ use std::os::raw::c_void;
 
 pub use self::binary::{BinaryData, BinaryViewType, JsArrayBuffer, JsBuffer};
 #[cfg(feature = "napi-1")]
-pub use self::boxed::JsBox;
+pub use self::boxed::{Finalize, JsBox};
 #[cfg(feature = "napi-5")]
 pub use self::date::{DateError, DateErrorKind, JsDate};
 pub use self::error::JsError;


### PR DESCRIPTION
* Expose the `Finalize` trait as `neon::types::Finalize` so that docs are visible
* Improved docs and build scripts in `create-neon` to make release builds more
  discoverable (https://github.com/neon-bindings/neon/pull/771)
* Update `nan` to fix an Electron 13 incompatibility (https://github.com/neon-bindings/neon/pull/778)