### PR TITLE
`Object::call_with()`

### DIFF
--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -314,10 +314,7 @@ mod traits {
             K: PropertyKey,
         {
             let mut options = self.get::<JsFunction, _, _>(cx, method)?.call_with(cx);
-            options.this(Handle::new_internal(Self::from_raw(
-                cx.env(),
-                self.to_raw(),
-            )));
+            options.this(JsValue::new_internal(self.to_raw()));
             Ok(options)
         }
     }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -308,7 +308,7 @@ mod traits {
             Root::new(cx, self)
         }
 
-        fn call_with<'a, C, K>(&self, cx: &mut C, method: K) -> NeonResult<CallOptions<'a>>
+        fn call_method_with<'a, C, K>(&self, cx: &mut C, method: K) -> NeonResult<CallOptions<'a>>
         where
             C: Context<'a>,
             K: PropertyKey,

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -137,7 +137,7 @@ mod traits {
     use crate::result::{NeonResult, Throw};
     use crate::types::function::CallOptions;
     use crate::types::utf8::Utf8;
-    use crate::types::{build, JsUndefined, JsValue, Value, JsFunction};
+    use crate::types::{build, JsFunction, JsUndefined, JsValue, Value};
     use neon_runtime::raw;
 
     #[cfg(feature = "napi-6")]
@@ -314,7 +314,10 @@ mod traits {
             K: PropertyKey,
         {
             let mut options = self.get::<JsFunction, _, _>(cx, method)?.call_with(cx);
-            options.this(Handle::new_internal(Self::from_raw(cx.env(), self.to_raw())));
+            options.this(Handle::new_internal(Self::from_raw(
+                cx.env(),
+                self.to_raw(),
+            )));
             Ok(options)
         }
     }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -135,8 +135,9 @@ mod traits {
     use crate::context::Context;
     use crate::handle::{Handle, Managed, Root};
     use crate::result::{NeonResult, Throw};
+    use crate::types::function::CallOptions;
     use crate::types::utf8::Utf8;
-    use crate::types::{build, JsUndefined, JsValue, Value};
+    use crate::types::{build, JsUndefined, JsValue, Value, JsFunction};
     use neon_runtime::raw;
 
     #[cfg(feature = "napi-6")]
@@ -305,6 +306,16 @@ mod traits {
 
         fn root<'a, C: Context<'a>>(&self, cx: &mut C) -> Root<Self> {
             Root::new(cx, self)
+        }
+
+        fn call_with<'a, C, K>(&self, cx: &mut C, method: K) -> NeonResult<CallOptions<'a>>
+        where
+            C: Context<'a>,
+            K: PropertyKey,
+        {
+            let mut options = self.get::<JsFunction, _, _>(cx, method)?.call_with(cx);
+            options.this(Handle::new_internal(Self::from_raw(cx.env(), self.to_raw())));
+            Ok(options)
         }
     }
 

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -250,7 +250,7 @@ describe("JsObject", function () {
       },
       unary(x) {
         return this.value + x;
-      }
+      },
     };
 
     assert.strictEqual(addon.call_nullary_method(obj), 42);

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -265,6 +265,6 @@ describe("JsObject", function () {
       },
     };
 
-    assert.stringEqual(addon.call_symbol_method(obj, sym), "hello");
+    assert.strictEqual(addon.call_symbol_method(obj, sym), "hello");
   });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -256,4 +256,15 @@ describe("JsObject", function () {
     assert.strictEqual(addon.call_nullary_method(obj), 42);
     assert.strictEqual(addon.call_unary_method(obj, 17), 59);
   });
+
+  it("calling Object::call_with() with a symbol method name works", function () {
+    const sym = Symbol.for("mySymbol");
+    const obj = {
+      [sym]() {
+        return "hello";
+      },
+    };
+
+    assert.stringEqual(addon.call_symbol_method(obj, sym), "hello");
+  });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -241,4 +241,19 @@ describe("JsObject", function () {
     assert.strictEqual(addon.byte_length(msg), buf.length);
     assert.strictEqual(addon.byte_length(buf), buf.length);
   });
