### PR TITLE
safety(neon): Improve safety of JsBox on Node-API >= 8

### DIFF
--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.58" # used for a doc example
 nodejs-sys = "0.13.0"
 
 [dependencies]
+getrandom = { version = "0.2.7", optional = true }
 libloading = "0.7.3"
 semver = "1"
 smallvec = "1.4.2"
@@ -55,7 +56,7 @@ napi-4 = ["napi-3"]
 napi-5 = ["napi-4"]
 napi-6 = ["napi-5"]
 napi-7 = ["napi-6"]
-napi-8 = ["napi-7"]
+napi-8 = ["napi-7", "getrandom"]
 napi-latest = ["napi-8"]
 napi-experimental = ["napi-8"]
 

--- a/crates/neon/src/sys/bindings/functions.rs
+++ b/crates/neon/src/sys/bindings/functions.rs
@@ -335,6 +335,13 @@ mod napi8 {
         extern "C" {
             fn object_freeze(env: Env, object: Value) -> Status;
             fn object_seal(env: Env, object: Value) -> Status;
+            fn type_tag_object(env: Env, object: Value, tag: *const TypeTag) -> Status;
+            fn check_object_type_tag(
+                env: Env,
+                object: Value,
+                tag: *const TypeTag,
+                result: *mut bool,
+            ) -> Status;
         }
     );
 }

--- a/crates/neon/src/sys/bindings/types.rs
+++ b/crates/neon/src/sys/bindings/types.rs
@@ -226,3 +226,11 @@ pub struct Deferred__ {
 }
 
 pub type Deferred = *mut Deferred__;
+
+#[cfg(feature = "napi-8")]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeTag {
+    pub(crate) lower: u64,
+    pub(crate) upper: u64,
+}

--- a/crates/neon/src/sys/tag.rs
+++ b/crates/neon/src/sys/tag.rs
@@ -114,3 +114,21 @@ pub unsafe fn is_promise(env: Env, val: Local) -> bool {
     );
     result
 }
+
+#[cfg(feature = "napi-8")]
+pub unsafe fn type_tag_object(env: Env, object: Local, tag: &super::TypeTag) {
+    assert_eq!(
+        napi::type_tag_object(env, object, tag as *const _),
+        napi::Status::Ok
+    );
+}
+
+#[cfg(feature = "napi-8")]
+pub unsafe fn check_object_type_tag(env: Env, object: Local, tag: &super::TypeTag) -> bool {
+    let mut result = false;
+    assert_eq!(
+        napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _),
+        napi::Status::Ok
+    );
+    result
+}


### PR DESCRIPTION
Generate a unique type id for the crate and tag externals. This is done at runtime instead of compile time to help with reproducible builds.

This requires that the module be built for Node-API 8+. In the future, we may want to do optional symbol loading for internal code that makes runtime decisions. That way we could provide this additional safety guarantee on newer versions of Node even if it was compiled for an older version.