### PR TITLE
neon: Remove JsResultExt

### DIFF
--- a/crates/neon/src/handle/mod.rs
+++ b/crates/neon/src/handle/mod.rs
@@ -63,7 +63,7 @@ pub use self::root::Root;
 use crate::{
     context::{internal::Env, Context},
     handle::internal::{SuperType, TransparentNoCopyWrapper},
-    result::{JsResult, JsResultExt},
+    result::{JsResult, ResultExt},
     sys::{self, raw},
     types::Value,
 };
@@ -138,7 +138,7 @@ impl<F: Value, T: Value> Error for DowncastError<F, T> {}
 /// The result of a call to [`Handle::downcast()`](Handle::downcast).
 pub type DowncastResult<'a, F, T> = Result<Handle<'a, T>, DowncastError<F, T>>;
 
-impl<'a, F: Value, T: Value> JsResultExt<'a, T> for DowncastResult<'a, F, T> {
+impl<'a, F: Value, T: Value> ResultExt<Handle<'a, T>> for DowncastResult<'a, F, T> {
     fn or_throw<'b, C: Context<'b>>(self, cx: &mut C) -> JsResult<'a, T> {
         match self {
             Ok(v) => Ok(v),

--- a/crates/neon/src/prelude.rs
+++ b/crates/neon/src/prelude.rs
@@ -8,7 +8,7 @@ pub use crate::{
     },
     handle::{Handle, Root},
     object::Object,
-    result::{JsResult, JsResultExt, NeonResult, ResultExt as NeonResultExt},
+    result::{JsResult, NeonResult, ResultExt as NeonResultExt},
     types::{
         boxed::{Finalize, JsBox},
         JsArray, JsArrayBuffer, JsBoolean, JsBuffer, JsError, JsFunction, JsNull, JsNumber,

--- a/crates/neon/src/result/mod.rs
+++ b/crates/neon/src/result/mod.rs
@@ -38,7 +38,7 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::{context::Context, handle::Handle, types::Value};
+use crate::{context::Context, handle::Handle};
 
 /// A [unit type][unit] indicating that the JavaScript thread is throwing an exception.
 ///
@@ -68,12 +68,6 @@ pub type NeonResult<T> = Result<T, Throw>;
 
 /// Shorthand for a [`NeonResult`](NeonResult) that produces JavaScript values.
 pub type JsResult<'b, T> = NeonResult<Handle<'b, T>>;
-
-/// Extension trait for converting Rust [`Result`](std::result::Result) values
-/// into [`JsResult`](JsResult) values by throwing JavaScript exceptions.
-pub trait JsResultExt<'a, V: Value> {
-    fn or_throw<'b, C: Context<'b>>(self, cx: &mut C) -> JsResult<'a, V>;
-}
 
 /// Extension trait for converting Rust [`Result`](std::result::Result) values
 /// into [`NeonResult`](NeonResult) values by throwing JavaScript exceptions.

--- a/crates/neon/src/sys/bindings/mod.rs
+++ b/crates/neon/src/sys/bindings/mod.rs
@@ -37,7 +37,7 @@ macro_rules! napi_name {
 ///
 /// Sample input:
 ///
-/// ```
+/// ```ignore
 /// extern "C" {
 ///     fn get_undefined(env: Env, result: *mut Value) -> Status;
 ///     /* Additional functions may be included */  
@@ -46,7 +46,7 @@ macro_rules! napi_name {
 ///
 /// Generated output:
 ///
-/// ```
+/// ```ignore
 /// // Each field is a pointer to a N-API function
 /// struct Napi {
 ///     get_undefined: unsafe extern "C" fn(env: Env, result: *mut Value) -> Status,

--- a/crates/neon/src/types/date.rs
+++ b/crates/neon/src/types/date.rs
@@ -9,7 +9,7 @@ use crate::{
     context::{internal::Env, Context},
     handle::{internal::TransparentNoCopyWrapper, Handle, Managed},
     object::Object,
-    result::{JsResult, JsResultExt},
+    result::{JsResult, ResultExt},
     sys::{self, raw},
 };
 
@@ -75,7 +75,7 @@ impl DateErrorKind {
     }
 }
 
-impl<'a, T: Value> JsResultExt<'a, T> for Result<Handle<'a, T>, DateError> {
+impl<'a, T: Value> ResultExt<Handle<'a, T>> for Result<Handle<'a, T>, DateError> {
     /// Creates an `Error` on error
     fn or_throw<'b, C: Context<'b>>(self, cx: &mut C) -> JsResult<'a, T> {
         self.or_else(|e| cx.throw_range_error(e.0.as_str()))

--- a/crates/neon/src/types/mod.rs
+++ b/crates/neon/src/types/mod.rs
@@ -98,7 +98,7 @@ use crate::{
         Handle, Managed,
     },
     object::{Object, This},
-    result::{JsResult, JsResultExt, NeonResult, Throw},
+    result::{JsResult, NeonResult, ResultExt, Throw},
     sys::{self, raw},
     types::{
         function::{CallOptions, ConstructOptions},
@@ -388,7 +388,7 @@ impl fmt::Display for StringOverflow {
 /// The result of constructing a new `JsString`.
 pub type StringResult<'a> = Result<Handle<'a, JsString>, StringOverflow>;
 
-impl<'a> JsResultExt<'a, JsString> for StringResult<'a> {
+impl<'a> ResultExt<Handle<'a, JsString>> for StringResult<'a> {
     fn or_throw<'b, C: Context<'b>>(self, cx: &mut C) -> JsResult<'a, JsString> {
         match self {
             Ok(v) => Ok(v),


### PR DESCRIPTION
`JsResultExt` is redundant with `ResultExt`. They are identical traits except for an additional `V: Value` bound in `JsResultExt`.

Having two traits presents the opportunity for ambiguous method resolution. This PR proposes that we take the opportunity before 1.0 to make a breaking change and remove `JsResultExt`.

As demonstrated in the diff, replacing a `JsResultExt` implementation with `ResultExt` is as trivial as replacing `JsResultExt<..>` with `ResultExt<Handle<..>>`.