### PR TITLE
Make it harder to forge `Throw` tokens

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -494,7 +494,7 @@ pub trait Context<'a>: ContextInternal<'a> {
         unsafe {
             neon_runtime::error::throw(self.env().to_raw(), v.to_raw());
         }
-        Err(Throw)
+        Err(Throw(()))
     }
 
     /// Creates a direct instance of the [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error) class.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -494,7 +494,7 @@ pub trait Context<'a>: ContextInternal<'a> {
         unsafe {
             neon_runtime::error::throw(self.env().to_raw(), v.to_raw());
         }
-        Err(Throw(()))
+        Err(Throw::new())
     }
 
     /// Creates a direct instance of the [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error) class.

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -65,7 +65,7 @@ impl ConstructorCallCallback {
                     );
                 }
             }
-            Err(Throw)
+            Err(Throw(()))
         }
 
         ConstructorCallCallback(callback::<T>)

--- a/src/object/class/internal.rs
+++ b/src/object/class/internal.rs
@@ -65,7 +65,7 @@ impl ConstructorCallCallback {
                     );
                 }
             }
-            Err(Throw(()))
+            Err(Throw::new())
         }
 
         ConstructorCallCallback(callback::<T>)

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -168,7 +168,7 @@ pub(crate) trait ClassInternal: Class {
             );
 
             if metadata_pointer.is_null() {
-                return Err(Throw);
+                return Err(Throw(()));
             }
 
             // NOTE: None of the error cases below need to delete the ClassMetadata object, since the
@@ -181,7 +181,7 @@ pub(crate) trait ClassInternal: Class {
                 class_name.as_ptr(),
                 class_name.len() as u32,
             ) {
-                return Err(Throw);
+                return Err(Throw(()));
             }
 
             for (name, method) in descriptor.methods {
@@ -196,7 +196,7 @@ pub(crate) trait ClassInternal: Class {
                     name.len() as u32,
                     method.to_raw(),
                 ) {
-                    return Err(Throw);
+                    return Err(Throw(()));
                 }
             }
 

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -168,7 +168,7 @@ pub(crate) trait ClassInternal: Class {
             );
 
             if metadata_pointer.is_null() {
-                return Err(Throw(()));
+                return Err(Throw::new());
             }
 
             // NOTE: None of the error cases below need to delete the ClassMetadata object, since the
@@ -181,7 +181,7 @@ pub(crate) trait ClassInternal: Class {
                 class_name.as_ptr(),
                 class_name.len() as u32,
             ) {
-                return Err(Throw(()));
+                return Err(Throw::new());
             }
 
             for (name, method) in descriptor.methods {
@@ -196,7 +196,7 @@ pub(crate) trait ClassInternal: Class {
                     name.len() as u32,
                     method.to_raw(),
                 ) {
-                    return Err(Throw(()));
+                    return Err(Throw::new());
                 }
             }
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -115,7 +115,7 @@ mod traits {
             if unsafe { key.set_from(&mut result, self.to_raw(), val.to_raw()) } {
                 Ok(result)
             } else {
-                Err(Throw)
+                Err(Throw(()))
             }
         }
     }
@@ -265,7 +265,7 @@ mod traits {
             if unsafe { key.set_from(cx, &mut result, self.to_raw(), val.to_raw()) } {
                 Ok(result)
             } else {
-                Err(Throw)
+                Err(Throw(()))
             }
         }
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -115,7 +115,7 @@ mod traits {
             if unsafe { key.set_from(&mut result, self.to_raw(), val.to_raw()) } {
                 Ok(result)
             } else {
-                Err(Throw(()))
+                Err(Throw::new())
             }
         }
     }
@@ -265,7 +265,7 @@ mod traits {
             if unsafe { key.set_from(cx, &mut result, self.to_raw(), val.to_raw()) } {
                 Ok(result)
             } else {
-                Err(Throw(()))
+                Err(Throw::new())
             }
         }
 

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -48,7 +48,7 @@ use std::marker::PhantomData;
 ///
 /// [unit]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#unit-like-structs-without-any-fields
 #[derive(Debug)]
