### PR TITLE
Remove feature flags from accepted RFCs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,10 @@
 [alias]
 # Neon defines mutually exclusive feature flags which prevents using `cargo clippy --all-features`
 # The following aliases simplify linting the entire workspace
-check-napi = "check --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features proc-macros,try-catch-api,napi-experimental,promise-api,task-api"
-check-legacy = "check --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,try-catch-api,legacy-runtime"
-clippy-legacy = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,try-catch-api,legacy-runtime -- -A clippy::missing_safety_doc"
-clippy-napi = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features proc-macros,try-catch-api,napi-experimental,promise-api,task-api -- -A clippy::missing_safety_doc"
+check-napi = "check --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features napi-experimental"
+check-legacy = "check --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,legacy-runtime"
+clippy-legacy = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p tests -p static_tests --features event-handler-api,proc-macros,legacy-runtime -- -A clippy::missing_safety_doc"
+clippy-napi = "clippy --all-targets --no-default-features -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --features napi-experimental -- -A clippy::missing_safety_doc"
 neon-test = "test -p neon -p neon-runtime -p neon-build -p neon-macros -p electron-tests -p napi-tests --no-default-features --features=napi-experimental"
-neon-doc = "rustdoc --no-default-features --features=channel-api,napi-experimental,proc-macros,try-catch-api,promise-api,task-api -- --cfg docsrs"
-neon-doc-test = "test --doc --no-default-features --features=channel-api,napi-experimental,proc-macros,try-catch-api,promise-api,task-api"
+neon-doc = "rustdoc --no-default-features --features=napi-experimental -- --cfg docsrs"
+neon-doc-test = "test --doc --no-default-features --features=napi-experimental"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Use npm v8
-        run: npm install -g npm@8
+        # https://github.com/npm/cli/issues/4552
+        run: npm -g i npm@~8.3
       - name: install build-essential
         run: sudo apt-get install -y build-essential
       - name: npm install workspace

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Use npm v8
-        run: npm install -g npm@8
+        # https://github.com/npm/cli/issues/4552
+        run: npm -g i npm@~8.3
       - name: npm install workspace
         run: npm install
       - name: run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,13 @@ napi-6 = ["napi-5", "neon-runtime/napi-6"]
 napi-latest = ["napi-6"]
 napi-experimental = ["napi-6", "neon-runtime/napi-experimental"]
 
