### PR TITLE
Support for `bigint`

### DIFF
--- a/crates/neon-runtime/src/nan/primitive.rs
+++ b/crates/neon-runtime/src/nan/primitive.rs
@@ -31,3 +31,7 @@ pub use neon_sys::Neon_Primitive_Number as number;
 
 /// Gets the underlying value of a `v8::Number` object.
 pub use neon_sys::Neon_Primitive_NumberValue as number_value;
+
+pub use neon_sys::Neon_Primitive_BigInt as bigint;
+
+pub use neon_sys::Neon_Primitive_BigIntValue as bigint_value;

--- a/crates/neon-runtime/src/nan/tag.rs
+++ b/crates/neon-runtime/src/nan/tag.rs
@@ -9,6 +9,9 @@ pub use neon_sys::Neon_Tag_IsNull as is_null;
 /// Indicates if the value type is `Number`.
 pub use neon_sys::Neon_Tag_IsNumber as is_number;
 
+/// Indicates if the value type is `BigInt`.
+pub use neon_sys::Neon_Tag_IsBigInt as is_bigint;
+
 /// Indicates if the value type is `Boolean`.
 pub use neon_sys::Neon_Tag_IsBoolean as is_boolean;
 

--- a/crates/neon-runtime/src/napi/bigint.rs
+++ b/crates/neon-runtime/src/napi/bigint.rs
@@ -35,7 +35,8 @@ pub unsafe fn new_bigint_from_u64(env: Env, value: u64) -> Local {
 pub unsafe fn value_i64(env: Env, p: Local) -> (i64, bool) {
     let mut value: i64 = 0;
     let mut lossless = false;
-    let status = napi::get_value_bigint_int64(env, p, &mut value as *mut _, &mut lossless as *mut _);
+    let status =
+        napi::get_value_bigint_int64(env, p, &mut value as *mut _, &mut lossless as *mut _);
     assert_eq!(status, napi::Status::Ok);
     (value, lossless)
 }
@@ -49,7 +50,8 @@ pub unsafe fn value_i64(env: Env, p: Local) -> (i64, bool) {
 pub unsafe fn value_u64(env: Env, p: Local) -> (u64, bool) {
     let mut value: u64 = 0;
     let mut lossless = false;
-    let status = napi::get_value_bigint_uint64(env, p, &mut value as *mut _, &mut lossless as *mut _);
+    let status =
+        napi::get_value_bigint_uint64(env, p, &mut value as *mut _, &mut lossless as *mut _);
     assert_eq!(status, napi::Status::Ok);
     (value, lossless)
 }

--- a/crates/neon-runtime/src/napi/bigint.rs
+++ b/crates/neon-runtime/src/napi/bigint.rs
@@ -1,0 +1,29 @@
+use crate::napi::bindings as napi;
+use crate::raw::{Env, Local};
+use std::mem::MaybeUninit;
+
+/// Create a new date object
+///
+/// # Safety
+///
+/// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
+pub unsafe fn new_bigint(env: Env, value: i64) -> Local {
+    let mut local = MaybeUninit::zeroed();
+    let status = napi::create_bigint_int64(env, value, local.as_mut_ptr());
+    assert_eq!(status, napi::Status::Ok);
+    local.assume_init()
+}
+
+/// Get the value of a date object
+///
+/// # Safety
+///
+/// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
+/// `Local` must be an NAPI value associated with the given `Env`
+pub unsafe fn value_i64(env: Env, p: Local) -> i64 {
+    let mut value: i64 = 0;
+    let mut lossless = false;
+    let status = napi::get_value_bigint_int64(env, p, &mut value as *mut _, &mut lossless as *mut _);
+    assert_eq!(status, napi::Status::Ok);
+    value
+}

--- a/crates/neon-runtime/src/napi/bigint.rs
+++ b/crates/neon-runtime/src/napi/bigint.rs
@@ -2,7 +2,7 @@ use crate::napi::bindings as napi;
 use crate::raw::{Env, Local};
 use std::mem::MaybeUninit;
 
-/// Create a new date object
+/// Create a new bigint object
 ///
 /// # Safety
 ///
@@ -14,16 +14,42 @@ pub unsafe fn new_bigint(env: Env, value: i64) -> Local {
     local.assume_init()
 }
 
-/// Get the value of a date object
+/// Create a new bigint object
+///
+/// # Safety
+///
+/// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
+pub unsafe fn new_bigint_from_u64(env: Env, value: u64) -> Local {
+    let mut local = MaybeUninit::zeroed();
+    let status = napi::create_bigint_uint64(env, value, local.as_mut_ptr());
+    assert_eq!(status, napi::Status::Ok);
+    local.assume_init()
+}
+
+/// Get the value of a bigint object
 ///
 /// # Safety
 ///
 /// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
 /// `Local` must be an NAPI value associated with the given `Env`
-pub unsafe fn value_i64(env: Env, p: Local) -> i64 {
+pub unsafe fn value_i64(env: Env, p: Local) -> (i64, bool) {
     let mut value: i64 = 0;
     let mut lossless = false;
     let status = napi::get_value_bigint_int64(env, p, &mut value as *mut _, &mut lossless as *mut _);
     assert_eq!(status, napi::Status::Ok);
-    value
+    (value, lossless)
+}
+
+/// Get the value of a bigint object
+///
+/// # Safety
+///
+/// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
+/// `Local` must be an NAPI value associated with the given `Env`
+pub unsafe fn value_u64(env: Env, p: Local) -> (u64, bool) {
+    let mut value: u64 = 0;
+    let mut lossless = false;
+    let status = napi::get_value_bigint_uint64(env, p, &mut value as *mut _, &mut lossless as *mut _);
+    assert_eq!(status, napi::Status::Ok);
+    (value, lossless)
 }

--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -341,13 +341,33 @@ mod napi6 {
 
             fn create_bigint_uint64(env: Env, value: u64, result: *mut Value) -> Status;
 
-            fn create_bigint_words(env: Env, sign_bit: isize, word_count: usize, words: *mut u64) -> Status;
+            fn create_bigint_words(
+                env: Env,
+                sign_bit: isize,
+                word_count: usize,
+                words: *mut u64,
+            ) -> Status;
 
-            fn get_value_bigint_int64(env: Env, value: Value, result: *mut i64, lossless: *mut bool) -> Status;
+            fn get_value_bigint_int64(
+                env: Env,
+                value: Value,
+                result: *mut i64,
+                lossless: *mut bool,
+            ) -> Status;
 
-            fn get_value_bigint_uint64(env: Env, value: Value, result: *mut u64, lossless: *mut bool) -> Status;
+            fn get_value_bigint_uint64(
+                env: Env,
+                value: Value,
+                result: *mut u64,
+                lossless: *mut bool,
+            ) -> Status;
 
-            fn get_value_bigint_words(env: Env, value: Value, sign_bit: *mut isize, words: *mut u64) -> Status;
+            fn get_value_bigint_words(
+                env: Env,
+                value: Value,
+                sign_bit: *mut isize,
+                words: *mut u64,
+            ) -> Status;
         }
     );
 }

--- a/crates/neon-runtime/src/napi/bindings/functions.rs
+++ b/crates/neon-runtime/src/napi/bindings/functions.rs
@@ -336,6 +336,18 @@ mod napi6 {
             ) -> Status;
 
             fn get_instance_data(env: Env, data: *mut *mut c_void) -> Status;
+
+            fn create_bigint_int64(env: Env, value: i64, result: *mut Value) -> Status;
+
+            fn create_bigint_uint64(env: Env, value: u64, result: *mut Value) -> Status;
+
+            fn create_bigint_words(env: Env, sign_bit: isize, word_count: usize, words: *mut u64) -> Status;
+
+            fn get_value_bigint_int64(env: Env, value: Value, result: *mut i64, lossless: *mut bool) -> Status;
+
+            fn get_value_bigint_uint64(env: Env, value: Value, result: *mut u64, lossless: *mut bool) -> Status;
+
+            fn get_value_bigint_words(env: Env, value: Value, sign_bit: *mut isize, words: *mut u64) -> Status;
         }
     );
 }

