### PR TITLE
fix(neon): Tag `Root` with an instance id and verify before using

### DIFF
--- a/crates/neon-runtime/src/napi/reference.rs
+++ b/crates/neon-runtime/src/napi/reference.rs
@@ -15,6 +15,8 @@ pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
     result.assume_init()
 }
 
+/// # Safety
+/// Must only be used from the same module context that created the reference
 pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     let mut result = MaybeUninit::uninit();
 
@@ -26,6 +28,8 @@ pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     result.assume_init() as usize
 }
 
+/// # Safety
+/// Must only be used from the same module context that created the reference
 pub unsafe fn unreference(env: Env, value: napi::Ref) {
     let mut result = MaybeUninit::uninit();
 
@@ -39,6 +43,8 @@ pub unsafe fn unreference(env: Env, value: napi::Ref) {
     }
 }
 
+/// # Safety
+/// Must only be used from the same module context that created the reference
 pub unsafe fn get(env: Env, value: napi::Ref) -> Local {
     let mut result = MaybeUninit::uninit();
 

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib"]
 
+[dependencies]
+once_cell = "1"
+
 [dependencies.neon]
 version = "*"
 path = "../.."

--- a/test/napi/lib/workers.js
+++ b/test/napi/lib/workers.js
@@ -1,0 +1,108 @@
+const assert = require("assert");
+const { Worker, isMainThread, parentPort } = require("worker_threads");
+
+const addon = require("..");
+
+// Receive a message, try that method and return the error message
+if (!isMainThread) {
+  parentPort.once("message", (message) => {
+    try {
+      switch (message) {
+        case "get_and_replace":
+          addon.get_and_replace({});
+          break;
+        case "get_or_init":
+          addon.get_or_init(() => ({}));
+          break;
+        case "get_or_init_clone":
+          addon.get_or_init_clone(() => ({}));
+          break;
+        default:
+          throw new Error(`Unexpected message: ${message}`);
+      }
+
+      throw new Error("Did not throw an exception");
+    } catch (err) {
+      parentPort.postMessage(err);
+    }
+  });
+
+  return;
+}
+
+describe("Worker / Root Tagging Tests", () => {
+  describe("Single Threaded", () => {
+    it("should be able to stash a global with `get_and_replace`", () => {
+      const first = {};
+      const second = {};
+
+      assert.strictEqual(addon.get_and_replace(first), undefined);
+      assert.strictEqual(addon.get_and_replace(second), first);
+      assert.strictEqual(addon.get_and_replace({}), second);
+    });
+
+    it("should be able to lazily initialize with `get_or_init`", () => {
+      const o = {};
+
+      assert.strictEqual(
+        addon.get_or_init(() => o),
+        o
+      );
+      assert.strictEqual(
+        addon.get_or_init(() => ({})),
+        o
+      );
+      assert.strictEqual(addon.get_or_init(), o);
+    });
+
+    it("should be able to lazily initialize with `get_or_init_clone`", () => {
+      const o = {};
+
+      assert.strictEqual(
+        addon.get_or_init_clone(() => o),
+        o
+      );
+      assert.strictEqual(
+        addon.get_or_init_clone(() => ({})),
+        o
+      );
+      assert.strictEqual(addon.get_or_init_clone(), o);
+    });
+  });
+
+  // Note: These tests require that the previous set of tests have run or else they will fail
+  describe("Multi-Threaded", () => {
+    it("should fail to use `get_and_replace`", (cb) => {
+      const worker = new Worker(__filename);
+
+      worker.once("message", (message) => {
+        assert.ok(/wrong module/.test(message));
+        cb();
+      });
+
+      worker.postMessage("get_and_replace");
+    });
+
+    it("should fail to use `get_or_init`", (cb) => {
+      const worker = new Worker(__filename);
+
+      worker.once("message", (message) => {
+        assert.ok(/wrong module/.test(message));
+        cb();
+      });
+
+      worker.postMessage("get_or_init");
+    });
+
+    it("should fail to use `get_or_init`", (cb) => {
+      const worker = new Worker(__filename);
+
+      worker.once("message", (message) => {
+        assert.ok(/wrong module/.test(message));
+        cb();
+      });
+
+      worker.postMessage("get_or_init_clone");
+    });
+  });
+});

--- a/test/napi/src/js/workers.rs
+++ b/test/napi/src/js/workers.rs
@@ -1,0 +1,45 @@
+use std::sync::Mutex;
+
+use neon::prelude::*;
+use once_cell::sync::{Lazy, OnceCell};
+
+pub fn get_and_replace(mut cx: FunctionContext) -> JsResult<JsValue> {
+    static OBJECT: Lazy<Mutex<Option<Root<JsObject>>>> = Lazy::new(Default::default);
+
+    let mut global = OBJECT.lock().unwrap_or_else(|err| err.into_inner());
+    let next = cx.argument::<JsObject>(0)?.root(&mut cx);
+    let previous = global.replace(next);
+
+    Ok(match previous {
+        None => cx.undefined().upcast(),
+        Some(previous) => previous.into_inner(&mut cx).upcast(),
+    })
+}
+
+pub fn get_or_init(mut cx: FunctionContext) -> JsResult<JsObject> {
+    static OBJECT: OnceCell<Root<JsObject>> = OnceCell::new();
+
+    let o = OBJECT.get_or_try_init(|| {
+        cx.argument::<JsFunction>(0)?
+            .call_with(&cx)
+            .apply::<JsObject, _>(&mut cx)
+            .map(|v| v.root(&mut cx))
+    })?;
+
+    Ok(o.to_inner(&mut cx))
+}
+
+pub fn get_or_init_clone(mut cx: FunctionContext) -> JsResult<JsObject> {
+    static OBJECT: OnceCell<Root<JsObject>> = OnceCell::new();
+
+    let o = OBJECT.get_or_try_init(|| {
+        cx.argument::<JsFunction>(0)?
+            .call_with(&cx)
+            .apply::<JsObject, _>(&mut cx)
+            .map(|v| v.root(&mut cx))
+    })?;
+
+    // Note: This intentionally uses `clone` instead of `to_inner` in order to
+    // test the `clone` method.
+    Ok(o.clone(&mut cx).into_inner(&mut cx))
+}

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -12,6 +12,7 @@ mod js {
     pub mod strings;
     pub mod threads;
     pub mod types;
+    pub mod workers;
 }
 
 use js::arrays::*;
@@ -337,6 +338,9 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "deferred_settle_with_panic_throw",
         deferred_settle_with_panic_throw,
     )?;