+# DEPRECATED: These perform no action and will be removed in 1.0
+try-catch-api = []
+channel-api = []
+event-queue-api = []
+promise-api = []
+task-api = []
+
 # Feature flag to disable external dependencies on docs build
 # DEPRECATED: Will be removed with `legacy-runtime`
 docs-only = ["neon-runtime/docs-only"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,15 @@ default = ["legacy-runtime"]
 
 # Enable static tests. These can be fragile because of variations in Rust compiler
 # error message formatting from version to version, so they're disabled by default.
+# TODO: https://github.com/neon-bindings/neon/issues/871
 enable-static-tests = []
 
 # Enable the EventHandler API of RFC 25.
+# DEPRECATED: Will be removed with `legacy-runtime`
 event-handler-api = []
 
 # Enable the default panic hook. Useful for debugging neon itself.
+# DEPRECATED: Will be removed with `legacy-runtime`
 default-panic-hook = []
 
 # Feature flag to enable the legacy V8/NAN runtime. For now, this feature is
@@ -62,6 +65,7 @@ napi-latest = ["napi-6"]
 napi-experimental = ["napi-6", "neon-runtime/napi-experimental"]
 
 # Feature flag to disable external dependencies on docs build
+# DEPRECATED: Will be removed with `legacy-runtime`
 docs-only = ["neon-runtime/docs-only"]
 
 # Feature flag to enable the try_catch API of RFC 29.
@@ -75,6 +79,7 @@ channel-api = []
 event-queue-api = ["channel-api"]
 
 # Feature flag to include procedural macros
+# DEPRECATED: Will be removed with `legacy-runtime` since it is enabled by default in Node-API backend.
 proc-macros = ["neon-macros"]
 
 # Enable `JsPromise` and `Deferred`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,13 +68,6 @@ napi-experimental = ["napi-6", "neon-runtime/napi-experimental"]
 # DEPRECATED: Will be removed with `legacy-runtime`
 docs-only = ["neon-runtime/docs-only"]
 
-# Feature flag to enable the `EventQueue` API of RFC 33.
-# https://github.com/neon-bindings/rfcs/pull/32
-channel-api = []
-
-# Deprecated name for `channel-api`
-event-queue-api = ["channel-api"]
-
 # Feature flag to include procedural macros
 # DEPRECATED: Will be removed with `legacy-runtime` since it is enabled by default in Node-API backend.
 proc-macros = ["neon-macros"]
@@ -90,7 +83,6 @@ task-api = []
 no-default-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 features = [
-    "channel-api",
     "napi-experimental",
     "proc-macros",
     "promise-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,6 @@ napi-experimental = ["napi-6", "neon-runtime/napi-experimental"]
 # DEPRECATED: Will be removed with `legacy-runtime`
 docs-only = ["neon-runtime/docs-only"]
 
-# Feature flag to enable the try_catch API of RFC 29.
-try-catch-api = []
-
 # Feature flag to enable the `EventQueue` API of RFC 33.
 # https://github.com/neon-bindings/rfcs/pull/32
 channel-api = []
@@ -96,7 +93,6 @@ features = [
     "channel-api",
     "napi-experimental",
     "proc-macros",
-    "try-catch-api",
     "promise-api",
     "task-api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,6 @@ docs-only = ["neon-runtime/docs-only"]
 # DEPRECATED: Will be removed with `legacy-runtime` since it is enabled by default in Node-API backend.
 proc-macros = ["neon-macros"]
 
-# Enable `JsPromise` and `Deferred`
-# https://github.com/neon-bindings/rfcs/pull/35
-promise-api = []
 # Enable `TaskBuilder`
 # https://github.com/neon-bindings/rfcs/pull/35
 task-api = []
@@ -85,7 +82,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = [
     "napi-experimental",
     "proc-macros",
-    "promise-api",
     "task-api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,17 +72,12 @@ docs-only = ["neon-runtime/docs-only"]
 # DEPRECATED: Will be removed with `legacy-runtime` since it is enabled by default in Node-API backend.
 proc-macros = ["neon-macros"]
 
-# Enable `TaskBuilder`
-# https://github.com/neon-bindings/rfcs/pull/35
-task-api = []
-
 [package.metadata.docs.rs]
 no-default-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 features = [
     "napi-experimental",
     "proc-macros",
-    "task-api",
 ]
 
 [workspace]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -155,7 +155,7 @@ use crate::borrow::{Borrow, BorrowMut, Ref, RefMut};
 use crate::context::internal::Env;
 #[cfg(feature = "napi-4")]
 use crate::event::Channel;
-#[cfg(all(feature = "napi-1", feature = "task-api"))]
+#[cfg(feature = "napi-1")]
 use crate::event::TaskBuilder;
 use crate::handle::{Handle, Managed};
 #[cfg(feature = "napi-6")]
@@ -634,14 +634,13 @@ pub trait Context<'a>: ContextInternal<'a> {
         JsPromise::new(self)
     }
 
-    #[cfg(all(feature = "napi-1", feature = "task-api"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "task-api")))]
+    #[cfg(feature = "napi-1")]
     /// Creates a [`TaskBuilder`] which can be used to schedule the `execute`
     /// callback to asynchronously execute on the
     /// [Node worker pool](https://nodejs.org/en/docs/guides/dont-block-the-event-loop/).
     ///
     /// ```
-    /// # #[cfg(all(feature = "napi-1", feature = "task-api"))] {
+    /// # #[cfg(feature = "napi-1")] {
     /// # use neon::prelude::*;
     /// fn greet(mut cx: FunctionContext) -> JsResult<JsPromise> {
     ///     let name = cx.argument::<JsString>(0)?.value(&mut cx);
@@ -924,7 +923,7 @@ impl<'a> TaskContext<'a> {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }
 
-    #[cfg(any(all(feature = "napi-1", feature = "task-api"), feature = "napi-4"))]
+    #[cfg(feature = "napi-1")]
     pub(crate) fn with_context<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: Env, f: F) -> T {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -441,6 +441,10 @@ pub trait Context<'a>: ContextInternal<'a> {
         result
     }
 
+    #[cfg_attr(
+        feature = "try-catch-api",
+        deprecated = "`try-catch-api` feature has no impact and may be removed"
+    )]
     fn try_catch<T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
     where
         F: FnOnce(&mut Self) -> NeonResult<T>,
@@ -598,6 +602,21 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(feature = "napi-4")]
+    #[deprecated(since = "0.9.0", note = "Please use the channel() method instead")]
+    #[doc(hidden)]
+    fn queue(&mut self) -> Channel {
+        self.channel()
+    }
+
+    #[cfg(feature = "napi-4")]
+    #[cfg_attr(
+        feature = "channel-api",
+        deprecated = "`channel-api` feature has no impact and may be removed"
+    )]
+    #[cfg_attr(
+        all(not(feature = "channel-api"), feature = "event-queue-api"),
+        deprecated = "`event-queue-api` feature has no impact and may be removed"
+    )]
     #[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
     /// Returns an unbounded channel for scheduling events to be executed on the JavaScript thread.
     ///
