### PR TITLE
doc(neon): Use anyhow instead of failure in a doc example

### DIFF
--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dev-dependencies]
 semver = "0.9"
-psd = "0.1.9"     # used for a doc example
-failure = "0.1.5" # used for a doc example
+psd = "0.3.1"     # used for a doc example
+anyhow = "1.0.58" # used for a doc example
 
 [target.'cfg(not(target = "windows"))'.dev-dependencies]
 # Avoid `clang` as a dependency on windows

--- a/crates/neon/src/event/mod.rs
+++ b/crates/neon/src/event/mod.rs
@@ -61,10 +61,10 @@
 //! ```
 //! # use neon::prelude::*;
 //! # use psd::Psd;
-//! # use failure::Error;
+//! # use anyhow::{Context as _, Result};
 //! #
-//! fn psd_from_filename(filename: String) -> Result<Psd, Error> {
-//!     Psd::from_bytes(&std::fs::read(&filename)?)
+//! fn psd_from_filename(filename: String) -> Result<Psd> {
+//!     Psd::from_bytes(&std::fs::read(&filename)?).context("invalid psd file")
 //! }
 //!
 //! fn parse(filename: String, callback: Root<JsFunction>, channel: Channel) {


### PR DESCRIPTION
[`failure` crate](https://github.com/rust-lang-deprecated/failure) is deprecated and unmaintained now, so I replace the code using `failure::Error` with `anyhow::{Context, Result}`.