+    cx.export_function("get_and_replace", js::workers::get_and_replace)?;
+    cx.export_function("get_or_init", js::workers::get_or_init)?;
+    cx.export_function("get_or_init_clone", js::workers::get_or_init_clone)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Overview

`Root` are Neon's mechanism for holding persistent references to values on the JavaScript heap. They are both `Send` and `Sync` to allow holding references across Rust threads. However, the current implementation has a soundness hole.

Resolves https://github.com/neon-bindings/neon/issues/843

## Problem

When using [Node worker threads](https://nodejs.org/api/worker_threads.html), there may be multiple JavaScript runtimes present in the process. As shown in https://github.com/neon-bindings/neon/issues/843, it is possible to use a `Root` with a `Context` from the wrong runtime and cause a crash/undefined behavior.

## Solution

This PR resolves the issue by panicking when attempting to dereference from the wrong module instance. In the future, we may want to add `try_` variants to the `Root` methods to allow error handling without a `panic`. However, in most cases, this will be a logic error that applications cannot recover.

## Approach

On Node-API 6+, we use [instance data](https://nodejs.org/api/n-api.html#environment-life-cycle-apis) to store a unique identifier initialized from a global counter. Each `Root` stores the identifier for comparing later when being used.

On previous versions, the [`ThreadId`](https://doc.rust-lang.org/std/thread/struct.ThreadId.html) is used. This may not be as robust and is sensitive to V8 implementation details.