@@ -614,6 +633,10 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(feature = "napi-1")]
+    #[cfg_attr(
+        feature = "promise-api",
+        deprecated = "`promise-api` feature has no impact and may be removed"
+    )]
     /// Creates a [`Deferred`] and [`JsPromise`] pair. The [`Deferred`] handle can be
     /// used to resolve or reject the [`JsPromise`].
     ///
@@ -635,6 +658,10 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     #[cfg(feature = "napi-1")]
+    #[cfg_attr(
+        feature = "task-api",
+        deprecated = "`task-api` feature has no impact and may be removed"
+    )]
     /// Creates a [`TaskBuilder`] which can be used to schedule the `execute`
     /// callback to asynchronously execute on the
     /// [Node worker pool](https://nodejs.org/en/docs/guides/dont-block-the-event-loop/).

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -171,7 +171,7 @@ pub use crate::types::buffer::lock::Lock;
 #[cfg(feature = "napi-5")]
 use crate::types::date::{DateError, JsDate};
 use crate::types::error::JsError;
-#[cfg(all(feature = "napi-1", feature = "promise-api"))]
+#[cfg(feature = "napi-1")]
 use crate::types::{Deferred, JsPromise};
 use crate::types::{
     JsArray, JsArrayBuffer, JsBoolean, JsBuffer, JsFunction, JsNull, JsNumber, JsObject, JsString,
@@ -613,13 +613,12 @@ pub trait Context<'a>: ContextInternal<'a> {
         channel
     }
 
-    #[cfg(all(feature = "napi-1", feature = "promise-api"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "promise-api")))]
+    #[cfg(feature = "napi-1")]
     /// Creates a [`Deferred`] and [`JsPromise`] pair. The [`Deferred`] handle can be
     /// used to resolve or reject the [`JsPromise`].
     ///
     /// ```
-    /// # #[cfg(all(feature = "napi-1", feature = "promise-api"))] {
+    /// # #[cfg(feature = "napi-1")] {
     /// # use neon::prelude::*;
     /// fn resolve_promise(mut cx: FunctionContext) -> JsResult<JsPromise> {
     ///     let (deferred, promise) = cx.promise();
@@ -642,7 +641,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// [Node worker pool](https://nodejs.org/en/docs/guides/dont-block-the-event-loop/).
     ///
     /// ```
-    /// # #[cfg(all(feature = "napi-1", feature = "promise-api", feature = "task-api"))] {
+    /// # #[cfg(all(feature = "napi-1", feature = "task-api"))] {
     /// # use neon::prelude::*;
     /// fn greet(mut cx: FunctionContext) -> JsResult<JsPromise> {
     ///     let name = cx.argument::<JsString>(0)?.value(&mut cx);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -153,12 +153,12 @@ use crate::borrow::internal::Ledger;
 #[cfg(feature = "legacy-runtime")]
 use crate::borrow::{Borrow, BorrowMut, Ref, RefMut};
 use crate::context::internal::Env;
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[cfg(feature = "napi-4")]
 use crate::event::Channel;
 #[cfg(all(feature = "napi-1", feature = "task-api"))]
 use crate::event::TaskBuilder;
 use crate::handle::{Handle, Managed};
-#[cfg(all(feature = "napi-6", feature = "channel-api"))]
+#[cfg(feature = "napi-6")]
 use crate::lifecycle::InstanceData;
 #[cfg(feature = "legacy-runtime")]
 use crate::object::class::Class;
@@ -597,8 +597,8 @@ pub trait Context<'a>: ContextInternal<'a> {
         JsBox::new(self, v)
     }
 
-    #[cfg(all(feature = "napi-4", feature = "channel-api"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "channel-api"))))]
+    #[cfg(feature = "napi-4")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
     /// Returns an unbounded channel for scheduling events to be executed on the JavaScript thread.
     ///
     /// When using N-API >= 6,the channel returned by this method is backed by a shared queue.
@@ -611,13 +611,6 @@ pub trait Context<'a>: ContextInternal<'a> {
         let channel = Channel::new(self);
 
         channel
-    }
-
-    #[cfg(all(feature = "napi-4", feature = "channel-api"))]
-    #[deprecated(since = "0.9.0", note = "Please use the channel() method instead")]
-    #[doc(hidden)]
-    fn queue(&mut self) -> Channel {
-        self.channel()
     }
 
     #[cfg(all(feature = "napi-1", feature = "promise-api"))]
@@ -932,10 +925,7 @@ impl<'a> TaskContext<'a> {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }
 
-    #[cfg(any(
-        all(feature = "napi-1", feature = "task-api"),
-        all(feature = "napi-4", feature = "channel-api"),
-    ))]
+    #[cfg(any(all(feature = "napi-1", feature = "task-api"), feature = "napi-4"))]
     pub(crate) fn with_context<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: Env, f: F) -> T {
         Scope::with(env, |scope| f(TaskContext { scope }))
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -441,8 +441,6 @@ pub trait Context<'a>: ContextInternal<'a> {
         result
     }
 
-    #[cfg(feature = "try-catch-api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "try-catch-api")))]
     fn try_catch<T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
     where
         F: FnOnce(&mut Self) -> NeonResult<T>,

--- a/src/event/channel.rs
+++ b/src/event/channel.rs
@@ -54,7 +54,7 @@ type Callback = Box<dyn FnOnce(Env) + Send + 'static>;
 ///     Ok(cx.undefined())
 /// }
 /// ```
-#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "task-api"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 pub struct Channel {
     state: Arc<ChannelState>,
     has_ref: bool,
@@ -262,7 +262,7 @@ impl std::error::Error for JoinError {}
 //
 // NOTE: These docs will need to be updated to include `QueueFull` if bounded queues are
 // implemented.
-#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-4", feature = "task-api"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 pub struct SendError;
 
 impl std::fmt::Display for SendError {

--- a/src/event/channel.rs
+++ b/src/event/channel.rs
@@ -54,6 +54,14 @@ type Callback = Box<dyn FnOnce(Env) + Send + 'static>;
 ///     Ok(cx.undefined())
 /// }
 /// ```
+#[cfg_attr(
+    feature = "channel-api",
+    deprecated = "`channel-api` feature has no impact and may be removed"
+)]
+#[cfg_attr(
+    all(not(feature = "channel-api"), feature = "event-queue-api"),
+    deprecated = "`event-queue-api` feature has no impact and may be removed"
+)]
 #[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 pub struct Channel {
     state: Arc<ChannelState>,

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -135,6 +135,16 @@ pub use self::channel::{Channel, JoinError, JoinHandle, SendError};
 #[cfg(feature = "napi-1")]
 pub use self::task::TaskBuilder;
 
