### PR TITLE
Simplify `call` and `construct` to only take a `AsRef<Handle<JsValue>>` that can be directly passed to args

### DIFF
--- a/crates/neon-runtime/src/napi/fun.rs
+++ b/crates/neon-runtime/src/napi/fun.rs
@@ -32,7 +32,7 @@ pub unsafe fn call(
     fun: Local,
     this: Local,
     argc: i32,
-    argv: *mut c_void,
+    argv: *const c_void,
 ) -> bool {
     let status = napi::call_function(
         env,
@@ -51,7 +51,7 @@ pub unsafe fn construct(
     env: Env,
     fun: Local,
     argc: i32,
-    argv: *mut c_void,
+    argv: *const c_void,
 ) -> bool {
     let status = napi::new_instance(env, fun, argc as usize, argv as *const _, out as *mut _);
 

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -206,14 +206,14 @@ extern "C" {
         fun: Local,
         this: Local,
         argc: i32,
-        argv: *mut c_void,
+        argv: *const c_void,
     ) -> bool;
     pub fn Neon_Fun_Construct(
         out: &mut Local,
         isolate: Isolate,
         fun: Local,
         argc: i32,
-        argv: *mut c_void,
+        argv: *const c_void,
     ) -> bool;
 
     pub fn Neon_Mem_SameHandle(h1: Local, h2: Local) -> bool;

--- a/src/event/event_handler.rs
+++ b/src/event/event_handler.rs
@@ -47,7 +47,11 @@ impl EventHandler {
         F: Send + 'static,
     {
         self.schedule_with(move |cx, this, callback| {
-            let args = arg_cb(cx);
+            let args = arg_cb(cx)
+                .into_iter()
+                .map(|v| v.upcast())
+                .collect::<smallvec::SmallVec<[_; 4]>>();
+
             let _result = callback.call(cx, this, args);
         })
     }

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -109,6 +109,11 @@ pub trait Class: Managed + Any {
         AS: IntoIterator<Item = Handle<'b, A>>,
     {
         let constructor = Self::constructor(cx)?;
+        let args = args
+            .into_iter()
+            .map(|v| v.upcast())
+            .collect::<smallvec::SmallVec<[_; 4]>>();
+
         constructor.construct(cx, args)
     }
 

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -13,7 +13,7 @@ pub fn return_js_function(mut cx: FunctionContext) -> JsResult<JsFunction> {
 
 pub fn call_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let f = cx.argument::<JsFunction>(0)?;
-    let args: Vec<Handle<JsNumber>> = vec![cx.number(16.0)];
+    let args = [cx.number(16.0).upcast()];
     let null = cx.null();
     f.call(&mut cx, null, args)?
         .downcast::<JsNumber>()
@@ -23,7 +23,7 @@ pub fn call_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
 pub fn construct_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let f = cx.argument::<JsFunction>(0)?;
     let zero = cx.number(0.0);
-    let o = f.construct(&mut cx, vec![zero])?;
+    let o = f.construct(&mut cx, [zero.upcast()])?;
     let get_utc_full_year_method = o
         .get(&mut cx, "getUTCFullYear")?
         .downcast::<JsFunction>()

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -12,7 +12,7 @@ pub fn return_js_function(mut cx: FunctionContext) -> JsResult<JsFunction> {
 
 pub fn call_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let f = cx.argument::<JsFunction>(0)?;
-    let args: Vec<Handle<JsNumber>> = vec![cx.number(16.0)];
+    let args = [cx.number(16.0).upcast()];
     let null = cx.null();
     f.call(&mut cx, null, args)?
         .downcast::<JsNumber, _>(&mut cx)
@@ -22,7 +22,7 @@ pub fn call_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
 pub fn construct_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let f = cx.argument::<JsFunction>(0)?;
     let zero = cx.number(0.0);
-    let o = f.construct(&mut cx, vec![zero])?;
+    let o = f.construct(&mut cx, [zero.upcast()])?;
     let get_utc_full_year_method = o
         .get(&mut cx, "getUTCFullYear")?
         .downcast::<JsFunction, _>(&mut cx)

--- a/test/napi/src/js/threads.rs
+++ b/test/napi/src/js/threads.rs
@@ -45,7 +45,7 @@ pub fn multi_threaded_callback(mut cx: FunctionContext) -> JsResult<JsUndefined>
             channel.send(move |mut cx| {
                 let callback = callback.into_inner(&mut cx);
                 let this = cx.undefined();
-                let args = vec![cx.number(i as f64)];
+                let args = [cx.number(i as f64).upcast()];
 
                 callback.call(&mut cx, this, args)?;
 
@@ -78,7 +78,7 @@ impl AsyncGreeter {
             channel.send(|mut cx| {
                 let callback = callback.into_inner(&mut cx);
                 let this = cx.undefined();
-                let args = vec![cx.string(greeting)];
+                let args = [cx.string(greeting).upcast()];
 
                 callback.call(&mut cx, this, args)?;
 
@@ -163,7 +163,7 @@ pub fn drop_global_queue(mut cx: FunctionContext) -> JsResult<JsUndefined> {
                 self.channel.send(|mut cx| {
                     let callback = callback.into_inner(&mut cx);
                     let this = cx.undefined();
-                    let args = vec![cx.undefined()];
+                    let args = [cx.undefined().upcast()];
 
                     callback.call(&mut cx, this, args)?;
 
@@ -207,7 +207,7 @@ pub fn channel_join(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 
                 get_message
                     .into_inner(&mut cx)
-                    .call::<_, _, JsValue, _>(&mut cx, this, [])?
+                    .call(&mut cx, this, [])?
                     .downcast_or_throw::<JsString, _>(&mut cx)
                     .map(|v| v.value(&mut cx))
             })
@@ -220,7 +220,7 @@ pub fn channel_join(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         // Call back to JavaScript with the response
         channel.send(move |mut cx| {
             let this = cx.undefined();
-            let args = [cx.string(response)];
+            let args = [cx.string(response).upcast()];
 
             callback.into_inner(&mut cx).call(&mut cx, this, args)?;
 


### PR DESCRIPTION
A future PR will add a high level builder API for calling functions. In order to maintain a low level, high performance API, the existing APIs have been adapted to not require unnecessary allocation.

I went with `AsRef<[u8]>` so that `Vec` could be passed directly since this is an existing common pattern. The downside is that it could result in code bloat from monomorphization if many sized arrays are passed. We could minimize this later by moving the body of the function externally--this is a common pattern in `std`.