### PR TITLE
fix(cargo-cp-artifact): Unlink .node files before copying to flush macOS code signature cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2284,7 +2284,7 @@
       }
     },
     "pkgs/cargo-cp-artifact": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
@@ -2334,7 +2334,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "cargo-cp-artifact": "^0.1.6",
+        "cargo-cp-artifact": "^0.1.7",
         "chai": "^4.3.6",
         "mocha": "^10.0.0"
       }
@@ -3493,7 +3493,7 @@
     "napi-tests": {
       "version": "file:test/napi",
       "requires": {
-        "cargo-cp-artifact": "^0.1.6",
+        "cargo-cp-artifact": "^0.1.7",
         "chai": "^4.3.6",
         "mocha": "^10.0.0"
       }

--- a/pkgs/cargo-cp-artifact/package.json
+++ b/pkgs/cargo-cp-artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cargo-cp-artifact",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Copies compiler artifacts emitted by rustc by parsing Cargo metadata",
   "main": "src/index.js",
   "files": [

--- a/test/electron/package.json
+++ b/test/electron/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/electron/electron-quick-start",
   "devDependencies": {
     "@playwright/test": "^1.23.1",
-    "cargo-cp-artifact": "^0.1.6",
+    "cargo-cp-artifact": "^0.1.7",
     "electron": "^19.0.7",
     "playwright": "^1.23.1"
   }

--- a/test/napi/package.json
+++ b/test/napi/package.json
@@ -9,7 +9,7 @@
     "test": "mocha --v8-expose-gc --timeout 5000 --recursive lib"
   },
   "devDependencies": {
-    "cargo-cp-artifact": "^0.1.6",
+    "cargo-cp-artifact": "^0.1.7",
     "chai": "^4.3.6",
     "mocha": "^10.0.0"
   }


### PR DESCRIPTION
Resolves https://github.com/neon-bindings/neon/issues/911