--- a/crates/neon-runtime/src/napi/mod.rs
+++ b/crates/neon-runtime/src/napi/mod.rs
@@ -1,6 +1,8 @@
 pub mod array;
 pub mod arraybuffer;
 pub mod async_work;
+#[cfg(feature = "napi-6")]
+pub mod bigint;
 pub mod buffer;
 pub mod call;
 pub mod convert;
@@ -11,8 +13,6 @@ pub mod external;
 pub mod fun;
 #[cfg(feature = "napi-6")]
 pub mod lifecycle;
-#[cfg(feature = "napi-6")]
-pub mod bigint;
 pub mod mem;
 pub mod no_panic;
 pub mod object;

--- a/crates/neon-runtime/src/napi/mod.rs
+++ b/crates/neon-runtime/src/napi/mod.rs
@@ -11,6 +11,8 @@ pub mod external;
 pub mod fun;
 #[cfg(feature = "napi-6")]
 pub mod lifecycle;
+#[cfg(feature = "napi-6")]
+pub mod bigint;
 pub mod mem;
 pub mod no_panic;
 pub mod object;

--- a/crates/neon-runtime/src/napi/tag.rs
+++ b/crates/neon-runtime/src/napi/tag.rs
@@ -38,6 +38,10 @@ pub unsafe fn is_object(env: Env, val: Local) -> bool {
     is_type(env, val, napi::ValueType::Object)
 }
 
