### PR TITLE
Use syn-mid instead of syn + "full"

### DIFF
--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -15,4 +15,5 @@ napi = []
 
 [dependencies]
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = "1"
+syn-mid = "0.5"

--- a/crates/neon-macros/src/legacy.rs
+++ b/crates/neon-macros/src/legacy.rs
@@ -2,7 +2,7 @@ pub(crate) fn main(
     _attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let input = syn::parse_macro_input!(item as syn_mid::ItemFn);
 
     let attrs = &input.attrs;
     let vis = &input.vis;

--- a/crates/neon-macros/src/napi.rs
+++ b/crates/neon-macros/src/napi.rs
@@ -2,7 +2,7 @@ pub(crate) fn main(
     _attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let input = syn::parse_macro_input!(item as syn_mid::ItemFn);
 
     let attrs = &input.attrs;
     let vis = &input.vis;


### PR DESCRIPTION
Neon's use of syn is for the `#[neon::main]` macro, but that doesn't actually have to parse the function body to do its work. [syn-mid](https://docs.rs/syn-mid/) treats the body as an opaque blob, which should be a little faster.