### PR TITLE
soundness(neon): Require `T: 'static` on `JsArrayBuffer::external` and `JsBuffer::external`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "A safe abstraction layer for Node.js."
 readme = "README.md"
@@ -12,7 +12,7 @@ build = "build.rs"
 edition = "2018"
 
 [build-dependencies]
-neon-build = { version = "=0.10.0", path = "crates/neon-build" }
+neon-build = { version = "=0.10.1", path = "crates/neon-build" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -24,8 +24,8 @@ failure = "0.1.5" # used for a doc example
 [dependencies]
 semver = "0.9.0"
 smallvec = "1.4.2"
-neon-runtime = { version = "=0.10.0", path = "crates/neon-runtime" }
-neon-macros = { version = "=0.10.0", path = "crates/neon-macros", optional = true }
+neon-runtime = { version = "=0.10.1", path = "crates/neon-runtime" }
+neon-macros = { version = "=0.10.1", path = "crates/neon-macros", optional = true }
 
 [features]
 default = ["legacy-runtime"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,27 @@
+# Version 0.10.1
+
+Fix a soundness hole in `JsArrayBuffer::external`
+and `JsBuffer::external` (https://github.com/neon-bindings/neon/pull/897).
+
+Thanks to [@Cassy343](https://github.com/Cassy343) for finding the [issue](https://github.com/neon-bindings/neon/issues/896)!
+
+In previous versions of Neon, it was possible to create a `JsArrayBuffer` or `JsBuffer` that references data without the `'static` lifetime.
+
+```rust
+pub fn soundness_hole(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
+    let mut data = vec![0u8, 1, 2, 3];
+    
+    // Creating an external from `&mut [u8]` instead of `Vec<u8>` since there is a blanket impl
+    // of `AsMut<T> for &mut T`
+    let buf = JsArrayBuffer::external(&mut cx, data.as_mut_slice());
+
+    // `buf` is still holding a reference to `data`!
+    drop(data);
+
+    Ok(buf)
+}
+```
+
 # Version 0.10
 
 See the [Neon 0.10 Migration Guide](MIGRATION_GUIDE_0.10.md) for more details about new features and breaking changes.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Build and load native Rust/Neon modules.",
   "author": "Dave Herman <david.herman@gmail.com>",
   "repository": {

--- a/crates/neon-build/Cargo.toml
+++ b/crates/neon-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-build"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Build logic required for Neon projects."
 repository = "https://github.com/neon-bindings/neon"
@@ -9,4 +9,4 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-neon-sys = { version = "=0.10.0", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.10.1", path = "../neon-sys", optional = true }

--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-macros"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Procedural macros supporting Neon"
 repository = "https://github.com/neon-bindings/neon"

--- a/crates/neon-runtime/Cargo.toml
+++ b/crates/neon-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-runtime"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dave Herman <david.herman@gmail.com>"]
 description = "Bindings to the Node.js native addon API, used by the Neon implementation."
 repository = "https://github.com/neon-bindings/neon"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0.0"
 libloading = { version = "0.6.5", optional = true }
-neon-sys = { version = "=0.10.0", path = "../neon-sys", optional = true }
+neon-sys = { version = "=0.10.1", path = "../neon-sys", optional = true }
 smallvec = "1.4.2"
 
 [dev-dependencies]

--- a/crates/neon-sys/Cargo.toml
+++ b/crates/neon-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-sys"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["David Herman <david.herman@gmail.com>"]
 description = "Exposes the low-level V8/NAN C/C++ APIs. Will be superseded by N-API."
 edition = "2018"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "cli": {
       "name": "neon-cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "SEE LICENSE IN LICENSE-*",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/src/types/buffer/types.rs
+++ b/src/types/buffer/types.rs
@@ -43,7 +43,7 @@ impl JsBuffer {
     pub fn external<'a, C, T>(cx: &mut C, data: T) -> Handle<'a, Self>
     where
         C: Context<'a>,
-        T: AsMut<[u8]> + Send,
+        T: AsMut<[u8]> + Send + 'static,
     {
         let env = cx.env().to_raw();
         let value = unsafe { neon_runtime::buffer::new_external(env, data) };
@@ -151,7 +151,7 @@ impl JsArrayBuffer {
     pub fn external<'a, C, T>(cx: &mut C, data: T) -> Handle<'a, Self>
     where
         C: Context<'a>,
-        T: AsMut<[u8]> + Send,
+        T: AsMut<[u8]> + Send + 'static,
     {
         let env = cx.env().to_raw();
         let value = unsafe { neon_runtime::arraybuffer::new_external(env, data) };


### PR DESCRIPTION
Currently, types used as the backing storage of external `ArrayBuffer` do not need to be `'static`! This makes it trivial to create a soundness hole (use after free), with only safe Rust.

```rust
pub fn soundness_hole(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
    let mut data = vec![0u8, 1, 2, 3];
    
    // Creating an external from `&mut [u8]` instead of `Vec<u8>` since there is a blanket impl
    // of `AsMut<T> for &mut T`
    let buf = JsArrayBuffer::external(&mut cx, data.as_mut_slice());

    // `buf` is still holding a reference to `data`!
    drop(data);

    Ok(buf)
}
```

Fixes https://github.com/neon-bindings/neon/issues/896