### PR TITLE
fix: Make native modules built with Neon work in Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Neon projects to 0.10!
 Support for [LTS versions of Node](https://github.com/nodejs/LTS#release-schedule) and current are expected. If you're
 using a different version of Node and believe it should be supported, let us know.
 
+### Bun (experimental)
+
+[Bun](https://bun.sh/) is an alternate JavaScript runtime that targets Node compatibility. In many cases Neon modules will work in bun; however, at the time of this writing, some Node-API functions are [not implemented](https://github.com/Jarred-Sumner/bun/issues/158).
+
 ### Rust
 
 Neon supports Rust stable version 1.18 and higher. We test on the latest stable, beta, and nightly versions of Rust.

--- a/crates/neon/src/sys/bindings/functions.rs
+++ b/crates/neon/src/sys/bindings/functions.rs
@@ -371,19 +371,19 @@ pub(super) unsafe fn load(env: Env) -> Result<(), libloading::Error> {
     // with `Error: Module did not self-register` if N-API does not exist.
     let version = get_version(&host, env).expect("Failed to find N-API version");
 
-    napi1::load(&host, version, 1)?;
+    napi1::load(&host, version, 1);
 
     #[cfg(feature = "napi-4")]
-    napi4::load(&host, version, 4)?;
+    napi4::load(&host, version, 4);
 
     #[cfg(feature = "napi-5")]
-    napi5::load(&host, version, 5)?;
+    napi5::load(&host, version, 5);
 
     #[cfg(feature = "napi-6")]
-    napi6::load(&host, version, 6)?;
+    napi6::load(&host, version, 6);
 
     #[cfg(feature = "napi-8")]
-    napi8::load(&host, version, 8)?;
+    napi8::load(&host, version, 8);
 
     Ok(())
 }


### PR DESCRIPTION
[bun](https://bun.sh/) is a new JavaScript runtime designed to be Node.js compatible--including Node-API. However, it currently ships with an incomplete set of Node-APIs.

The following changes symbol loading to print a warning to `stderr` if a symbol is missing instead of panicking. This should be no change on Node because symbols are guaranteed to exist if the Node-API version number matches. On `bun`, this converts a panic on load to a panic when attempting to use the API.

With these changes, simple Neon modules work with `bun`. However, because of Neon's heavily reliance on `napi_get_instance_data`, many more powerful features will not work until this API is implemented in bun.