### PR TITLE
Create functions from closures

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -290,6 +290,7 @@ mod napi4 {
 #[cfg(feature = "napi-5")]
 mod napi5 {
     use super::super::types::*;
+    use std::ffi::c_void;
 
     generate!(
         extern "C" {
@@ -298,6 +299,15 @@ mod napi5 {
             fn get_date_value(env: Env, value: Value, result: *mut f64) -> Status;
 
             fn is_date(env: Env, value: Value, result: *mut bool) -> Status;
+
+            fn add_finalizer(
+                env: Env,
+                js_object: Value,
+                native_object: *mut c_void,
+                finalize_cb: Finalize,
+                finalize_hint: *mut c_void,
+                result: Ref,
+            ) -> Status;
         }
     );
 }

--- a/crates/neon-runtime/src/napi/call.rs
+++ b/crates/neon-runtime/src/napi/call.rs
@@ -42,21 +42,6 @@ impl Arguments {
     }
 }
 
-#[repr(C)]
-pub struct CCallback {
-    pub static_callback: *mut c_void,
-    pub dynamic_callback: *mut c_void,
-}
-
-impl Default for CCallback {
-    fn default() -> Self {
-        CCallback {
-            static_callback: null_mut(),
-            dynamic_callback: null_mut(),
-        }
-    }
-}
-
 pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
     let mut target: MaybeUninit<Local> = MaybeUninit::zeroed();
 

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -51,12 +51,17 @@ where
             ptr::null_mut(),
         );
 
+        // If adding the finalizer fails the closure will leak, but it would
+        // be unsafe to drop it because there's no guarantee V8 won't use the
+        // pointer.
         assert_eq!(status, napi::Status::Ok);
     }
 
     Ok(out)
 }
 
+// C ABI compatible function for invoking a boxed closure from the data field
+// of a Node-API JavaScript function
 unsafe extern "C" fn call_boxed<F>(env: Env, info: napi::CallbackInfo) -> Local
 where
     F: Fn(Env, napi::CallbackInfo) -> Local + 'static,

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -9,7 +9,7 @@ use crate::raw::{Env, Local};
 
 pub unsafe fn new<F>(env: Env, name: &str, callback: F) -> Result<Local, napi::Status>
 where
