### PR TITLE
fix(neon): Emit an unhandled rejection instead of an uncaught exception

### DIFF
--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -237,17 +237,6 @@ mod napi1 {
     );
 }
 
-#[cfg(feature = "napi-3")]
-mod napi3 {
-    use super::super::types::*;
-
-    generate!(
-        extern "C" {
-            fn fatal_exception(env: Env, err: Value) -> Status;
-        }
-    );
-}
-
 #[cfg(feature = "napi-4")]
 mod napi4 {
     use super::super::types::*;
@@ -341,8 +330,6 @@ mod napi6 {
 }
 
 pub(crate) use napi1::*;
-#[cfg(feature = "napi-3")]
-pub(crate) use napi3::*;
 #[cfg(feature = "napi-4")]
 pub(crate) use napi4::*;
 #[cfg(feature = "napi-5")]
@@ -373,9 +360,6 @@ pub(crate) unsafe fn load(env: Env) -> Result<(), libloading::Error> {
     let version = get_version(&host, env).expect("Failed to find N-API version");
 
     napi1::load(&host, version, 1)?;
-
-    #[cfg(feature = "napi-3")]
-    napi3::load(&host, version, 3)?;
 
     #[cfg(feature = "napi-4")]
     napi4::load(&host, version, 4)?;

--- a/crates/neon-runtime/src/napi/tsfn.rs
+++ b/crates/neon-runtime/src/napi/tsfn.rs
@@ -170,7 +170,7 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     }
 
     // Provides a C ABI wrapper for invoking the user supplied function pointer
-    // On panic or exception, creates an `uncaughtException` of the form:
+    // On panic or exception, creates a fatal exception of the form:
     // Error(msg: string) {
     //     // Exception thrown
     //     cause?: Error,

--- a/test/napi/lib/threads.js
+++ b/test/napi/lib/threads.js
@@ -5,17 +5,17 @@ const assert = require("chai").assert;
   // These tests require GC exposed to shutdown properly; skip if it is not
   return typeof global.gc === "function" ? describe : describe.skip;
 })()("sync", function () {
-  let uncaughtExceptionListeners = [];
+  let unhandledRejectionListeners = [];
 
   beforeEach(() => {
-    uncaughtExceptionListeners = process.listeners("uncaughtException");
+    unhandledRejectionListeners = process.listeners("unhandledRejection");
   });
 
   afterEach(() => {
     // Restore listeners
-    process.removeAllListeners("uncaughtException");
-    uncaughtExceptionListeners.forEach((listener) =>
-      process.on("uncaughtException", listener)
+    process.removeAllListeners("unhandledRejection");
+    unhandledRejectionListeners.forEach((listener) =>
+      process.on("unhandledRejection", listener)
     );
 
     // Force garbage collection to shutdown `Channel`
@@ -152,11 +152,11 @@ const assert = require("chai").assert;
     }
   });
 
-  it("should throw an uncaughtException when panicking in a channel", function (cb) {
+  it("should throw an unhandledRejection when panicking in a channel", function (cb) {
     const msg = "Hello, Panic!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -181,11 +181,11 @@ const assert = require("chai").assert;
     addon.channel_panic(msg);
   });
 
-  it("should throw an uncaughtException when throwing in a channel", function (cb) {
+  it("should throw an unhandledRejection when throwing in a channel", function (cb) {
     const msg = "Hello, Throw!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -209,11 +209,11 @@ const assert = require("chai").assert;
     addon.channel_throw(msg);
   });
 
-  it("should throw an uncaughtException when panicking and throwing in a channel", function (cb) {
+  it("should throw an unhandledRejection when panicking and throwing in a channel", function (cb) {
     const msg = "Oh, no!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -240,8 +240,8 @@ const assert = require("chai").assert;
   it("should be able to downcast a panic in a channel", function (cb) {
     const msg = "Hello, Secret Panic!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err.panic, Error);
         assert.ok(
@@ -259,11 +259,11 @@ const assert = require("chai").assert;
     addon.channel_custom_panic(msg);
   });
 
-  it("should throw an uncaughtException when panicking in a task", function (cb) {
+  it("should throw an unhandledRejection when panicking in a task", function (cb) {
     const msg = "Hello, Panic!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -288,11 +288,11 @@ const assert = require("chai").assert;
     addon.task_panic_execute(msg);
   });
 
-  it("should throw an uncaughtException when panicking in a task complete", function (cb) {
+  it("should throw an unhandledRejection when panicking in a task complete", function (cb) {
     const msg = "Hello, Panic!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -317,11 +317,11 @@ const assert = require("chai").assert;
     addon.task_panic_complete(msg);
   });
 
-  it("should throw an uncaughtException when throwing in a task complete", function (cb) {
+  it("should throw an unhandledRejection when throwing in a task complete", function (cb) {
     const msg = "Hello, Throw!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -345,11 +345,11 @@ const assert = require("chai").assert;
     addon.task_throw(msg);
   });
 
-  it("should throw an uncaughtException when panicking and throwing in a task complete", function (cb) {
+  it("should throw an unhandledRejection when panicking and throwing in a task complete", function (cb) {
     const msg = "Oh, no!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err, Error);
         assert.ok(
@@ -376,8 +376,8 @@ const assert = require("chai").assert;
   it("should be able to downcast a panic in a task", function (cb) {
     const msg = "Hello, Secret Panic!";
 
-    process.removeAllListeners("uncaughtException");
-    process.once("uncaughtException", (err) => {
+    process.removeAllListeners("unhandledRejection");
+    process.once("unhandledRejection", (err) => {
       try {
         assert.instanceOf(err.panic, Error);
         assert.ok(


### PR DESCRIPTION
## Why

Because of a Node bug, triggering a `fatal_exception` from a threadsafe function or task callback crashes the process with the default handler. This PR proposes that Neon trigger an `unhandledRejection` instead which avoids the bug.

## Impact

On recent versions of Node, this has the same intended consequence: the error is logged and the process terminates uncleanly. However, on older versions of Node, the rejection will only be logged.

## Why wasn't this caught?

While investigating the issue, I was curious why we didn't see it in unit tests. It appears that the internal code in the default exception handler is *necessary* for the bug. Since our tests replace this code, the bug never happens. The same would be true for any exception handler a user could write since it only uses internal/private APIs. This makes me wonder if the C++ crash is acceptable.

## Plan

It's strange to trigger an `unhandledRejection` for something that is unrelated to Promises. In the future, we may change this back to `uncaughtException`. However, in order to avoid a breaking change:

1. Add a feature flag that causes `uncaughtException` instead of `unhandledRejection`
2. Make the feature flag default in `create-neon` so that all new projects use it
3. Consider changing the default feature flag for everyone

We may choose to take a stance that it *shouldn't* impact many people and even though it's _technically_ a breaking change, the impact should be light and _could_ be considered a bug fix. In that case, we would make a feature flag to restore the original behavior and push out the change with only a minor revision.