### PR TITLE
Overload result type of `Object::get()`

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -87,8 +87,8 @@
 //! # use neon::prelude::*;
 //! # fn iterate(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 //!     let iterator = cx.argument::<JsObject>(0)?;         // iterator object
-//!     let next = iterator.get(&mut cx, "next")?           // iterator's `next` method
-//!         .downcast_or_throw::<JsFunction, _>(&mut cx)?;
+//!     let next: Handle<JsFunction> =                      // iterator's `next` method
+//!         iterator.get(&mut cx, "next")?;
 //!     let mut numbers = vec![];                           // results vector
 //!     let mut done = false;                               // loop controller
 //!
@@ -98,13 +98,12 @@
 //!                 .call_with(&cx)
 //!                 .this(iterator)
 //!                 .apply(&mut cx)?;
-//!             let number = obj.get(&mut cx, "value")?           // temporary number
-//!                 .downcast_or_throw::<JsNumber, _>(&mut cx)?
-//!                 .value(&mut cx);
-//!             numbers.push(number);
-//!             Ok(obj.get(&mut cx, "done")?                      // temporary boolean
-//!                 .downcast_or_throw::<JsBoolean, _>(&mut cx)?
-//!                 .value(&mut cx))
+//!             let number: Handle<JsNumber> =                    // temporary number
+//!                 obj.get(&mut cx, "value")?;
+//!             numbers.push(number.value(&mut cx));
+//!             let done: Handle<JsBoolean> =                     // temporary boolean
+//!                 obj.get(&mut cx, "done")?;
+//!             Ok(done.value(&mut cx))
 //!         })?;
 //!     }
 //! #   Ok(cx.undefined())

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -39,14 +39,10 @@
 //! fn area(mut cx: FunctionContext) -> JsResult<JsNumber> {
 //!     let rect: Handle<JsObject> = cx.argument(0)?;
 //!
-//!     let width: Handle<JsNumber> = rect
-//!         .get(&mut cx, "width")?
-//!         .downcast_or_throw(&mut cx)?;
+//!     let width: Handle<JsNumber> = rect.get(&mut cx, "width")?;
 //!     let w: f64 = width.value(&mut cx);
 //!