-pub struct Throw(PhantomData<*mut ()>); // *mut is !Send + !Sync, making it harder to forge
+pub struct Throw(PhantomData<*mut ()>); // *mut is !Send + !Sync, making it harder to accidentally store
 
 impl Throw {
     pub(crate) fn new() -> Self {

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -37,6 +37,7 @@ use crate::context::Context;
 use crate::handle::Handle;
 use crate::types::Value;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::marker::PhantomData;
 
 /// A [unit type][unit] indicating that the JavaScript thread is throwing an exception.
 ///
@@ -47,7 +48,13 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 ///
 /// [unit]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#unit-like-structs-without-any-fields
 #[derive(Debug)]
-pub struct Throw(pub(crate) ());
+pub struct Throw(PhantomData<*mut ()>); // *mut is !Send + !Sync, making it harder to forge
+
+impl Throw {
+    pub(crate) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl Display for Throw {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -47,7 +47,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 ///
 /// [unit]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#unit-like-structs-without-any-fields
 #[derive(Debug)]
-pub struct Throw;
+pub struct Throw(pub(crate) ());
 
 impl Display for Throw {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -98,7 +98,7 @@ pub(crate) fn convert_panics<T, F: UnwindSafe + FnOnce() -> NeonResult<T>>(
                 #[cfg(feature = "napi-1")]
                 neon_runtime::error::clear_exception(env.to_raw());
                 neon_runtime::error::throw_error_from_utf8(env.to_raw(), data, len);
-                Err(Throw(()))
+                Err(Throw::new())
             }
         }
     }

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -98,7 +98,7 @@ pub(crate) fn convert_panics<T, F: UnwindSafe + FnOnce() -> NeonResult<T>>(
                 #[cfg(feature = "napi-1")]
                 neon_runtime::error::clear_exception(env.to_raw());
                 neon_runtime::error::throw_error_from_utf8(env.to_raw(), data, len);
-                Err(Throw)
+                Err(Throw(()))
             }
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -117,7 +117,7 @@ pub(crate) fn build<'a, T: Managed, F: FnOnce(&mut raw::Local) -> bool>(
         if init(&mut local) {
             Ok(Handle::new_internal(T::from_raw(env, local)))
         } else {
-            Err(Throw)
+            Err(Throw(()))
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -124,7 +124,7 @@ pub(crate) fn build<'a, T: Managed, F: FnOnce(&mut raw::Local) -> bool>(
         if init(&mut local) {
             Ok(Handle::new_internal(T::from_raw(env, local)))
         } else {
-            Err(Throw(()))
+            Err(Throw::new())
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -45,7 +45,7 @@
 //!     cx: &mut impl Context<'a>,
 //!     object: Handle<'a, JsObject>
 //! ) -> JsResult<'a, JsArray> {
-//!     object.downcast(cx).or_throw(cx)
+//!     object.downcast().or_throw(cx)
 //! }
 //! # }
 //! ```

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -45,7 +45,14 @@
 //!     cx: &mut impl Context<'a>,
 //!     object: Handle<'a, JsObject>
 //! ) -> JsResult<'a, JsArray> {
-//!     object.downcast().or_throw(cx)
+//! #   #[cfg(feature = "legacy-runtime")]
+//! #   return
+//! #   object.downcast().or_throw(cx)
+//! #   ;
+//! #   #[cfg(feature = "napi-1")]
+//! #   return
+//!     object.downcast(cx).or_throw(cx)
+//! #   ;
 //! }
 //! # }
 //! ```

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -168,7 +168,7 @@ pub fn unexpected_throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> 
     // It's hard to forge a bogus throw token, but you can still do it by
     // forcing a real throw, saving the token for later, and catching the
     // throw to return the VM back out of its throwing state.
-    let _ = cx.try_catch::<(), _>(|cx| {
+    let _ = cx.try_catch(|cx| {
         let forge: Handle<JsFunction> = JsFunction::new(cx, forge_throw)?;
         let null: Handle<JsValue> = cx.null().upcast();
         let args: Vec<Handle<JsValue>> = vec![];

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -150,17 +150,12 @@ thread_local! {
 }
 
 fn forge_throw(mut cx: FunctionContext) -> JsResult<JsValue> {
-    // Force a random JS error to temporarily enter the throwing state.
-    let v: Handle<JsValue> = cx.null().upcast();
-    match v.downcast_or_throw::<JsNumber, _>(&mut cx) {
-        Ok(_) => panic!("failed to forge throw"),
-        Err(throw) => {
-            // Save the throw token in thread-local storage.
-            FORGED_THROW.with(|forged_throw| {
-                *forged_throw.borrow_mut() = Some(throw);
-            })
-        }
-    }
+    // Force an arbitrary JS error to temporarily enter the throwing state.
+    let throw = cx.throw_error::<_, ()>("forced error").unwrap_err();
+    // Save the throw token in thread-local storage.
+    FORGED_THROW.with(|forged_throw| {
+        *forged_throw.borrow_mut() = Some(throw);
+    });
     panic!("get us out of here");
 }
 

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -176,9 +176,7 @@ pub fn unexpected_throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> 
         Ok(())
     });
 
-    let retrieved_throw = FORGED_THROW.with(|forged_throw| {
-        forged_throw.borrow_mut().take()
-    });
+    let retrieved_throw = FORGED_THROW.with(|forged_throw| forged_throw.borrow_mut().take());
 
     match retrieved_throw {
         Some(throw) => Ok(cx.try_catch(|_| Err(throw)).unwrap_or_else(|err| err)),

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use neon::object::This;
 use neon::prelude::*;
 use neon::result::Throw;
@@ -143,8 +145,45 @@ pub fn panic_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     Ok(cx.try_catch(|_| panic!("oh no")).unwrap_or_else(|err| err))
 }
 
+thread_local! {
+    static FORGED_THROW: RefCell<Option<Throw>> = RefCell::new(None);
+}
+
+fn forge_throw(mut cx: FunctionContext) -> JsResult<JsValue> {
+    // Force a random JS error to temporarily enter the throwing state.
+    let v: Handle<JsValue> = cx.null().upcast();
+    match v.downcast_or_throw::<JsNumber, _>(&mut cx) {
+        Ok(_) => panic!("failed to forge throw"),
+        Err(throw) => {
+            // Save the throw token in thread-local storage.
+            FORGED_THROW.with(|forged_throw| {
+                *forged_throw.borrow_mut() = Some(throw);
+            })
+        }
+    }
+    panic!("get us out of here");
+}
+
 pub fn unexpected_throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
-    Ok(cx.try_catch(|_| Err(Throw)).unwrap_or_else(|err| err))
+    // It's hard to forge a bogus throw token, but you can still do it by
+    // forcing a real throw, saving the token for later, and catching the
+    // throw to return the VM back out of its throwing state.
+    let _ = cx.try_catch::<(), _>(|cx| {
+        let forge: Handle<JsFunction> = JsFunction::new(cx, forge_throw)?;
+        let null: Handle<JsValue> = cx.null().upcast();
+        let args: Vec<Handle<JsValue>> = vec![];
+        forge.call(cx, null, args)?;
+        Ok(())
+    });
+
+    let retrieved_throw = FORGED_THROW.with(|forged_throw| {
+        forged_throw.borrow_mut().take()
+    });
+
+    match retrieved_throw {
+        Some(throw) => Ok(cx.try_catch(|_| Err(throw)).unwrap_or_else(|err| err)),
+        None => Ok(cx.string("failed to retrieve forged throw").upcast()),
+    }
 }
 
 pub fn downcast_error(mut cx: FunctionContext) -> JsResult<JsString> {


### PR DESCRIPTION
This PR makes it harder (though not technically impossible) to forge `Throw` tokens. We already have safety mechanisms in place in case of forged `Throw` tokens, leading to well-defined panics (as opposed to something unsafe, like undefined behavior). But this should help prevent programs from _accidentally_ saving and reusing a `Throw` token.

There is also a test case that still does show how it's technically possible to forge a token, and demonstrates that it still has predictable behavior.

An alternative that would be even safer would be to place a lifetime on a `Throw` token, making it impossible to store them in long-lived storage. But this would leak into the type signatures of e.g. `NeonResult` and APIs that use it, which would add a lot of complexity to Neon for little value. The panic is for a rare enough case that the extra type safety wouldn't be worth it IMO.

One more change I want to make in this PR is to add `!Send` phantom data to the `Throw` type so that it can't be shared outside of its thread.