### PR TITLE
Copy safety

### DIFF
--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -7,7 +7,7 @@ use std::ptr::null_mut;
 /// `Local` handles get associated to a V8 `HandleScope` container. Note: Node.js creates a
 /// `HandleScope` right before calling functions in native addons.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Local {
     pub handle: *mut c_void,
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -714,7 +714,7 @@ impl<'a> ModuleContext<'a> {
         f: fn(FunctionContext) -> JsResult<T>,
     ) -> NeonResult<()> {
         let value = JsFunction::new(self, f)?.upcast::<JsValue>();
-        self.exports.set(self, key, value)?;
+        self.exports.clone().set(self, key, value)?;
         Ok(())
     }
 
@@ -726,7 +726,9 @@ impl<'a> ModuleContext<'a> {
         V: Value,
     {
         let value = JsFunction::new(self, f)?.upcast::<JsValue>();
-        self.exports.set(self, key, value)?;
+        // Note: Cloning `exports` is necessary to avoid holding a shared reference to
+        // `self` while attempting to use it mutably in `set`.
+        self.exports.clone().set(self, key, value)?;
         Ok(())
     }
 
@@ -734,13 +736,13 @@ impl<'a> ModuleContext<'a> {
     /// Convenience method for exporting a Neon class constructor from a module.
     pub fn export_class<T: Class>(&mut self, key: &str) -> NeonResult<()> {
         let constructor = T::constructor(self)?;
-        self.exports.set(self, key, constructor)?;
+        self.exports.clone().set(self, key, constructor)?;
         Ok(())
     }
 
     /// Exports a JavaScript value from a Neon module.
     pub fn export_value<T: Value>(&mut self, key: &str, val: Handle<T>) -> NeonResult<()> {
-        self.exports.set(self, key, val)?;
+        self.exports.clone().set(self, key, val)?;
         Ok(())
     }
 

--- a/src/handle/internal.rs
+++ b/src/handle/internal.rs
@@ -1,5 +1,30 @@
+use std::fmt::Debug;
+use std::mem;
+
 use crate::types::Value;
 
 pub trait SuperType<T: Value> {
-    fn upcast_internal(v: T) -> Self;
+    fn upcast_internal(v: &T) -> Self;
+}
+
+#[doc(hidden)]
+/// Trait asserting that `Self` is a transparent wrapper around `Self::Inner`
+/// with identical representation and may be safely transmuted.
+///
+/// # Safety
+/// `Self` must be `#[repr(transparent)]` with a field `Self::Inner`
+pub unsafe trait TransparentNoCopyWrapper: Sized {
+    type Inner: Debug + Copy;
+
+    // A default implementation cannot be provided because it would create
+    // dependently sized types. This may be supported in a future Rust version.
+    fn into_inner(self) -> Self::Inner;
+
+    fn wrap_ref(s: &Self::Inner) -> &Self {
+        unsafe { mem::transmute(s) }
+    }
+
+    fn wrap_mut(s: &mut Self::Inner) -> &mut Self {
+        unsafe { mem::transmute(s) }
+    }
 }

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -58,7 +58,7 @@ pub(crate) mod root;
 #[cfg(feature = "napi-1")]
 pub use self::root::Root;
 
-use self::internal::SuperType;
+use self::internal::{SuperType, TransparentNoCopyWrapper};
 use crate::context::internal::Env;
 use crate::context::Context;
 use crate::result::{JsResult, JsResultExt};
@@ -68,20 +68,23 @@ use neon_runtime::raw;
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 use std::marker::PhantomData;
+use std::mem;
 use std::ops::{Deref, DerefMut};
 
 /// The trait of data owned by the JavaScript engine and that can only be accessed via handles.
-pub trait Managed: Copy {
-    fn to_raw(self) -> raw::Local;
+pub trait Managed: TransparentNoCopyWrapper {
+    fn to_raw(&self) -> raw::Local;
 
     fn from_raw(env: Env, h: raw::Local) -> Self;
 }
 
 /// A handle to a JavaScript value that is owned by the JavaScript engine.
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
+#[repr(transparent)]
 pub struct Handle<'a, T: Managed + 'a> {
-    value: T,
+    // Contains the actual `Copy` JavaScript value data. It will be wrapped in
+    // in a `!Copy` type when dereferencing. Only `T` should be visible to the user.
+    value: <T as TransparentNoCopyWrapper>::Inner,
     phantom: PhantomData<&'a T>,
 }
 
@@ -95,10 +98,21 @@ impl<'a, T: Managed + 'a> PartialEq for Handle<'a, T> {
 #[cfg(feature = "legacy-runtime")]
 impl<'a, T: Managed + 'a> Eq for Handle<'a, T> {}
 
+impl<'a, T: Managed> Clone for Handle<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: Managed> Copy for Handle<'a, T> {}
+
 impl<'a, T: Managed + 'a> Handle<'a, T> {
     pub(crate) fn new_internal(value: T) -> Handle<'a, T> {
         Handle {
-            value,
+            value: value.into_inner(),
             phantom: PhantomData,
         }
     }
@@ -151,7 +165,7 @@ impl<'a, T: Value> Handle<'a, T> {
     ///
     /// This method does not require an execution context because it only copies a handle.
     pub fn upcast<U: Value + SuperType<T>>(&self) -> Handle<'a, U> {
-        Handle::new_internal(SuperType::upcast_internal(self.value))
+        Handle::new_internal(SuperType::upcast_internal(self.deref()))
     }
 
     #[cfg(feature = "legacy-runtime")]
@@ -170,7 +184,7 @@ impl<'a, T: Value> Handle<'a, T> {
     /// # }
     /// ```
     pub fn is_a<U: Value>(&self) -> bool {
-        U::is_typeof(Env::current(), self.value)
+        U::is_typeof(Env::current(), self.deref())
     }
 
     #[cfg(feature = "napi-1")]
@@ -189,7 +203,7 @@ impl<'a, T: Value> Handle<'a, T> {
     /// # }
     /// ```
     pub fn is_a<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> bool {
-        U::is_typeof(cx.env(), self.value)
+        U::is_typeof(cx.env(), self.deref())
     }
 
     #[cfg(feature = "legacy-runtime")]
@@ -198,7 +212,7 @@ impl<'a, T: Value> Handle<'a, T> {
     /// continue interacting with the JS engine if this method produces an `Err`
     /// result.
     pub fn downcast<U: Value>(&self) -> DowncastResult<'a, T, U> {
-        match U::downcast(Env::current(), self.value) {
+        match U::downcast(Env::current(), self.deref()) {
             Some(v) => Ok(Handle::new_internal(v)),
             None => Err(DowncastError::new()),
         }
@@ -210,7 +224,7 @@ impl<'a, T: Value> Handle<'a, T> {
     /// continue interacting with the JS engine if this method produces an `Err`
     /// result.
     pub fn downcast<'b, U: Value, C: Context<'b>>(&self, cx: &mut C) -> DowncastResult<'a, T, U> {
-        match U::downcast(cx.env(), self.value) {
+        match U::downcast(cx.env(), self.deref()) {
             Some(v) => Ok(Handle::new_internal(v)),
             None => Err(DowncastError::new()),
         }
@@ -247,12 +261,12 @@ impl<'a, T: Value> Handle<'a, T> {
 impl<'a, T: Managed> Deref for Handle<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        &self.value
+        unsafe { mem::transmute(&self.value) }
     }
 }
 
 impl<'a, T: Managed> DerefMut for Handle<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut self.value
+        unsafe { mem::transmute(&mut self.value) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,10 +336,17 @@ macro_rules! class_definition {
 #[macro_export(local_inner_macros)]
 macro_rules! impl_managed {
     ($cls:ident) => {
+        unsafe impl $crate::macro_internal::TransparentNoCopyWrapper for $cls {
+            type Inner = $crate::macro_internal::runtime::raw::Local;
+
+            fn into_inner(self) -> Self::Inner {
+                self.0
+            }
+        }
+
         impl $crate::handle::Managed for $cls {
-            fn to_raw(self) -> $crate::macro_internal::runtime::raw::Local {
-                let $cls(raw) = self;
-                raw
+            fn to_raw(&self) -> $crate::macro_internal::runtime::raw::Local {
+                self.0
             }
 
             fn from_raw(
@@ -406,8 +413,8 @@ macro_rules! declare_types {
     };
 
     { $(#[$attr:meta])* pub class $cls:ident as $cname:ident for $typ:ty { $($body:tt)* } $($rest:tt)* } => {
-        #[derive(Copy, Clone)]
-        #[repr(C)]
+        #[derive(Debug)]
+        #[repr(transparent)]
         $(#[$attr])*
         pub struct $cls($crate::macro_internal::runtime::raw::Local);
 

--- a/src/macro_internal/mod.rs
+++ b/src/macro_internal/mod.rs
@@ -1,5 +1,7 @@
 //! Internals needed by macros. These have to be exported for the macros to work
 pub use crate::context::internal::{initialize_module, Env};
+#[cfg(feature = "legacy-runtime")]
+pub use crate::handle::internal::TransparentNoCopyWrapper;
 /// but are subject to change and should never be explicitly used.
 
 #[cfg(feature = "legacy-runtime")]

--- a/src/object/class/mod.rs
+++ b/src/object/class/mod.rs
@@ -240,7 +240,7 @@ impl<T: Class> ValueInternal for T {
         }
     }
 
-    fn is_typeof<Other: Value>(mut env: Env, value: Other) -> bool {
+    fn is_typeof<Other: Value>(mut env: Env, value: &Other) -> bool {
         let map = env.class_map();
         match map.get(&TypeId::of::<T>()) {
             None => false,

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -91,7 +91,7 @@ mod traits {
     /// The trait of all object types.
     pub trait Object: Value {
         fn get<'a, V: Value, C: Context<'a>, K: PropertyKey>(
-            self,
+            &self,
             cx: &mut C,
             key: K,
         ) -> NeonResult<Handle<'a, V>> {
@@ -100,7 +100,7 @@ mod traits {
             v.downcast_or_throw(cx)
         }
 
-        fn get_own_property_names<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsArray> {
+        fn get_own_property_names<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsArray> {
             let env = cx.env();
             build(env, |out| unsafe {
                 neon_runtime::object::get_own_property_names(out, env.to_raw(), self.to_raw())
@@ -108,7 +108,7 @@ mod traits {
         }
 
         fn set<'a, C: Context<'a>, K: PropertyKey, W: Value>(
-            self,
+            &self,
             _: &mut C,
             key: K,
             val: Handle<W>,
@@ -238,7 +238,7 @@ mod traits {
     /// The trait of all object types.
     pub trait Object: Value {
         fn get<'a, V: Value, C: Context<'a>, K: PropertyKey>(
-            self,
+            &self,
             cx: &mut C,
             key: K,
         ) -> NeonResult<Handle<'a, V>> {
@@ -250,7 +250,7 @@ mod traits {
 
         #[cfg(feature = "napi-6")]
         #[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
-        fn get_own_property_names<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsArray> {
+        fn get_own_property_names<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsArray> {
             let env = cx.env();
 
             build(cx.env(), |out| unsafe {
@@ -259,7 +259,7 @@ mod traits {
         }
 
         fn set<'a, C: Context<'a>, K: PropertyKey, W: Value>(
-            self,
+            &self,
             cx: &mut C,
             key: K,
             val: Handle<W>,

--- a/src/types/boxed.rs
+++ b/src/types/boxed.rs
@@ -6,12 +6,29 @@ use neon_runtime::raw;
 
 use crate::context::internal::Env;
 use crate::context::{Context, FinalizeContext};
-use crate::handle::{Handle, Managed};
+use crate::handle::{internal::TransparentNoCopyWrapper, Handle, Managed};
 use crate::object::Object;
 use crate::types::private::ValueInternal;
 use crate::types::Value;
+use private::JsBoxInner;
 
 type BoxAny = Box<dyn Any + Send + 'static>;
+
+mod private {
+    pub struct JsBoxInner<T: Send + 'static> {
+        pub(super) local: neon_runtime::raw::Local,
+        // Cached raw pointer to the data contained in the `JsBox`. This value is
+        // required to implement `Deref` for `JsBox`. Unlike most `Js` types, `JsBox`
+        // is not a transparent wrapper around a `napi_value` and cannot implement `This`.
+        //
+        // Safety: `JsBox` cannot verify the lifetime. Store a raw pointer to force
+        // uses to be marked unsafe. In practice, it can be treated as `'static` but
+        // should only be exposed as part of a `Handle` tied to a `Context` lifetime.
+        // Safety: The value must not move on the heap; we must never give a mutable
+        // reference to the data until the `JsBox` is no longer accessible.
+        pub(super) raw_data: *const T,
+    }
+}
 
 /// A smart pointer for Rust data managed by the JavaScript engine.
 ///
@@ -124,23 +141,18 @@ type BoxAny = Box<dyn Any + Send + 'static>;
 ///
 ///     Ok(cx.string(greeting))
 /// }
-pub struct JsBox<T: Send + 'static> {
-    local: raw::Local,
-    // Cached raw pointer to the data contained in the `JsBox`. This value is
-    // required to implement `Deref` for `JsBox`. Unlike most `Js` types, `JsBox`
-    // is not a transparent wrapper around a `napi_value` and cannot implement `This`.
-    //
-    // Safety: `JsBox` cannot verify the lifetime. Store a raw pointer to force
-    // uses to be marked unsafe. In practice, it can be treated as `'static` but
-    // should only be exposed as part of a `Handle` tied to a `Context` lifetime.
-    // Safety: The value must not move on the heap; we must never give a mutable
-    // reference to the data until the `JsBox` is no longer accessible.
-    raw_data: *const T,
+#[repr(transparent)]
+pub struct JsBox<T: Send + 'static>(JsBoxInner<T>);
+
+impl<T: Send + 'static> std::fmt::Debug for JsBoxInner<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JsBox<{}>", std::any::type_name::<T>())
+    }
 }
 
 impl<T: Send + 'static> std::fmt::Debug for JsBox<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "JsBox<{}>", std::any::type_name::<T>())
+        std::fmt::Debug::fmt(&self.0, f)
     }
 }
 
@@ -151,9 +163,9 @@ unsafe fn maybe_external_deref<'a>(env: Env, local: raw::Local) -> Option<&'a Bo
 }
 
 // Custom `Clone` implementation since `T` might not be `Clone`
-impl<T: Send + 'static> Clone for JsBox<T> {
+impl<T: Send + 'static> Clone for JsBoxInner<T> {
     fn clone(&self) -> Self {
-        JsBox {
+        Self {
             local: self.local,
             raw_data: self.raw_data,
         }
@@ -162,13 +174,21 @@ impl<T: Send + 'static> Clone for JsBox<T> {
 
 impl<T: Send + 'static> Object for JsBox<T> {}
 
-impl<T: Send + 'static> Copy for JsBox<T> {}
+impl<T: Send + 'static> Copy for JsBoxInner<T> {}
 
 impl<T: Send + 'static> Value for JsBox<T> {}
 
+unsafe impl<T: Send + 'static> TransparentNoCopyWrapper for JsBox<T> {
+    type Inner = JsBoxInner<T>;
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+}
+
 impl<T: Send + 'static> Managed for JsBox<T> {
-    fn to_raw(self) -> raw::Local {
-        self.local
+    fn to_raw(&self) -> raw::Local {
+        self.0.local
     }
 
     fn from_raw(env: Env, local: raw::Local) -> Self {
@@ -177,7 +197,7 @@ impl<T: Send + 'static> Managed for JsBox<T> {
             .downcast_ref()
             .expect("Failed to downcast Any");
 
-        Self { local, raw_data }
+        Self(JsBoxInner { local, raw_data })
     }
 }
 
@@ -186,19 +206,19 @@ impl<T: Send + 'static> ValueInternal for JsBox<T> {
         any::type_name::<Self>().to_string()
     }
 
-    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+    fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool {
         let data = unsafe { maybe_external_deref(env, other.to_raw()) };
 
         data.map(|v| v.is::<T>()).unwrap_or(false)
     }
 
-    fn downcast<Other: Value>(env: Env, other: Other) -> Option<Self> {
+    fn downcast<Other: Value>(env: Env, other: &Other) -> Option<Self> {
         let local = other.to_raw();
         let data = unsafe { maybe_external_deref(env, local) };
 
         // Attempt to downcast the `Option<&BoxAny>` to `Option<*const T>`
         data.and_then(|v| v.downcast_ref())
-            .map(|raw_data| Self { local, raw_data })
+            .map(|raw_data| Self(JsBoxInner { local, raw_data }))
     }
 }
 
@@ -243,7 +263,7 @@ impl<T: Finalize + Send + 'static> JsBox<T> {
         let raw_data = &*v as *const dyn Any as *const T;
         let local = unsafe { external::create(cx.env().to_raw(), v, finalizer::<T>) };
 
-        Handle::new_internal(Self { local, raw_data })
+        Handle::new_internal(Self(JsBoxInner { local, raw_data }))
     }
 }
 
@@ -253,7 +273,7 @@ impl<'a, T: Send + 'static> Deref for JsBox<T> {
     fn deref(&self) -> &Self::Target {
         // Safety: This depends on a `Handle<'a, JsBox<T>>` wrapper to provide
         // a proper lifetime.
-        unsafe { &*self.raw_data }
+        unsafe { &*self.0.raw_data }
     }
 }
 

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -7,18 +7,27 @@ use neon_runtime::raw;
 
 use crate::context::internal::Env;
 use crate::context::Context;
+use crate::handle::{internal::TransparentNoCopyWrapper, Handle, Managed};
 use crate::result::{NeonResult, Throw};
 use crate::types::private::ValueInternal;
 use crate::types::utf8::Utf8;
-use crate::types::{build, Handle, Managed, Object, Value};
+use crate::types::{build, Object, Value};
 
 /// A JS `Error` object.
-#[repr(C)]
-#[derive(Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug)]
 pub struct JsError(raw::Local);
 
+unsafe impl TransparentNoCopyWrapper for JsError {
+    type Inner = raw::Local;
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+}
+
 impl Managed for JsError {
-    fn to_raw(self) -> raw::Local {
+    fn to_raw(&self) -> raw::Local {
         self.0
     }
 
@@ -32,7 +41,7 @@ impl ValueInternal for JsError {
         "Error".to_string()
     }
 
-    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool {
+    fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool {
         unsafe { neon_runtime::tag::is_error(env.to_raw(), other.to_raw()) }
     }
 }

--- a/src/types/private.rs
+++ b/src/types/private.rs
@@ -17,9 +17,9 @@ use std::os::raw::c_void;
 pub trait ValueInternal: Managed + 'static {
     fn name() -> String;
 
-    fn is_typeof<Other: Value>(env: Env, other: Other) -> bool;
+    fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool;
 
-    fn downcast<Other: Value>(env: Env, other: Other) -> Option<Self> {
+    fn downcast<Other: Value>(env: Env, other: &Other) -> Option<Self> {
         if Self::is_typeof(env, other) {
             Some(Self::from_raw(env, other.to_raw()))
         } else {


### PR DESCRIPTION
Currently, it is possible to `Copy` and `Clone` `Js*` types which is *unsafe*. These types depend on being contained in a `Handle` to verify the lifetime. They should only exist as references outside of a `Handle`. Unfortunately, the ability to clone allows getting an owned copy from a reference.

This change attempts to minimize impact to users by making `Handle<T>` `Copy`, while making the inner `T` `!Copy`. This works by introducing a new marker trait `TransparentWrapper` which indicates a type is a transparent wrapper around a `TransparentWrapper::Inner` type--allowing transmutation between the two.

Using this `trait`, `Handle` actually stores a `Copy` inner type, while implementing `Deref` with a `Target` to the `!Copy` outer type.

Unfortunately, since `Copy` won't propagate upward from a `Deref`, all APIs that currently take `self` on a `Value` were changed to take `&self` to keep from requiring a manual `clone()`. This could still impact users in some places--for example when creating an `Object` with a circular reference.