+#[cfg(feature = "napi-4")]
+#[deprecated(since = "0.9.0", note = "Please use the Channel type instead")]
+#[doc(hidden)]
+pub type EventQueue = self::channel::Channel;
+
+#[cfg(feature = "napi-4")]
+#[deprecated(since = "0.9.0", note = "Please use the SendError type instead")]
+#[doc(hidden)]
+pub type EventQueueError = self::channel::SendError;
+
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 mod event_handler;
 

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -123,27 +123,17 @@
 //! [psd-crate]: https://crates.io/crates/psd
 //! [psd-file]: https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/
 
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[cfg(feature = "napi-4")]
 mod channel;
 
 #[cfg(all(feature = "napi-1", feature = "task-api"))]
 mod task;
 
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[cfg(feature = "napi-4")]
 pub use self::channel::{Channel, JoinError, JoinHandle, SendError};
 
 #[cfg(all(feature = "napi-1", feature = "task-api"))]
 pub use self::task::TaskBuilder;
-
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
-#[deprecated(since = "0.9.0", note = "Please use the Channel type instead")]
-#[doc(hidden)]
-pub type EventQueue = self::channel::Channel;
-
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
-#[deprecated(since = "0.9.0", note = "Please use the SendError type instead")]
-#[doc(hidden)]
-pub type EventQueueError = self::channel::SendError;
 
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 mod event_handler;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -126,13 +126,13 @@
 #[cfg(feature = "napi-4")]
 mod channel;
 