+pub unsafe fn is_bigint(env: Env, val: Local) -> bool {
+    is_type(env, val, napi::ValueType::BigInt)
+}
+
 pub unsafe fn is_array(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -260,6 +260,9 @@ extern "C" {
     pub fn Neon_Primitive_Number(out: &mut Local, isolate: Isolate, v: f64);
     pub fn Neon_Primitive_NumberValue(p: Local) -> f64;
 
+    pub fn Neon_Primitive_BigInt(out: &mut Local, isolate: Isolate, v: i64);
+    pub fn Neon_Primitive_BigIntValue(out: &mut Local, isolate: Isolate, v: i64);
+
     pub fn Neon_Scope_Escape(
         isolate: Isolate,
         out: &mut Local,
@@ -295,6 +298,7 @@ extern "C" {
     pub fn Neon_Tag_IsUndefined(isolate: Isolate, val: Local) -> bool;
     pub fn Neon_Tag_IsNull(isolate: Isolate, val: Local) -> bool;
     pub fn Neon_Tag_IsNumber(isolate: Isolate, val: Local) -> bool;
+    pub fn Neon_Tag_IsBigInt(isolate: Isolate, val: Local) -> bool;
     pub fn Neon_Tag_IsBoolean(isolate: Isolate, val: Local) -> bool;
     pub fn Neon_Tag_IsString(isolate: Isolate, val: Local) -> bool;
     pub fn Neon_Tag_IsObject(isolate: Isolate, val: Local) -> bool;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -164,14 +164,14 @@ use crate::lifecycle::InstanceData;
 use crate::object::class::Class;
 use crate::object::{Object, This};
 use crate::result::{JsResult, NeonResult, Throw};
+#[cfg(feature = "napi-6")]
+use crate::types::bigint::JsBigInt;
 #[cfg(feature = "napi-1")]
 use crate::types::boxed::{Finalize, JsBox};
 #[cfg(feature = "napi-1")]
 pub use crate::types::buffer::lock::Lock;
 #[cfg(feature = "napi-5")]
 use crate::types::date::{DateError, JsDate};
-#[cfg(feature = "napi-6")]
-use crate::types::bigint::JsBigInt;
 use crate::types::error::JsError;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 use crate::types::{Deferred, JsPromise};

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -171,7 +171,7 @@ pub use crate::types::buffer::lock::Lock;
 #[cfg(feature = "napi-5")]
 use crate::types::date::{DateError, JsDate};
 #[cfg(feature = "napi-6")]
-use crate::types::bigint::{JsBigInt};
+use crate::types::bigint::JsBigInt;
 use crate::types::error::JsError;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 use crate::types::{Deferred, JsPromise};

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -170,6 +170,8 @@ use crate::types::boxed::{Finalize, JsBox};
 pub use crate::types::buffer::lock::Lock;
 #[cfg(feature = "napi-5")]
 use crate::types::date::{DateError, JsDate};
+#[cfg(feature = "napi-6")]
+use crate::types::bigint::{JsBigInt};
 use crate::types::error::JsError;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 use crate::types::{Deferred, JsPromise};
@@ -528,6 +530,12 @@ pub trait Context<'a>: ContextInternal<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
     fn date(&mut self, value: impl Into<f64>) -> Result<Handle<'a, JsDate>, DateError> {
         JsDate::new(self, value)
+    }
+
+    #[cfg(feature = "napi-6")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
+    fn bigint(&mut self, value: impl Into<i64>) -> Handle<'a, JsBigInt> {
+        JsBigInt::new(self, value)
     }
 
     /// Produces a handle to the JavaScript global object.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -37,6 +37,8 @@ pub use crate::task::Task;
 #[cfg(feature = "legacy-runtime")]
 #[doc(no_inline)]
 pub use crate::types::BinaryData;
+#[cfg(feature = "napi-6")]
+pub use crate::types::JsBigInt;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 #[doc(no_inline)]
 pub use crate::types::JsPromise;
@@ -48,8 +50,6 @@ pub use crate::types::{
     JsArray, JsArrayBuffer, JsBoolean, JsBuffer, JsError, JsFunction, JsNull, JsNumber, JsObject,
     JsString, JsUndefined, JsValue, Value,
 };
-#[cfg(feature = "napi-6")]
-pub use crate::types::{JsBigInt};
 #[cfg(feature = "napi-1")]
 #[doc(no_inline)]
 pub use crate::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -48,6 +48,8 @@ pub use crate::types::{
     JsArray, JsArrayBuffer, JsBoolean, JsBuffer, JsError, JsFunction, JsNull, JsNumber, JsObject,
     JsString, JsUndefined, JsValue, Value,
 };
+#[cfg(feature = "napi-6")]
+pub use crate::types::{JsBigInt};
 #[cfg(feature = "napi-1")]
 #[doc(no_inline)]
 pub use crate::{

--- a/src/types/bigint.rs
+++ b/src/types/bigint.rs
@@ -1,0 +1,73 @@
+use super::{private::ValueInternal, Value};
+use crate::context::internal::Env;
+use crate::context::Context;
+use crate::handle::{internal::TransparentNoCopyWrapper, Handle, Managed};
+use crate::object::Object;
+use crate::result::{JsResult, JsResultExt};
+use neon_runtime;
+use neon_runtime::raw;
+use std::error::Error;
+use std::fmt;
+use std::fmt::Debug;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
+pub struct JsBigInt(raw::Local);
+
+impl Value for JsBigInt {}
+
+unsafe impl TransparentNoCopyWrapper for JsBigInt {
+    type Inner = raw::Local;
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+}
+
+impl Managed for JsBigInt {
+    fn to_raw(&self) -> raw::Local {
+        self.0
+    }
+
+    fn from_raw(_: Env, h: raw::Local) -> Self {
+        JsBigInt(h)
+    }
+}
+
+impl JsBigInt {
+    pub fn new<'a, C: Context<'a>, T: Into<i64>>(cx: &mut C, x: T) -> Handle<'a, JsBigInt> {
+        // JsBigInt::new_internal(cx.env(), x.into())
+        let env = cx.env().to_raw();
+        let value = x.into();
+        let local = unsafe { neon_runtime::bigint::new_bigint(env, value) };
+        let bigint = Handle::new_internal(JsBigInt(local));
+        bigint
+    }
+
+    /*
+    pub(crate) fn new_internal<'a>(env: Env, v: i64) -> Handle<'a, JsBigInt> {
+        unsafe {
+            let mut local: raw::Local = std::mem::zeroed();
+            neon_runtime::primitive::bigint(&mut local, env.to_raw(), v);
+            Handle::new_internal(JsBigInt(local))
+        }
+    }
+    */
+
+    pub fn value<'a, C: Context<'a>>(self, cx: &mut C) -> i64 {
+        let env = cx.env().to_raw();
+        unsafe { neon_runtime::bigint::value_i64(env, self.to_raw()) }
+    }
+
+}
+
+impl ValueInternal for JsBigInt {
+    fn name() -> String {
+        "bigint".to_string()
+    }
+
+    fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool {
+        unsafe { neon_runtime::tag::is_bigint(env.to_raw(), other.to_raw()) }
+    }
+}

--- a/src/types/bigint.rs
+++ b/src/types/bigint.rs
@@ -41,7 +41,7 @@ pub struct GetBigIntLossyValueResult<T> {
 
 impl<T> fmt::Display for GetBigIntLossyValueResult<T>
 where
-    T: fmt::Display
+    T: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.value)
@@ -94,7 +94,6 @@ impl JsBigInt {
             lossless: result.1,
         }
     }
-
 }
 
 impl ValueInternal for JsBigInt {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -108,6 +108,8 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 
+#[cfg(feature = "napi-6")]
+pub use self::bigint::JsBigInt;
 #[cfg(feature = "legacy-runtime")]
 pub use self::binary::{BinaryData, BinaryViewType, JsArrayBuffer, JsBuffer};
 #[cfg(feature = "napi-1")]
@@ -119,8 +121,6 @@ pub use self::date::{DateError, DateErrorKind, JsDate};
 pub use self::error::JsError;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 pub use self::promise::{Deferred, JsPromise};
-#[cfg(feature = "napi-6")]
-pub use self::bigint::{JsBigInt};
 
 pub(crate) fn build<'a, T: Managed, F: FnOnce(&mut raw::Local) -> bool>(
     env: Env,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -87,6 +87,8 @@ pub mod function;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 pub(crate) mod promise;
 
+#[cfg(feature = "napi-6")]
+pub(crate) mod bigint;
 pub(crate) mod private;
 pub(crate) mod utf8;
 
@@ -117,6 +119,8 @@ pub use self::date::{DateError, DateErrorKind, JsDate};
 pub use self::error::JsError;
 #[cfg(all(feature = "napi-1", feature = "promise-api"))]
 pub use self::promise::{Deferred, JsPromise};
+#[cfg(feature = "napi-6")]
+pub use self::bigint::{JsBigInt};
 
 pub(crate) fn build<'a, T: Managed, F: FnOnce(&mut raw::Local) -> bool>(
     env: Env,

--- a/test/napi/src/js/types.rs
+++ b/test/napi/src/js/types.rs
@@ -54,6 +54,12 @@ pub fn is_number(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     Ok(cx.boolean(result))
 }
 
+pub fn is_bigint(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let val: Handle<JsValue> = cx.argument(0)?;
+    let result = val.is_a::<JsBigInt, _>(&mut cx);
+    Ok(cx.boolean(result))
+}
+
 pub fn is_object(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let val: Handle<JsValue> = cx.argument(0)?;
     let result = val.is_a::<JsObject, _>(&mut cx);

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -261,6 +261,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("is_error", is_error)?;
     cx.export_function("is_null", is_null)?;
     cx.export_function("is_number", is_number)?;
+    cx.export_function("is_bigint", is_bigint)?;
     cx.export_function("is_object", is_object)?;
     cx.export_function("is_string", is_string)?;
     cx.export_function("is_undefined", is_undefined)?;


### PR DESCRIPTION
Initial support for `JsBigInt` (neon) / `bigint` (js). So far implemented wrappers for creating and getting bigints using `i64` and `u64`.

TODO:
* [ ] Unit tests
* [ ] Doc updates
* [ ] Support arbitrary-length bigints via [`napi_create_bigint_words`](https://nodejs.org/api/n-api.html#napi_create_bigint_words)
  * [ ] Support rust `u128` and `i128` types by automatically using the above arbitrary-length API


Please let me know if this PR is headed in the right direction. I created it against the `next/0.10` branch as I had difficulties getting the `main` branch working correctly with the existing project I have to test this feature. 