### PR TITLE
Add APIs that convert between `Context` and `napi_env` 

### DIFF
--- a/src/context/ffi.rs
+++ b/src/context/ffi.rs
@@ -1,0 +1,45 @@
+use super::internal::{ContextInternal, Env, Scope, ScopeMetadata};
+use super::Context;
+use neon_runtime::raw;
+
+/// Opaque type representing the underlying env of a context
+///
+/// See `Context::with_raw_env` for details.
+#[repr(C)]
+pub struct RawEnv {
+    // Create opaque type as suggested in https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
+    _data: [u8; 0],
+    _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+impl RawEnv {
+    /// Creates a context in the env
+    pub fn with_context<T, F>(&mut self, f: F) -> T
+    where
+        F: for<'b> FnOnce(RawContext<'b>) -> T,
+    {
+        let env = unsafe { std::mem::transmute(self) };
+        RawContext::with(env, f)
+    }
+}
+
+pub struct RawContext<'a> {
+    scope: Scope<'a, raw::HandleScope>,
+}
+
+impl<'a> ContextInternal<'a> for RawContext<'a> {
+    fn scope_metadata(&self) -> &ScopeMetadata {
+        &self.scope.metadata
+    }
+}
+
+impl<'a> Context<'a> for RawContext<'a> {}
+
+impl<'a> RawContext<'a> {
+    fn with<T, F>(env: Env, f: F) -> T
+    where
+        F: for<'b> FnOnce(RawContext<'b>) -> T,
+    {
+        Scope::with(env, |scope| f(RawContext { scope }))
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -296,7 +296,7 @@ impl<'a> Lock<'a> {
 pub trait Context<'a>: ContextInternal<'a> {
     /// Get the underlying `napi-env` of the context
     #[cfg(feature = "napi-1")]
-    fn to_raw_env(&self) -> *mut c_void {
+    fn as_mut_ptr(&mut self) -> *mut c_void {
         self.env().to_raw() as *mut c_void
     }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -294,6 +294,8 @@ impl<'a> Lock<'a> {
 ///
 /// A context has a lifetime `'a`, which ensures the safety of handles managed by the JS garbage collector. All handles created during the lifetime of a context are kept alive for that duration and cannot outlive the context.
 pub trait Context<'a>: ContextInternal<'a> {
+
+    /// Get the underlying `napi-env` of the context
     #[cfg(feature = "napi-1")]
     fn to_raw_env(&self) -> *mut c_void {
         self.env().to_raw() as *mut c_void
@@ -823,6 +825,10 @@ impl<'a> TaskContext<'a> {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }
 
+    /// Constructs a context from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer `env` must be a `napi_env` that remains valid during the call of this method.
     #[cfg(feature = "napi-1")]
     pub unsafe fn with_raw_env<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(
         env: *mut c_void,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -294,6 +294,12 @@ impl<'a> Lock<'a> {
 ///
 /// A context has a lifetime `'a`, which ensures the safety of handles managed by the JS garbage collector. All handles created during the lifetime of a context are kept alive for that duration and cannot outlive the context.
 pub trait Context<'a>: ContextInternal<'a> {
+
+    #[cfg(feature = "napi-1")]
+    fn to_raw_env(&self) -> *mut c_void {
+        self.env().to_raw() as *mut c_void
+    }
+
     /// Lock the JavaScript engine, returning an RAII guard that keeps the lock active as long as the guard is alive.
     ///
     /// If this is not the currently active context (for example, if it was used to spawn a scoped context with `execute_scoped` or `compute_scoped`), this method will panic.
@@ -818,7 +824,13 @@ impl<'a> TaskContext<'a> {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }
 
-    #[cfg(all(feature = "napi-4", feature = "channel-api"))]
+    #[cfg(all(feature = "napi-1"))]
+    pub unsafe fn with_raw_env<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: *mut c_void, f: F) -> T {
+        let env = std::mem::transmute(env);
+        Self::with_context(env, f)
+    }
+
+    #[cfg(all(feature = "napi-1"))]
     pub(crate) fn with_context<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: Env, f: F) -> T {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -294,7 +294,6 @@ impl<'a> Lock<'a> {
 ///
 /// A context has a lifetime `'a`, which ensures the safety of handles managed by the JS garbage collector. All handles created during the lifetime of a context are kept alive for that duration and cannot outlive the context.
 pub trait Context<'a>: ContextInternal<'a> {
-
     #[cfg(feature = "napi-1")]
     fn to_raw_env(&self) -> *mut c_void {
         self.env().to_raw() as *mut c_void
@@ -824,13 +823,16 @@ impl<'a> TaskContext<'a> {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }
 
-    #[cfg(all(feature = "napi-1"))]
-    pub unsafe fn with_raw_env<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: *mut c_void, f: F) -> T {
+    #[cfg(feature = "napi-1")]
+    pub unsafe fn with_raw_env<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(
+        env: *mut c_void,
+        f: F,
+    ) -> T {
         let env = std::mem::transmute(env);
         Self::with_context(env, f)
     }
 
-    #[cfg(all(feature = "napi-1"))]
+    #[cfg(feature = "napi-1")]
     pub(crate) fn with_context<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: Env, f: F) -> T {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -294,7 +294,6 @@ impl<'a> Lock<'a> {
 ///
 /// A context has a lifetime `'a`, which ensures the safety of handles managed by the JS garbage collector. All handles created during the lifetime of a context are kept alive for that duration and cannot outlive the context.
 pub trait Context<'a>: ContextInternal<'a> {
-
     /// Get the underlying `napi-env` of the context
     #[cfg(feature = "napi-1")]
     fn to_raw_env(&self) -> *mut c_void {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -304,8 +304,8 @@ pub trait Context<'a>: ContextInternal<'a> {
     ///
     /// # Safety
     /// `&mut RawEnv` can be converted to `*mut void`, passed across FFI boundaries, and then
-    //  converted back to `&mut RawEnv`.
-    /// Mutable aliasing is allowed because `RawEnv` is zero-sized (https://github.com/rust-lang/rust-memory-model/issues/44),
+    ///  converted back to `&mut RawEnv`.
+    /// Mutable aliasing is allowed because `RawEnv` is zero-sized (https://rust-lang.github.io/unsafe-code-guidelines/glossary.html),
     /// but callers are still responsible for upholding other borrowing rules.
     #[cfg(feature = "napi-1")]
     fn with_raw_env<T, F>(&mut self, f: F) -> T

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -107,6 +107,15 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         .collect::<Result<Vec<_>, _>>()?;
     assert_eq!(property_names, &["0", "a", "whatever"]);
 
+    let raw_env = cx.to_raw_env();
+    let forty_two = unsafe {
+        TaskContext::with_raw_env(raw_env, |mut cx| {
+            let forty_two = cx.number(42);
+            forty_two.value(&mut cx)
+        })
+    };
+    assert_eq!(forty_two, 42f64);
+
     cx.export_value("rustCreated", rust_created)?;
 
     fn add1(mut cx: FunctionContext) -> JsResult<JsNumber> {

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -111,10 +111,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     let forty_two = unsafe {
         TaskContext::with_raw_env(raw_env, |mut cx| {
             let forty_two = cx.number(42);
-            forty_two.value(&mut cx)
+            forty_two.value(&mut cx) as u8
         })
     };
-    assert_eq!(forty_two, 42f64);
+    assert_eq!(forty_two, 42);
 
     cx.export_value("rustCreated", rust_created)?;
 

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -107,7 +107,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         .collect::<Result<Vec<_>, _>>()?;
     assert_eq!(property_names, &["0", "a", "whatever"]);
 
-    let raw_env = cx.to_raw_env();
+    let raw_env = cx.as_mut_ptr();
     let forty_two = unsafe {
         TaskContext::with_raw_env(raw_env, |mut cx| {
             let forty_two = cx.number(42);


### PR DESCRIPTION
Closes #611.

`with_raw_env` is useful when neon is not used as the "entry" of a native module, so after getting a raw `napi_env` we need the unsafe API to bootstrap a `neon::Context`.