-#[cfg(all(feature = "napi-1", feature = "task-api"))]
+#[cfg(feature = "napi-1")]
 mod task;
 
 #[cfg(feature = "napi-4")]
 pub use self::channel::{Channel, JoinError, JoinHandle, SendError};
 
-#[cfg(all(feature = "napi-1", feature = "task-api"))]
+#[cfg(feature = "napi-1")]
 pub use self::task::TaskBuilder;
 
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]

--- a/src/event/task.rs
+++ b/src/event/task.rs
@@ -8,6 +8,10 @@ use crate::handle::Handle;
 use crate::result::{JsResult, NeonResult};
 use crate::types::{Deferred, JsPromise, Value};
 
+#[cfg_attr(
+    feature = "task-api",
+    deprecated = "`task-api` feature has no impact and may be removed"
+)]
 /// Node asynchronous task builder
 ///
 /// ```

--- a/src/event/task.rs
+++ b/src/event/task.rs
@@ -8,7 +8,6 @@ use crate::handle::Handle;
 use crate::result::{JsResult, NeonResult};
 use crate::types::{Deferred, JsPromise, Value};
 
-#[cfg_attr(docsrs, doc(cfg(feature = "task-api")))]
 /// Node asynchronous task builder
 ///
 /// ```

--- a/src/event/task.rs
+++ b/src/event/task.rs
@@ -4,21 +4,14 @@ use std::thread;
 use neon_runtime::{async_work, raw};
 
 use crate::context::{internal::Env, Context, TaskContext};
-#[cfg(feature = "promise-api")]
 use crate::handle::Handle;
-#[cfg(feature = "promise-api")]
-use crate::result::JsResult;
-use crate::result::NeonResult;
-#[cfg(feature = "promise-api")]
-use crate::types::Value;
-#[cfg(feature = "promise-api")]
-use crate::types::{Deferred, JsPromise};
+use crate::result::{JsResult, NeonResult};
+use crate::types::{Deferred, JsPromise, Value};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "task-api")))]
 /// Node asynchronous task builder
 ///
 /// ```
-/// # #[cfg(feature = "promise-api")] {
 /// # use neon::prelude::*;
 /// fn greet(mut cx: FunctionContext) -> JsResult<JsPromise> {
 ///     let name = cx.argument::<JsString>(0)?.value(&mut cx);
@@ -29,7 +22,6 @@ use crate::types::{Deferred, JsPromise};
 ///
 ///     Ok(promise)
 /// }
-/// # }
 /// ```
 pub struct TaskBuilder<'cx, C, E> {
     cx: &'cx mut C,
@@ -61,8 +53,6 @@ where
         schedule(env, execute, complete);
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "promise-api")))]
-    #[cfg(feature = "promise-api")]
     /// Schedules a task to execute on the Node worker pool and returns a
     /// promise that is resolved with the value from the `complete` callback.
     ///
