### PR TITLE
Remove unused cslice dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ psd = "0.1.9"     # used for a doc example
 failure = "0.1.5" # used for a doc example
 
 [dependencies]
-cslice = "0.2"
 semver = "0.9.0"
 smallvec = "1.4.2"
 neon-runtime = { version = "=0.9.1", path = "crates/neon-runtime" }


### PR DESCRIPTION
This dependency appears to be leftover from a very old version of the Neon project. I couldn't find any places it is used.