### PR TITLE
fix: More accurate lifetime bounds on scoped methods to allow valid code to compile

### DIFF
--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -174,7 +174,10 @@ describe("JsFunction", function () {
   });
 
   it("computes a value in a scoped computation", function () {
+    const o = {};
+
     assert.equal(addon.compute_scoped(), 99);
+    assert.equal(addon.recompute_scoped(o), o);
   });
 
   it("catches an exception with cx.try_catch", function () {

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -215,6 +215,14 @@ pub fn compute_scoped(mut cx: FunctionContext) -> JsResult<JsNumber> {
     Ok(i)
 }
 
+// Simple identity function to verify that a handle can be moved to `compute_scoped`
+// closure and re-escaped.
+pub fn recompute_scoped(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let value = cx.argument::<JsValue>(0)?;
+
+    cx.compute_scoped(move |_| Ok(value))
+}
+
 pub fn throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     let v = cx
         .argument_opt(0)

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -193,6 +193,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("check_string_and_number", check_string_and_number)?;
     cx.export_function("execute_scoped", execute_scoped)?;
     cx.export_function("compute_scoped", compute_scoped)?;
+    cx.export_function("recompute_scoped", recompute_scoped)?;
 
     cx.export_function("return_js_array", return_js_array)?;
     cx.export_function("return_js_array_with_number", return_js_array_with_number)?;


### PR DESCRIPTION
Prior to this change, it was impossible to escape a value in `execute_scoped` that was created in an outer scope. This is because the
function definition allowed for the outer and inner lifetimes to be entirely unrelated.

This is technically a breaking change, but in many cases the more strict bound will cause code to be more likely to compile.

The following code compiles *after* this change, but not before:

```rust
fn example(mut cx: FunctionContext) -> JsResult<JsValue> {
    let value = cx.argument::<JsValue>(0)?;

    cx.compute_scoped(move |_| Ok(value))
}
```