+
+  it("calling Object::call_with() properly calls object methods", function () {
+    const obj = {
+      value: 42,
+      nullary() {
+        return this.value;
+      },
+      unary(x) {
+        return this.value + x;
+      }
+    };
+
+    assert.strictEqual(addon.call_nullary_method(obj), 42);
+    assert.strictEqual(addon.call_unary_method(obj, 17), 59);
+  });
 });

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -230,3 +230,9 @@ pub fn call_unary_method(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let x: Handle<JsNumber> = cx.argument::<JsNumber>(1)?;
     obj.call_with(&mut cx, "unary")?.arg(x).apply(&mut cx)
 }
+
+pub fn call_symbol_method(mut cx: FunctionContext) -> JsResult<JsString> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    let sym: Handle<JsValue> = cx.argument::<JsValue>(1)?;
+    obj.call_with(&mut cx, sym)?.apply(&mut cx)
+}

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -222,17 +222,19 @@ pub fn byte_length(mut cx: FunctionContext) -> JsResult<JsNumber> {
 
 pub fn call_nullary_method(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
-    obj.call_with(&mut cx, "nullary")?.apply(&mut cx)
+    obj.call_method_with(&mut cx, "nullary")?.apply(&mut cx)
 }
 
 pub fn call_unary_method(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
     let x: Handle<JsNumber> = cx.argument::<JsNumber>(1)?;
-    obj.call_with(&mut cx, "unary")?.arg(x).apply(&mut cx)
+    obj.call_method_with(&mut cx, "unary")?
+        .arg(x)
+        .apply(&mut cx)
 }
 
 pub fn call_symbol_method(mut cx: FunctionContext) -> JsResult<JsString> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
     let sym: Handle<JsValue> = cx.argument::<JsValue>(1)?;
-    obj.call_with(&mut cx, sym)?.apply(&mut cx)
+    obj.call_method_with(&mut cx, sym)?.apply(&mut cx)
 }

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -219,3 +219,14 @@ pub fn byte_length(mut cx: FunctionContext) -> JsResult<JsNumber> {
 
     Ok(cx.number(len as f64))
 }
+
+pub fn call_nullary_method(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    obj.call_with(&mut cx, "nullary")?.apply(&mut cx)
+}
+
+pub fn call_unary_method(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    let x: Handle<JsNumber> = cx.argument::<JsNumber>(1)?;
+    obj.call_with(&mut cx, "unary")?.arg(x).apply(&mut cx)
+}

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -245,6 +245,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("byte_length", byte_length)?;
     cx.export_function("call_nullary_method", call_nullary_method)?;
     cx.export_function("call_unary_method", call_unary_method)?;
+    cx.export_function("call_symbol_method", call_symbol_method)?;
 
     cx.export_function("create_date", create_date)?;
     cx.export_function("get_date_value", get_date_value)?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -243,6 +243,8 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;
     cx.export_function("write_buffer_with_borrow_mut", write_buffer_with_borrow_mut)?;
     cx.export_function("byte_length", byte_length)?;
+    cx.export_function("call_nullary_method", call_nullary_method)?;
+    cx.export_function("call_unary_method", call_unary_method)?;
 
     cx.export_function("create_date", create_date)?;
     cx.export_function("get_date_value", get_date_value)?;


### PR DESCRIPTION
Add `Object::call_with()` convenience method to call a method on an object.

Example:

```rust
let s: Handle<JsString> = date.call_with(&mut cx, "toLocaleString")?
    .arg(cx.string("en-GB"))
    .apply(&mut cx)?;
```

Closes #873.

## Design questions

- Are we OK with the inconsistencies with `JsFunction::call_with()`?
  - This is fallible.
  - This takes a mutable reference to the context.
- Alternative names: `date.call_with()` vs `date.call_method()` vs `date.call_method_with()` 