@@ -120,7 +110,6 @@ where
     });
 }
 
-#[cfg(feature = "promise-api")]
 // Schedule a task to execute on the Node worker pool and settle a `Promise` with the result
 fn schedule_promise<I, O, D, V>(env: Env, input: I, complete: D, deferred: Deferred)
 where
@@ -140,7 +129,6 @@ where
     }
 }
 
-#[cfg(feature = "promise-api")]
 fn complete_promise<O, D, V>(
     env: raw::Env,
     output: thread::Result<O>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,7 @@
 #[cfg(feature = "legacy-runtime")]
 pub mod borrow;
 pub mod context;
-#[cfg(any(
-    feature = "event-handler-api",
-    all(feature = "napi-1", feature = "task-api"),
-    feature = "napi-4"
-))]
+#[cfg(any(feature = "event-handler-api", feature = "napi-1"))]
 pub mod event;
 pub mod handle;
 pub mod meta;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub mod context;
 #[cfg(any(
     feature = "event-handler-api",
     all(feature = "napi-1", feature = "task-api"),
-    all(feature = "napi-4", feature = "channel-api")
+    feature = "napi-4"
 ))]
 pub mod event;
 pub mod handle;

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -15,7 +15,6 @@ use neon_runtime::raw::Env;
 use neon_runtime::tsfn::ThreadsafeFunction;
 
 use crate::context::Context;
-#[cfg(feature = "channel-api")]
 use crate::event::Channel;
 use crate::handle::root::NapiRef;
 #[cfg(feature = "promise-api")]
@@ -53,7 +52,6 @@ pub(crate) struct InstanceData {
     drop_queue: Arc<ThreadsafeFunction<DropData>>,
 
     /// Shared `Channel` that is cloned to be returned by the `cx.channel()` method
-    #[cfg(all(feature = "channel-api"))]
     shared_channel: Channel,
 }
 
@@ -101,7 +99,6 @@ impl InstanceData {
             queue
         };
 
