### PR TITLE
soundness(neon): Require `T: 'static` on `JsArrayBuffer::external` and `JsBuffer::external`

### DIFF
--- a/crates/neon/src/types/buffer/types.rs
+++ b/crates/neon/src/types/buffer/types.rs
@@ -44,7 +44,7 @@ impl JsBuffer {
     pub fn external<'a, C, T>(cx: &mut C, data: T) -> Handle<'a, Self>
     where
         C: Context<'a>,
-        T: AsMut<[u8]> + Send,
+        T: AsMut<[u8]> + Send + 'static,
     {
         let env = cx.env().to_raw();
         let value = unsafe { sys::buffer::new_external(env, data) };
@@ -157,7 +157,7 @@ impl JsArrayBuffer {
     pub fn external<'a, C, T>(cx: &mut C, data: T) -> Handle<'a, Self>
     where
         C: Context<'a>,
-        T: AsMut<[u8]> + Send,
+        T: AsMut<[u8]> + Send + 'static,
     {
         let env = cx.env().to_raw();
         let value = unsafe { sys::arraybuffer::new_external(env, data) };


### PR DESCRIPTION
Currently, types used as the backing storage of external `ArrayBuffer` do not need to be `'static`! This makes it trivial to create a soundness hole (use after free), with only safe Rust.

```rust
pub fn soundness_hole(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
    let mut data = vec![0u8, 1, 2, 3];
    
    // Creating an external from `&mut [u8]` instead of `Vec<u8>` since there is a blanket impl
    // of `AsMut<T> for &mut T`
    let buf = JsArrayBuffer::external(&mut cx, data.as_mut_slice());

    // `buf` is still holding a reference to `data`!
    drop(data);

    Ok(buf)
}
```

Fixes https://github.com/neon-bindings/neon/issues/896