### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         rust-toolchain: [nightly]
 
     steps:
@@ -30,8 +30,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: install build-essential
-        run: sudo apt-get install -y build-essential
       - run: npm install
       - name: Prettier Formatting
         run: npm run prettier:check

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        rust-toolchain: [stable, beta, nightly]
+        node-version: [14.x, 16.x, 18.x]
+        rust-toolchain: [stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,8 +33,6 @@ jobs:
       - name: Use npm v8
         # https://github.com/npm/cli/issues/4552
         run: npm -g i npm@~8.3
-      - name: install build-essential
-        run: sudo apt-get install -y build-essential
       - name: npm install workspace
         run: npm install
       - name: run tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        rust-toolchain: [stable, beta, nightly]
+        node-version: [14.x, 16.x, 18.x]
+        rust-toolchain: [stable, nightly]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        rust-toolchain: [stable, beta, nightly]
+        node-version: [14.x, 16.x, 18.x]
+        rust-toolchain: [stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
@@ -31,22 +31,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install libclang
-        uses: KyleMayes/install-llvm-action@01144dc97b1e2693196c3056414a44f15180648b
-        with:
-          version: "10"
-          directory: ${{ runner.temp }}/llvm
       - name: Use npm v8
         # Windows bug in npm 8.4
         # https://github.com/npm/cli/issues/4341
         run: npm -g i npm@~8.3
-      - name: Update header files
-        run: npx node-gyp install
-      - name: Configure MSVS version
-        run: npm config set msvs_version 2022
       - name: npm install workspace
         run: npm install
-        env:
-          LIBCLANG_PATH: ${{ runner.temp }}/llvm/bin
       - name: run tests
         run: npm test

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -11,10 +11,13 @@ exclude = ["neon.jpg", "doc/**/*"]
 edition = "2018"
 
 [dev-dependencies]
-nodejs-sys = "0.13.0"
 semver = "0.9"
 psd = "0.1.9"     # used for a doc example
 failure = "0.1.5" # used for a doc example
+
+[target.'cfg(not(target = "windows"))'.dev-dependencies]
+# Avoid `clang` as a dependency on windows
+nodejs-sys = "0.13.0"
 
 [dependencies]
 libloading = "0.7.3"

--- a/crates/neon/src/sys/bindings/mod.rs
+++ b/crates/neon/src/sys/bindings/mod.rs
@@ -3,8 +3,8 @@
 //! These types are manually copied from bindings generated from `bindgen`. To
 //! update, use the following approach:
 //!
-//! * Run `cargo test` at least once to install `nodejs-sys`
-//! * Open the generated bindings at `target/release/build/nodejs-sys-*/out/bindings.rs`
+//! * Run `cargo build` with `--cfg neon=dev` at least once to install `nodejs-sys`
+//! * Open the generated bindings at `target/debug/build/nodejs-sys-*/out/bindings.rs`
 //! * Copy the types needed into `types.rs` and `functions.rs`
 //! * Modify to match Rust naming conventions:
 //!   - Remove `napi_` prefixes


### PR DESCRIPTION
* Remove clang dependency on Windows
* Drop Node 12, add Node 18
* Use latest npm 8
* Drop Rust beta channel from the build matrix

I looked through a lot of history and the best I could tell, testing on `beta` has never caught a bug. Nightly is nice for new linting, but I chose to drop beta since it's redundant with `nightly` and will shrink the build matrix some.