-//!     let height: Handle<JsNumber> = rect
-//!         .get(&mut cx, "height")?
-//!         .downcast_or_throw(&mut cx)?;
+//!     let height: Handle<JsNumber> = rect.get(&mut cx, "height")?;
 //!     let h: f64 = height.value(&mut cx);
 //!
 //!     Ok(cx.number(w * h))

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -90,12 +90,14 @@ mod traits {
 
     /// The trait of all object types.
     pub trait Object: Value {
-        fn get<'a, C: Context<'a>, K: PropertyKey>(
+        fn get<'a, V: Value, C: Context<'a>, K: PropertyKey>(
             self,
             cx: &mut C,
             key: K,
-        ) -> NeonResult<Handle<'a, JsValue>> {
-            build(cx.env(), |out| unsafe { key.get_from(out, self.to_raw()) })
+        ) -> NeonResult<Handle<'a, V>> {
+            let v: Handle<JsValue> =
+                build(cx.env(), |out| unsafe { key.get_from(out, self.to_raw()) })?;
+            v.downcast_or_throw(cx)
         }
 
         fn get_own_property_names<'a, C: Context<'a>>(self, cx: &mut C) -> JsResult<'a, JsArray> {
@@ -235,14 +237,15 @@ mod traits {
 
     /// The trait of all object types.
     pub trait Object: Value {
-        fn get<'a, C: Context<'a>, K: PropertyKey>(
+        fn get<'a, V: Value, C: Context<'a>, K: PropertyKey>(
             self,
             cx: &mut C,
             key: K,
-        ) -> NeonResult<Handle<'a, JsValue>> {
-            build(cx.env(), |out| unsafe {
+        ) -> NeonResult<Handle<'a, V>> {
+            let v: Handle<JsValue> = build(cx.env(), |out| unsafe {
                 key.get_from(cx, out, self.to_raw())
-            })
+            })?;
+            v.downcast_or_throw(cx)
         }
 
         #[cfg(feature = "napi-6")]

--- a/src/types/boxed.rs
+++ b/src/types/boxed.rs
@@ -282,10 +282,8 @@ impl<'a, T: Send + 'static> Deref for JsBox<T> {
 /// impl Finalize for Point {
 ///     fn finalize<'a, C: Context<'a>>(self, cx: &mut C) {
 ///         let global = cx.global();
-///         let emit = global
+///         let emit: Handle<JsFunction> = global
 ///             .get(cx, "emit")
-///             .unwrap()
-///             .downcast::<JsFunction, _>(cx)
 ///             .unwrap();
 ///
 ///         let args = vec![

--- a/src/types/function/mod.rs
+++ b/src/types/function/mod.rs
@@ -17,8 +17,7 @@ pub(crate) mod private;
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
 /// # let global = cx.global();
-/// # let parse_int = global.get(&mut cx, "parseInt")?;
-/// # let parse_int: Handle<JsFunction> = parse_int.downcast_or_throw(&mut cx)?;
+/// # let parse_int: Handle<JsFunction> = global.get(&mut cx, "parseInt")?;
 /// let x: Handle<JsNumber> = parse_int
 ///     .call_with(&cx)
 ///     .arg(cx.string("42"))
@@ -77,8 +76,7 @@ impl<'a> CallOptions<'a> {
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
 /// # let global = cx.global();
-/// # let url = global.get(&mut cx, "URL")?;
-/// # let url: Handle<JsFunction> = url.downcast_or_throw(&mut cx)?;
+/// # let url: Handle<JsFunction> = global.get(&mut cx, "URL")?;
 /// let obj = url
 ///     .construct_with(&cx)
 ///     .arg(cx.string("https://neon-bindings.com"))

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -699,9 +699,7 @@ impl Object for JsArray {}
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
 /// # let global = cx.global();
 /// // Extract the parseInt function from the global object
-/// let parse_int: Handle<JsFunction> = global
-///     .get(&mut cx, "parseInt")?
-///     .downcast_or_throw(&mut cx)?;
+/// let parse_int: Handle<JsFunction> = global.get(&mut cx, "parseInt")?;
 ///
 /// // Call parseInt("42")
 /// let x: Handle<JsNumber> = parse_int
@@ -722,9 +720,7 @@ impl Object for JsArray {}
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
 /// # let global = cx.global();
 /// // Extract the URL constructor from the global object
-/// let url: Handle<JsFunction> = global
-///     .get(&mut cx, "URL")?
-///     .downcast_or_throw(&mut cx)?;
+/// let url: Handle<JsFunction> = global.get(&mut cx, "URL")?;
 ///
 /// // Call new URL("https://neon-bindings.com")
 /// let obj = url

--- a/test/dynamic/native/src/js/eventhandler.rs
+++ b/test/dynamic/native/src/js/eventhandler.rs
@@ -18,7 +18,7 @@ declare_types! {
 
     constructor(mut cx) {
       let mut this = cx.this();
-      let f = this.get(&mut cx, "emit")?.downcast::<JsFunction>().or_throw(&mut cx)?;
+      let f: Handle<JsFunction> = this.get(&mut cx, "emit")?;
       let cb = EventHandler::new(&cx, this, f);
       {
         let guard = cx.lock();

--- a/test/dynamic/native/src/js/functions.rs
+++ b/test/dynamic/native/src/js/functions.rs
@@ -24,10 +24,7 @@ pub fn construct_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let f = cx.argument::<JsFunction>(0)?;
     let zero = cx.number(0.0);
     let o = f.construct(&mut cx, [zero.upcast()])?;
-    let get_utc_full_year_method = o
-        .get(&mut cx, "getUTCFullYear")?
-        .downcast::<JsFunction>()
-        .or_throw(&mut cx)?;
+    let get_utc_full_year_method: Handle<JsFunction> = o.get(&mut cx, "getUTCFullYear")?;
     let args: Vec<Handle<JsValue>> = vec![];
     get_utc_full_year_method
         .call(&mut cx, o.upcast::<JsValue>(), args)?

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -28,13 +28,8 @@ pub fn call_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<JsNum
 }
 
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {
-    let math = cx
-        .global()
-        .get(cx, "Math")?
-        .downcast_or_throw::<JsObject, _>(cx)?;
-    let max = math
-        .get(cx, "max")?
-        .downcast_or_throw::<JsFunction, _>(cx)?;
+    let math: Handle<JsObject> = cx.global().get(cx, "Math")?;
+    let max: Handle<JsFunction> = math.get(cx, "max")?;
     Ok(max)
 }
 
@@ -103,8 +98,7 @@ pub fn exec_js_function_with_implicit_this(mut cx: FunctionContext) -> JsResult<
 
 pub fn call_js_function_with_heterogeneous_tuple(mut cx: FunctionContext) -> JsResult<JsArray> {
     cx.global()
-        .get(&mut cx, "Array")?
-        .downcast_or_throw::<JsFunction, _>(&mut cx)?
+        .get::<JsFunction, _, _>(&mut cx, "Array")?
         .call_with(&cx)
         .args((cx.number(1.0), cx.string("hello"), cx.boolean(true)))
         .apply(&mut cx)
@@ -114,10 +108,7 @@ pub fn construct_js_function(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let f = cx.argument::<JsFunction>(0)?;
     let zero = cx.number(0.0);
     let o = f.construct(&mut cx, [zero.upcast()])?;
-    let get_utc_full_year_method = o
-        .get(&mut cx, "getUTCFullYear")?
-        .downcast::<JsFunction, _>(&mut cx)
-        .or_throw(&mut cx)?;
+    let get_utc_full_year_method: Handle<JsFunction> = o.get(&mut cx, "getUTCFullYear")?;
     let args: Vec<Handle<JsValue>> = vec![];
     get_utc_full_year_method
         .call(&mut cx, o.upcast::<JsValue>(), args)?
@@ -131,10 +122,7 @@ pub fn construct_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<
         .construct_with(&cx)
         .arg(cx.number(0.0))
         .apply(&mut cx)?;
-    let get_utc_full_year_method = o
-        .get(&mut cx, "getUTCFullYear")?
-        .downcast::<JsFunction, _>(&mut cx)
-        .or_throw(&mut cx)?;
+    let get_utc_full_year_method: Handle<JsFunction> = o.get(&mut cx, "getUTCFullYear")?;
     get_utc_full_year_method
         .call_with(&cx)
         .this(o)
@@ -143,7 +131,7 @@ pub fn construct_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<
 
 pub fn construct_js_function_with_overloaded_result(mut cx: FunctionContext) -> JsResult<JsArray> {
     let global = cx.global();
-    let f: Handle<JsFunction> = global.get(&mut cx, "Array")?.downcast_or_throw(&mut cx)?;
+    let f: Handle<JsFunction> = global.get(&mut cx, "Array")?;
     f.construct_with(&cx)
         .arg(cx.number(1))
         .arg(cx.number(2))

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -72,7 +72,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
 
     assert!(
         ({
-            let v: Handle<JsNumber> = rust_created.get(&mut cx, "a")?.downcast_or_throw(&mut cx)?;
+            let v: Handle<JsNumber> = rust_created.get(&mut cx, "a")?;
             v.value(&mut cx)
         } - 1.0f64)
             .abs()
@@ -80,7 +80,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     );
     assert!(
         ({
-            let v: Handle<JsNumber> = rust_created.get(&mut cx, 0)?.downcast_or_throw(&mut cx)?;
+            let v: Handle<JsNumber> = rust_created.get(&mut cx, 0)?;
             v.value(&mut cx)
         } - 1.0f64)
             .abs()
@@ -88,9 +88,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     );
     assert_eq!(
         {
-            let v: Handle<JsBoolean> = rust_created
-                .get(&mut cx, "whatever")?
-                .downcast_or_throw(&mut cx)?;
+            let v: Handle<JsBoolean> = rust_created.get(&mut cx, "whatever")?;
             v.value(&mut cx)
         },
         true


### PR DESCRIPTION
This PR changes the `Object::get()` API to return an overloaded result type `V: Value` instead of `JsValue`, and automatically performs the downcasting on behalf of the caller. Since it's already a fallible API, this should generally end up being more concise and ergonomic.

This is a backwards-incompatible change, however, and will require migration notes if we decide to go through with it.

(Replaces #795)
