### PR TITLE
fix(neon-runtime): Catch panics in `Channel::send` callbacks and convert to `uncaughtException`

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -202,6 +202,17 @@ mod napi1 {
     );
 }
 
+#[cfg(feature = "napi-3")]
+mod napi3 {
+    use super::super::types::*;
+
+    generate!(
+        extern "C" {
+            fn fatal_exception(env: Env, err: Value) -> Status;
+        }
+    );
+}
+
 #[cfg(feature = "napi-4")]
 mod napi4 {
     use super::super::types::*;
@@ -285,6 +296,8 @@ mod napi6 {
 }
 
 pub(crate) use napi1::*;
+#[cfg(feature = "napi-3")]
+pub(crate) use napi3::*;
 #[cfg(feature = "napi-4")]
 pub(crate) use napi4::*;
 #[cfg(feature = "napi-5")]
@@ -315,6 +328,9 @@ pub(crate) unsafe fn load(env: Env) -> Result<(), libloading::Error> {
     let version = get_version(&host, env).expect("Failed to find N-API version");
 
     napi1::load(&host, version, 1)?;
+
+    #[cfg(feature = "napi-3")]
+    napi3::load(&host, version, 3)?;
 
     #[cfg(feature = "napi-4")]
     napi4::load(&host, version, 4)?;

--- a/test/napi/src/js/threads.rs
+++ b/test/napi/src/js/threads.rs
@@ -185,3 +185,10 @@ pub fn drop_global_queue(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 
     Ok(cx.undefined())
 }
+
+pub fn panic_in_channel(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    cx.channel()
+        .send(|_| panic!("Panicked in channel callback"));
+
+    Ok(cx.undefined())
+}

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -257,6 +257,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("greeter_greet", greeter_greet)?;
     cx.export_function("leak_channel", leak_channel)?;
     cx.export_function("drop_global_queue", drop_global_queue)?;
+    cx.export_function("panic_in_channel", panic_in_channel)?;
 
     Ok(())
 }


### PR DESCRIPTION
Panic unwinding across FFI is undefined behavior. Neon must catch panics in threadsafe function callbacks. A best effort is made to convert the panic message to an `uncaughtException`, but if unable, it will be printed to stderr.

`napi_fatal_exception` is only available in Node-API 3+, but since `napi_threadsafe_function` is only in Node-API 4+, we don't need any special handling.