-    F: Fn(Env, napi::CallbackInfo) -> Local + Send + 'static,
+    F: Fn(Env, napi::CallbackInfo) -> Local + 'static,
 {
     let mut out = MaybeUninit::uninit();
     let data = Box::into_raw(Box::new(callback));
@@ -59,7 +59,7 @@ where
 
 unsafe extern "C" fn call_boxed<F>(env: Env, info: napi::CallbackInfo) -> Local
 where
-    F: Fn(Env, napi::CallbackInfo) -> Local + Send + 'static,
+    F: Fn(Env, napi::CallbackInfo) -> Local + 'static,
 {
     let mut data = MaybeUninit::uninit();
     let status = napi::get_cb_info(

--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -1,29 +1,81 @@
 //! Facilities for working with JS functions.
 
+use std::mem::MaybeUninit;
 use std::os::raw::c_void;
-use std::ptr::null;
+use std::ptr;
 
-use crate::call::CCallback;
 use crate::napi::bindings as napi;
 use crate::raw::{Env, Local};
 
-/// Mutates the `out` argument provided to refer to a newly created `v8::Function`. Returns
-/// `false` if the value couldn't be created.
-pub unsafe fn new(out: &mut Local, env: Env, callback: CCallback) -> bool {
+pub unsafe fn new<F>(env: Env, name: &str, callback: F) -> Result<Local, napi::Status>
+where
+    F: Fn(Env, napi::CallbackInfo) -> Local + Send + 'static,
+{
+    let mut out = MaybeUninit::uninit();
+    let data = Box::into_raw(Box::new(callback));
     let status = napi::create_function(
         env,
-        null(),
-        0,
-        Some(std::mem::transmute(callback.static_callback)),
-        callback.dynamic_callback,
-        out as *mut Local,
+        name.as_ptr().cast(),
+        name.len(),
+        Some(call_boxed::<F>),
+        data.cast(),
+        out.as_mut_ptr(),
     );
 
-    status == napi::Status::Ok
+    if status == napi::Status::PendingException {
+        Box::from_raw(data);
+
+        return Err(status);
+    }
+
+    assert_eq!(status, napi::Status::Ok);
+
+    let out = out.assume_init();
+
+    #[cfg(feature = "napi-5")]
+    {
+        unsafe extern "C" fn drop_function<F>(
+            _env: Env,
+            _finalize_data: *mut c_void,
+            finalize_hint: *mut c_void,
+        ) {
+            Box::from_raw(finalize_hint.cast::<F>());
+        }
+
+        let status = napi::add_finalizer(
+            env,
+            out,
+            ptr::null_mut(),
+            Some(drop_function::<F>),
+            data.cast(),
+            ptr::null_mut(),
+        );
+
+        assert_eq!(status, napi::Status::Ok);
+    }
+
+    Ok(out)
 }
 
-pub unsafe fn get_dynamic_callback(_env: Env, data: *mut c_void) -> *mut c_void {
-    data
+unsafe extern "C" fn call_boxed<F>(env: Env, info: napi::CallbackInfo) -> Local
+where
+    F: Fn(Env, napi::CallbackInfo) -> Local + Send + 'static,
+{
+    let mut data = MaybeUninit::uninit();
+    let status = napi::get_cb_info(
+        env,
+        info,
+        ptr::null_mut(),
+        ptr::null_mut(),
+        ptr::null_mut(),
+        data.as_mut_ptr(),
+    );
+
+    assert_eq!(status, napi::Status::Ok);
+
+    let callback = &*data.assume_init().cast::<F>();
+
+    callback(env, info)
 }
 
 pub unsafe fn call(

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -722,7 +722,7 @@ impl<'a> ModuleContext<'a> {
     /// Convenience method for exporting a Neon function from a module.
     pub fn export_function<F, V>(&mut self, key: &str, f: F) -> NeonResult<()>
     where
-        F: Fn(FunctionContext) -> JsResult<V> + Send + 'static,
+        F: Fn(FunctionContext) -> JsResult<V> + 'static,
         V: Value,
     {
         let value = JsFunction::new(self, f)?.upcast::<JsValue>();

--- a/src/types/internal.rs
+++ b/src/types/internal.rs
@@ -1,13 +1,17 @@
 use super::Value;
 use crate::context::internal::Env;
-use crate::context::{CallbackInfo, FunctionContext};
+#[cfg(feature = "legacy-runtime")]
+use crate::context::CallbackInfo;
+#[cfg(feature = "legacy-runtime")]
+use crate::context::FunctionContext;
+#[cfg(feature = "legacy-runtime")]
 use crate::result::JsResult;
-use crate::types::error::convert_panics;
-use crate::types::{Handle, JsObject, Managed};
+use crate::types::{Handle, Managed};
 use neon_runtime;
+#[cfg(feature = "legacy-runtime")]
 use neon_runtime::call::CCallback;
 use neon_runtime::raw;
-use std::mem;
+#[cfg(feature = "legacy-runtime")]
 use std::os::raw::c_void;
 
 pub trait ValueInternal: Managed + 'static {
@@ -28,47 +32,24 @@ pub trait ValueInternal: Managed + 'static {
     }
 }
 
+#[cfg(feature = "legacy-runtime")]
 #[repr(C)]
 pub struct FunctionCallback<T: Value>(pub fn(FunctionContext) -> JsResult<T>);
 
 #[cfg(feature = "legacy-runtime")]
 impl<T: Value> Callback<()> for FunctionCallback<T> {
     extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) {
+        use crate::types::error::convert_panics;
+        use crate::types::JsObject;
+
         unsafe {
             info.with_cx::<JsObject, _, _>(env, |cx| {
                 let data = info.data(env);
-                let dynamic_callback: fn(FunctionContext) -> JsResult<T> =
-                    mem::transmute(neon_runtime::fun::get_dynamic_callback(env.to_raw(), data));
+                let dynamic_callback: fn(FunctionContext) -> JsResult<T> = std::mem::transmute(
+                    neon_runtime::fun::get_dynamic_callback(env.to_raw(), data),
+                );
                 if let Ok(value) = convert_panics(env, || dynamic_callback(cx)) {
                     info.set_return(value);
-                }
-            })
-        }
-    }
-
-    fn into_ptr(self) -> *mut c_void {
-        self.0 as *mut _
-    }
-}
-
-#[cfg(feature = "napi-1")]
-impl<T: Value> Callback<raw::Local> for FunctionCallback<T> {
-    extern "C" fn invoke(env: Env, info: CallbackInfo<'_>) -> raw::Local {
-        unsafe {
-            info.with_cx::<JsObject, _, _>(env, |cx| {
-                let data = info.data(env);
-                let dynamic_callback: fn(FunctionContext) -> JsResult<T> =
-                    mem::transmute(neon_runtime::fun::get_dynamic_callback(env.to_raw(), data));
-                if let Ok(value) = convert_panics(env, || dynamic_callback(cx)) {
-                    value.to_raw()
-                } else {
-                    // We do not have a Js Value to return, most likely due to an exception.
-                    // If we are in a throwing state, constructing a Js Value would be invalid.
-                    // While not explicitly written, the N-API documentation includes many examples
-                    // of returning `NULL` when a native function does not return a value.
-                    // Note, `raw::Local` in this context is a type alias for `*mut napi_value` and not a struct
-                    // https://nodejs.org/api/n-api.html#n_api_napi_create_function
-                    std::ptr::null_mut()
                 }
             })
         }
@@ -83,6 +64,7 @@ impl<T: Value> Callback<raw::Local> for FunctionCallback<T> {
 /// This type makes it possible to export a dynamically computed Rust function
 /// as a pair of 1) a raw pointer to the dynamically computed function, and 2)
 /// a static function that knows how to transmute that raw pointer and call it.
+#[cfg(feature = "legacy-runtime")]
 pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
     /// Extracts the computed Rust function and invokes it. The Neon runtime
     /// ensures that the computed function is provided as the extra data field,
@@ -91,8 +73,6 @@ pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
 
     /// See `invoke`. This is used by the non-n-api implementation, so that every impl for this
     /// trait doesn't need to provide two versions of `invoke`.
-    #[cfg(feature = "legacy-runtime")]
-    #[doc(hidden)]
     extern "C" fn invoke_compat(info: CallbackInfo<'_>) -> T {
         Self::invoke(Env::current(), info)
     }
@@ -103,12 +83,8 @@ pub(crate) trait Callback<T: Clone + Copy + Sized>: Sized {
     /// Exports the callback as a pair consisting of the static `Self::invoke`
     /// method and the computed callback, both converted to raw void pointers.
     fn into_c_callback(self) -> CCallback {
-        #[cfg(feature = "napi-1")]
-        let invoke = Self::invoke;
-        #[cfg(feature = "legacy-runtime")]
-        let invoke = Self::invoke_compat;
         CCallback {
-            static_callback: unsafe { mem::transmute(invoke as usize) },
+            static_callback: unsafe { std::mem::transmute(Self::invoke_compat as usize) },
             dynamic_callback: self.into_ptr(),
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -773,7 +773,12 @@ impl JsFunction {
             FunctionContext::with(env, &info, |cx| {
                 convert_panics(env, AssertUnwindSafe(|| f(cx)))
                     .map(|v| v.to_raw())
-                    .unwrap_or_else(|_| ptr::null_mut())
+                    // We do not have a Js Value to return, most likely due to an exception.
+                    // If we are in a throwing state, constructing a Js Value would be invalid.
+                    // While not explicitly written, the Node-API documentation includes many examples
+                    // of returning `NULL` when a native function does not return a value.
+                    // https://nodejs.org/api/n-api.html#n_api_napi_create_function
+                    .unwrap_or_else(|_: Throw| ptr::null_mut())
             })
         };
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -745,7 +745,7 @@ impl JsFunction {
     pub fn new<'a, C, F, V>(cx: &mut C, f: F) -> JsResult<'a, JsFunction>
     where
         C: Context<'a>,
-        F: Fn(FunctionContext) -> JsResult<V> + Send + 'static,
+        F: Fn(FunctionContext) -> JsResult<V> + 'static,
         V: Value,
     {
         Self::new_internal(cx, f)
@@ -755,7 +755,7 @@ impl JsFunction {
     fn new_internal<'a, C, F, V>(cx: &mut C, f: F) -> JsResult<'a, JsFunction>
     where
         C: Context<'a>,
-        F: Fn(FunctionContext) -> JsResult<V> + Send + 'static,
+        F: Fn(FunctionContext) -> JsResult<V> + 'static,
         V: Value,
     {
         use std::any;

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -120,6 +120,8 @@ describe('JsFunction', function() {
   });
 
   (global.gc ? it : it.skip)('should drop function when going out of scope', function(cb) {
+    // Run from an `IIFE` to ensure that `f` is out of scope and eligible for garbage
+    // collection when `global.gc()` is executed.
     (() => {
       const msg = "Hello, World!";
       const f = addon.caller_with_drop_callback(() => msg, cb);

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -114,4 +114,19 @@ describe('JsFunction', function() {
     assert.equal(addon.is_construct.call({}).wasConstructed, false);
     assert.equal((new addon.is_construct()).wasConstructed, true);
   });
+
+  it('should be able to call a function from a closure', function() {
+    assert.strictEqual(addon.count_called() + 1, addon.count_called());
+  });
+
+  (global.gc ? it : it.skip)('should drop function when going out of scope', function(cb) {
+    (() => {
+      const msg = "Hello, World!";
+      const f = addon.caller_with_drop_callback(() => msg, cb);
+
+      assert.strictEqual(f(), msg);
+    })();
+
+    global.gc();
+  });
 });

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -232,6 +232,17 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("call_and_catch", call_and_catch)?;
     cx.export_function("get_number_or_default", get_number_or_default)?;
     cx.export_function("is_construct", is_construct)?;
+    cx.export_function("caller_with_drop_callback", caller_with_drop_callback)?;
+
+    cx.export_function("count_called", {
+        let n = std::cell::RefCell::new(0);
+
+        move |mut cx| {
+            *n.borrow_mut() += 1;
+
+            Ok(cx.number(*n.borrow()))
+        }
+    })?;
 
     fn call_get_own_property_names(mut cx: FunctionContext) -> JsResult<JsArray> {
         let object = cx.argument::<JsObject>(0)?;


### PR DESCRIPTION
## What

Allow Neon users to create functions from closures.

```rust
    cx.export_function("count_called", {
        let n = std::cell::RefCell::new(0);

        move |mut cx| {
            *n.borrow_mut() += 1;

            Ok(cx.number(*n.borrow()))
        }
    })?;
```

## How

The closure is boxed and added as data. It works very similar to the current functions except the trampoline function is generic.

Dropping the Rust closure requires [`napi_add_finalizer`](https://nodejs.org/api/n-api.html#n_api_napi_add_finalizer) which was added in Node-API 5. For this reason, when using older Node-API versions, only `fn` instead of `Fn` are accepted.

## Future Expansion

It would be unsound to accept `FnMut` because a function may be reentrant. A function could trivially accept a reference to itself and then call that function. However, it is very cumbersome to use `RefCell` to get access to mutable state.

Since most functions will *not* have any possibility for reentrancy and since closure lifetime inference is very limited in Rust, it would be useful for Neon to provide a `JsFunction::new_mut` that accepts an `FnMut` and wraps it in a `RefCell`.
