### PR TITLE
fix: Compile errors from merging Throw changes

### DIFF
--- a/src/event/channel.rs
+++ b/src/event/channel.rs
@@ -129,7 +129,7 @@ impl Channel {
             // N-API creates a `HandleScope` before calling the callback.
             TaskContext::with_context(env, move |cx| {
                 // Error can be ignored; it only means the user didn't join
-                let _ = tx.send(f(cx));
+                let _ = tx.send(f(cx).map_err(|_| ()));
             });
         });
 
@@ -214,7 +214,8 @@ impl Drop for Channel {
 /// An owned permission to join on the result of a closure sent to the JavaScript main
 /// thread with [`Channel::send`].
 pub struct JoinHandle<T> {
-    rx: mpsc::Receiver<NeonResult<T>>,
+    // `Err` is always `Throw`, but `Throw` cannot be sent across threads
+    rx: mpsc::Receiver<Result<T, ()>>,
 }
 
 impl<T> JoinHandle<T> {

--- a/src/types/buffer/types.rs
+++ b/src/types/buffer/types.rs
@@ -24,7 +24,7 @@ impl JsBuffer {
         if let Ok(buf) = result {
             Ok(Handle::new_internal(Self(buf)))
         } else {
-            Err(Throw)
+            Err(Throw::new())
         }
     }
 
@@ -35,7 +35,7 @@ impl JsBuffer {
         if let Ok((buf, _)) = result {
             Ok(Handle::new_internal(Self(buf)))
         } else {
-            Err(Throw)
+            Err(Throw::new())
         }
     }
 
@@ -143,7 +143,7 @@ impl JsArrayBuffer {
         if let Ok(buf) = result {
             Ok(Handle::new_internal(Self(buf)))
         } else {
-            Err(Throw)
+            Err(Throw::new())
         }
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -933,7 +933,7 @@ impl JsFunction {
                 marker: PhantomData,
             }))
         } else {
-            Err(Throw)
+            Err(Throw::new())
         }
     }
 }


### PR DESCRIPTION
https://github.com/neon-bindings/neon/pull/862 was not up to date with `next/0.10` and the branch contained new uses of `Throw` that were not included.

This PR updates the additional usages to fix compilation issues.