-        #[cfg(all(feature = "channel-api"))]
         let shared_channel = {
             let mut channel = Channel::new(cx);
             channel.unref(cx);
@@ -111,7 +108,6 @@ impl InstanceData {
         let data = InstanceData {
             id: InstanceId::next(),
             drop_queue: Arc::new(drop_queue),
-            #[cfg(all(feature = "channel-api"))]
             shared_channel,
         };
 
@@ -125,7 +121,6 @@ impl InstanceData {
 
     /// Clones the shared channel and references it since new channels should start
     /// referenced, but the shared channel is unreferenced.
-    #[cfg(all(feature = "channel-api"))]
     pub(crate) fn channel<'a, C: Context<'a>>(cx: &mut C) -> Channel {
         let mut channel = InstanceData::get(cx).shared_channel.clone();
         channel.reference(cx);

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -17,7 +17,6 @@ use neon_runtime::tsfn::ThreadsafeFunction;
 use crate::context::Context;
 use crate::event::Channel;
 use crate::handle::root::NapiRef;
-#[cfg(feature = "promise-api")]
 use crate::types::promise::NodeApiDeferred;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -57,7 +56,6 @@ pub(crate) struct InstanceData {
 
 /// Wrapper for raw Node-API values to be dropped on the main thread
 pub(crate) enum DropData {
-    #[cfg(feature = "promise-api")]
     Deferred(NodeApiDeferred),
     Ref(NapiRef),
 }
@@ -68,7 +66,6 @@ impl DropData {
         if let Some(env) = env {
             unsafe {
                 match data {
-                    #[cfg(feature = "promise-api")]
                     DropData::Deferred(data) => data.leaked(env),
                     DropData::Ref(data) => data.unref(env),
                 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,6 +17,10 @@ pub use crate::event::EventHandler;
 #[cfg(feature = "napi-4")]
 #[doc(no_inline)]
 pub use crate::event::{Channel, SendError};
+#[cfg(feature = "napi-4")]
+#[doc(no_inline)]
+#[allow(deprecated)]
+pub use crate::event::{EventQueue, EventQueueError};
 #[doc(no_inline)]
 pub use crate::handle::Handle;
 #[cfg(feature = "legacy-runtime")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,13 +14,9 @@ pub use crate::declare_types;
 #[cfg(all(not(feature = "napi-1"), feature = "event-handler-api"))]
 #[doc(no_inline)]
 pub use crate::event::EventHandler;
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
+#[cfg(feature = "napi-4")]
 #[doc(no_inline)]
 pub use crate::event::{Channel, SendError};
-#[cfg(all(feature = "napi-4", feature = "channel-api"))]
-#[doc(no_inline)]
-#[allow(deprecated)]
-pub use crate::event::{EventQueue, EventQueueError};
 #[doc(no_inline)]
 pub use crate::handle::Handle;
 #[cfg(feature = "legacy-runtime")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -33,7 +33,7 @@ pub use crate::task::Task;
 #[cfg(feature = "legacy-runtime")]
 #[doc(no_inline)]
 pub use crate::types::BinaryData;
-#[cfg(all(feature = "napi-1", feature = "promise-api"))]
+#[cfg(feature = "napi-1")]
 #[doc(no_inline)]
 pub use crate::types::JsPromise;
 #[cfg(feature = "napi-1")]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -91,7 +91,7 @@ pub mod buffer;
 pub(crate) mod date;
 pub(crate) mod error;
 pub mod function;
-#[cfg(all(feature = "napi-1", feature = "promise-api"))]
+#[cfg(feature = "napi-1")]
 pub(crate) mod promise;
 
 pub(crate) mod private;
@@ -122,7 +122,7 @@ pub use self::buffer::types::{JsArrayBuffer, JsBuffer, JsTypedArray};
 #[cfg(feature = "napi-5")]
 pub use self::date::{DateError, DateErrorKind, JsDate};
 pub use self::error::JsError;
-#[cfg(all(feature = "napi-1", feature = "promise-api"))]
+#[cfg(feature = "napi-1")]
 pub use self::promise::{Deferred, JsPromise};
 
 pub(crate) fn build<'a, T: Managed, F: FnOnce(&mut raw::Local) -> bool>(

--- a/src/types/promise.rs
+++ b/src/types/promise.rs
@@ -23,6 +23,10 @@ const BOUNDARY: FailureBoundary = FailureBoundary {
 
 #[derive(Debug)]
 #[repr(transparent)]
+#[cfg_attr(
+    feature = "promise-api",
+    deprecated = "`promise-api` feature has no impact and may be removed"
+)]
 /// The JavaScript [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) value.
 ///
 /// [`JsPromise`] may be constructed with [`Context::promise`].

--- a/src/types/promise.rs
+++ b/src/types/promise.rs
@@ -21,7 +21,6 @@ const BOUNDARY: FailureBoundary = FailureBoundary {
     panic: "A panic occurred while resolving a `neon::types::Deferred`",
 };
 
-#[cfg_attr(docsrs, doc(cfg(feature = "promise-api")))]
 #[derive(Debug)]
 #[repr(transparent)]
 /// The JavaScript [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) value.
@@ -74,7 +73,6 @@ impl Value for JsPromise {}
 
 impl Object for JsPromise {}
 
-#[cfg_attr(docsrs, doc(cfg(feature = "promise-api")))]
 /// [`Deferred`] is a handle that can be used to resolve or reject a [`JsPromise`]
 ///
 /// It is recommended to settle a [`Deferred`] with [`Deferred::settle_with`] to ensure

--- a/src/types/promise.rs
+++ b/src/types/promise.rs
@@ -7,17 +7,13 @@ use neon_runtime::no_panic::FailureBoundary;
 use neon_runtime::tsfn::ThreadsafeFunction;
 use neon_runtime::{napi, raw};
 
-use crate::context::{internal::Env, Context};
+use crate::context::{internal::Env, Context, TaskContext};
+use crate::event::{Channel, JoinHandle, SendError};
 use crate::handle::{internal::TransparentNoCopyWrapper, Managed};
 #[cfg(feature = "napi-6")]
 use crate::lifecycle::{DropData, InstanceData};
 use crate::result::JsResult;
 use crate::types::{private::ValueInternal, Handle, Object, Value};
-#[cfg(feature = "channel-api")]
-use crate::{
-    context::TaskContext,
-    event::{Channel, JoinHandle, SendError},
-};
 
 const BOUNDARY: FailureBoundary = FailureBoundary {
     both: "A panic and exception occurred while resolving a `neon::types::Deferred`",
@@ -116,8 +112,6 @@ impl Deferred {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "channel-api")))]
-    #[cfg(feature = "channel-api")]
     /// Settle the [`JsPromise`] by sending a closure across a [`Channel`][`crate::event::Channel`]
     /// to be executed on the main JavaScript thread.
     ///
@@ -140,15 +134,12 @@ impl Deferred {
         })
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "channel-api")))]
-    #[cfg(feature = "channel-api")]
     /// Settle the [`JsPromise`] by sending a closure across a [`Channel`][crate::event::Channel]
     /// to be executed on the main JavaScript thread.
     ///
     /// Panics if there is a libuv error.
     ///
     /// ```
-    /// # #[cfg(feature = "channel-api")] {
     /// # use neon::prelude::*;
     /// # fn example(mut cx: FunctionContext) -> JsResult<JsPromise> {
     /// let channel = cx.channel();
@@ -157,7 +148,6 @@ impl Deferred {
     /// deferred.settle_with(&channel, move |mut cx| Ok(cx.number(42)));
     ///
     /// # Ok(promise)
-    /// # }
     /// # }
     /// ```
     pub fn settle_with<V, F>(self, channel: &Channel, complete: F) -> JoinHandle<()>

--- a/test/dynamic/native/Cargo.toml
+++ b/test/dynamic/native/Cargo.toml
@@ -11,9 +11,9 @@ name = "tests"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = {version = "*", path = "../../../crates/neon-build"}
+neon-build = { version = "*", path = "../../../crates/neon-build" }
 
 [dependencies.neon]
 version = "*"
 path = "../../../"
-features = ["event-handler-api", "proc-macros", "try-catch-api"]
+features = ["event-handler-api", "proc-macros"]

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -16,4 +16,4 @@ once_cell = "1"
 version = "*"
 path = "../.."
 default-features = false
-features = ["napi-6", "task-api"]
+features = ["napi-6"]

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -16,4 +16,4 @@ once_cell = "1"
 version = "*"
 path = "../.."
 default-features = false
-features = ["default-panic-hook", "napi-6", "channel-api", "promise-api", "task-api"]
+features = ["default-panic-hook", "napi-6", "promise-api", "task-api"]

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -16,4 +16,4 @@ once_cell = "1"
 version = "*"
 path = "../.."
 default-features = false
-features = ["default-panic-hook", "napi-6", "promise-api", "task-api"]
+features = ["napi-6", "task-api"]

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -16,4 +16,4 @@ once_cell = "1"
 version = "*"
 path = "../.."
 default-features = false
-features = ["default-panic-hook", "napi-6", "try-catch-api", "channel-api", "promise-api", "task-api"]
+features = ["default-panic-hook", "napi-6", "channel-api", "promise-api", "task-api"]


### PR DESCRIPTION
## Background

Neon uses feature flags to provide early access to features that may change while the RFC is still open. However, after accepting an RFC, the feature flag should be removed and the feature provided by default.

## Overview

This PR removes several feature flags (`try-catch-api`, `channel-api`, `event-queue-api`, `promise-api`, and `task-api`). These features all have accepted RFCs.

Additionally, feature flags that are *only* used for the `legacy` backend are commented as deprecated. This will serve as a note to remove when removing the `legacy` backend.

## Alternative

This PR *completely* removes the feature flags. This is a breaking change that will require users to remove the feature flag when upgrading.

Alternatively, Neon could only remove *usages* of the feature flag, but keep the flag in `Cargo.toml` for backwards compatibility, deferring the breaking change to a later release.

## Follow-up

The `enable-static-tests` feature flag should also be removed. https://github.com/neon-bindings/neon/issues/871 was filed as a follow-up for this effort.