### PR TITLE
neon: Relax the lifetime constraints on `TypedArray` borrows

### DIFF
--- a/src/types/buffer/mod.rs
+++ b/src/types/buffer/mod.rs
@@ -22,17 +22,17 @@ pub trait TypedArray: private::Sealed {
     ///
     /// This may not be used if a mutable borrow is in scope. For the dynamically
     /// checked variant see [`TypedArray::try_borrow`].
-    fn as_slice<'a: 'b, 'b, C>(&'b self, cx: &'b C) -> &'b [Self::Item]
+    fn as_slice<'cx, 'a, C>(&self, cx: &'a C) -> &'a [Self::Item]
     where
-        C: Context<'a>;
+        C: Context<'cx>;
 
     /// Statically checked mutable borrow of binary data.
     ///
     /// This may not be used if any other borrow is in scope. For the dynamically
     /// checked variant see [`TypedArray::try_borrow_mut`].
-    fn as_mut_slice<'a: 'b, 'b, C>(&'b mut self, cx: &'b mut C) -> &'b mut [Self::Item]
+    fn as_mut_slice<'cx, 'a, C>(&mut self, cx: &'a mut C) -> &'a mut [Self::Item]
     where
-        C: Context<'a>;
+        C: Context<'cx>;
 
     /// Dynamically checked immutable borrow of binary data, returning an error if the
     /// the borrow would overlap with a mutable borrow.
@@ -40,12 +40,9 @@ pub trait TypedArray: private::Sealed {
     /// The borrow lasts until [`Ref`] exits scope.
     ///
     /// This is the dynamically checked version of [`TypedArray::as_slice`].
-    fn try_borrow<'a: 'b, 'b, C>(
-        &self,
-        lock: &'b Lock<'b, C>,
-    ) -> Result<Ref<'b, Self::Item>, BorrowError>
+    fn try_borrow<'cx, 'a, C>(&self, lock: &'a Lock<C>) -> Result<Ref<'a, Self::Item>, BorrowError>
     where
-        C: Context<'a>;
+        C: Context<'cx>;
 
     /// Dynamically checked mutable borrow of binary data, returning an error if the
     /// the borrow would overlap with an active borrow.
@@ -53,12 +50,12 @@ pub trait TypedArray: private::Sealed {
     /// The borrow lasts until [`RefMut`] exits scope.
     ///
     /// This is the dynamically checked version of [`TypedArray::as_mut_slice`].
-    fn try_borrow_mut<'a: 'b, 'b, C>(
+    fn try_borrow_mut<'cx, 'a, C>(
         &mut self,
-        lock: &'b Lock<'b, C>,
-    ) -> Result<RefMut<'b, Self::Item>, BorrowError>
+        lock: &'a Lock<C>,
+    ) -> Result<RefMut<'a, Self::Item>, BorrowError>
     where
-        C: Context<'a>;
+        C: Context<'cx>;
 }
 
 #[derive(Debug)]

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -233,4 +233,12 @@ describe("JsObject", function () {
     );
     assert.equal(addon.get_own_property_names(object).length, 1);
   });
+
+  it("data borrowed on the heap can be held longer than the handle", function () {
+    const msg = "Hello, World!";
+    const buf = Buffer.from(msg);
+
+    assert.strictEqual(addon.byte_length(msg), buf.length);
+    assert.strictEqual(addon.byte_length(buf), buf.length);
+  });
 });

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -242,6 +242,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("read_buffer_with_borrow", read_buffer_with_borrow)?;
     cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;
     cx.export_function("write_buffer_with_borrow_mut", write_buffer_with_borrow_mut)?;
+    cx.export_function("byte_length", byte_length)?;
 
     cx.export_function("create_date", create_date)?;
     cx.export_function("get_date_value", get_date_value)?;


### PR DESCRIPTION
The current lifetimes are overly restrictive. The reference is valid for as long as the handle is valid. Since the `Context` is always the most narrow scope, it will be valid for at *least* as long as `Context`, even if the `Handle` type is dropped. This allows downcasting and returning a borrow within the same function.

See this thread for more details. https://rust-bindings.slack.com/archives/C0HE1SA65/p1647378845225649
