### PR TITLE
fix(neon): Fix undefined behavior in channel callbacks when there is a panic

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -226,6 +226,24 @@ mod napi1 {
             fn create_promise(env: Env, deferred: *mut Deferred, promise: *mut Value) -> Status;
             fn resolve_deferred(env: Env, deferred: Deferred, resolution: Value) -> Status;
             fn reject_deferred(env: Env, deferred: Deferred, rejection: Value) -> Status;
+
+            fn fatal_error(
+                location: *const c_char,
+                location_len: usize,
+                message: *const c_char,
+                message_len: usize,
+            );
+        }
+    );
+}
+
+#[cfg(feature = "napi-3")]
+mod napi3 {
+    use super::super::types::*;
+
+    generate!(
+        extern "C" {
+            fn fatal_exception(env: Env, err: Value) -> Status;
         }
     );
 }
@@ -313,6 +331,8 @@ mod napi6 {
 }
 
 pub(crate) use napi1::*;
+#[cfg(feature = "napi-3")]
+pub(crate) use napi3::*;
 #[cfg(feature = "napi-4")]
 pub(crate) use napi4::*;
 #[cfg(feature = "napi-5")]
@@ -343,6 +363,9 @@ pub(crate) unsafe fn load(env: Env) -> Result<(), libloading::Error> {
     let version = get_version(&host, env).expect("Failed to find N-API version");
 
     napi1::load(&host, version, 1)?;
+
+    #[cfg(feature = "napi-3")]
+    napi3::load(&host, version, 3)?;
 
     #[cfg(feature = "napi-4")]
     napi4::load(&host, version, 4)?;

--- a/crates/neon-runtime/src/napi/bindings/mod.rs
+++ b/crates/neon-runtime/src/napi/bindings/mod.rs
@@ -107,13 +107,13 @@ macro_rules! napi_name {
 /// ```
 macro_rules! generate {
     (extern "C" {
-        $(fn $name:ident($($param:ident: $ptype:ty$(,)?)*) -> $rtype:ty;)+
+        $(fn $name:ident($($param:ident: $ptype:ty$(,)?)*)$( -> $rtype:ty)?;)+
     }) => {
         pub(crate) struct Napi {
             $(
                 $name: unsafe extern "C" fn(
                     $($param: $ptype,)*
-                ) -> $rtype,
+                )$( -> $rtype)*,
             )*
         }
 
@@ -124,7 +124,7 @@ macro_rules! generate {
 
         static mut NAPI: Napi = {
             $(
-                unsafe extern "C" fn $name($(_: $ptype,)*) -> $rtype {
+                unsafe extern "C" fn $name($(_: $ptype,)*)$( -> $rtype)* {
                     panic_load()
                 }
             )*
@@ -159,7 +159,7 @@ macro_rules! generate {
 
         $(
             #[inline]
-            pub(crate) unsafe fn $name($($param: $ptype,)*) -> $rtype {
+            pub(crate) unsafe fn $name($($param: $ptype,)*)$( -> $rtype)* {
                 (NAPI.$name)($($param,)*)
             }
         )*

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -260,6 +260,14 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("sum_manual_promise", sum_manual_promise)?;
     cx.export_function("sum_rust_thread", sum_rust_thread)?;
     cx.export_function("leak_promise", leak_promise)?;
+    cx.export_function("channel_panic", channel_panic)?;
+    cx.export_function("channel_throw", channel_throw)?;
+    cx.export_function("channel_panic_throw", channel_panic_throw)?;
+    cx.export_function("channel_custom_panic", channel_custom_panic)?;
+    cx.export_function(
+        "channel_custom_panic_downcast",
+        channel_custom_panic_downcast,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

* Catches panics and converts to uncaughtException
* Throws uncaughtException if throwing
* Passes opaque exceptions through as JsBox

## Significant Changes

* Return `Err(Throw)` in `Channel::send` no longer *disappears*. Instead it will cause an `uncaughtException`
* Panicking in `Channel::send` is no longer undefined behavior. Instead it will cause an `uncaughtException`

## What

`uncaughtException` in pseudo code look like:

```js
const error = new Error("General neon message describing that there was an exception and/or panic");

// Exception was thrown while executing
if (exception) {
    error.cause = exception;
}

// Panic occurred while executing
if (panic) {
    // We were able to downcast the panic as a `String` or `&str`
    if (panicMsg) {
        error.panic = new Error(panicMsg);
    } else {
        error.panic = new Error("Unknown panic");
        error.panic.cause = JsBox(panic);
    }
}
```

```ts
interface UncaughtException extends Error {
    message: string;
    
    cause?: Error;

    panic?: Error & {
        cause?: JsBox
    };
}
```