### PR TITLE
`TypedArray::from_slice()`

### DIFF
--- a/crates/neon/src/types_impl/buffer/mod.rs
+++ b/crates/neon/src/types_impl/buffer/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     result::{JsResult, NeonResult, ResultExt},
     types::{
         buffer::lock::{Ledger, Lock},
-        JsArrayBuffer, JsTypedArray,
+        JsArrayBuffer, JsTypedArray, Value,
     },
 };
 
@@ -47,7 +47,7 @@ pub use types::Binary;
 /// ```
 ///
 /// [typed-arrays]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays
-pub trait TypedArray: private::Sealed {
+pub trait TypedArray: private::Sealed + Value {
     type Item: Binary;
 
     /// Statically checked immutable borrow of binary data.
@@ -91,6 +91,11 @@ pub trait TypedArray: private::Sealed {
 
     /// Returns the size, in bytes, of the allocated binary data.
     fn size<'cx, C>(&self, cx: &mut C) -> usize
+    where
+        C: Context<'cx>;
+
+    /// Constructs an instance from a slice by copying its contents.
+    fn from_slice<'cx, C>(cx: &mut C, slice: &[Self::Item]) -> JsResult<'cx, Self>
     where
         C: Context<'cx>;
 }

--- a/crates/neon/src/types_impl/buffer/mod.rs
+++ b/crates/neon/src/types_impl/buffer/mod.rs
@@ -47,7 +47,7 @@ pub use types::Binary;
 /// ```
 ///
 /// [typed-arrays]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays
-pub trait TypedArray: private::Sealed + Value {
+pub trait TypedArray: Value {
     type Item: Binary;
 
     /// Statically checked immutable borrow of binary data.

--- a/crates/neon/src/types_impl/buffer/types.rs
+++ b/crates/neon/src/types_impl/buffer/types.rs
@@ -589,6 +589,22 @@ where
     }
 }
 
+impl<T: Binary> JsTypedArray<T>
+where
+    JsTypedArray<T>: Value,
+{
+    /// Constructs an instance from a slice by copying its contents.
+    ///
+    /// This method is defined on `JsTypedArray` as a convenience and delegates to
+    /// [`TypedArray::from_slice`][TypedArray::from_slice].
+    pub fn from_slice<'cx, C>(cx: &mut C, slice: &[T]) -> JsResult<'cx, Self>
+    where
+        C: Context<'cx>,
+    {
+        <JsTypedArray<T> as TypedArray>::from_slice(cx, slice)
+    }
+}
+
 impl<T: Binary> JsTypedArray<T> {
     /// Constructs a typed array that views `buffer`.
     ///

--- a/crates/neon/src/types_impl/buffer/types.rs
+++ b/crates/neon/src/types_impl/buffer/types.rs
@@ -365,7 +365,7 @@ impl TypedArray for JsArrayBuffer {
 /// A marker trait for all possible element types of binary buffers.
 ///
 /// This trait can only be implemented within the Neon library.
-pub trait Binary: private::Sealed + Clone {
+pub trait Binary: private::Sealed + Copy {
     /// The internal Node-API enum value for this binary type.
     const TYPE_TAG: TypedArrayType;
 }
@@ -498,7 +498,7 @@ impl<T: Binary> Managed for JsTypedArray<T> {
 
 impl<T> TypedArray for JsTypedArray<T>
 where
-    T: Binary + Copy,
+    T: Binary,
     Self: Value,
 {
     type Item = T;

--- a/crates/neon/src/types_impl/buffer/types.rs
+++ b/crates/neon/src/types_impl/buffer/types.rs
@@ -60,6 +60,17 @@ impl JsBuffer {
         }
     }
 
+    /// Constructs a `JsBuffer` from a slice by copying its contents.
+    ///
+    /// This method is defined on `JsBuffer` as a convenience and delegates to
+    /// [`TypedArray::from_slice`][TypedArray::from_slice].
+    pub fn from_slice<'cx, C>(cx: &mut C, slice: &[u8]) -> JsResult<'cx, Self>
+    where
+        C: Context<'cx>,
+    {
+        <JsBuffer as TypedArray>::from_slice(cx, slice)
+    }
+
     /// Constructs a new `Buffer` object with uninitialized memory
     pub unsafe fn uninitialized<'a, C: Context<'a>>(cx: &mut C, len: usize) -> JsResult<'a, Self> {
         let result = sys::buffer::uninitialized(cx.env().to_raw(), len);
@@ -214,6 +225,17 @@ impl JsArrayBuffer {
         } else {
             Err(Throw::new())
         }
+    }
+
+    /// Constructs a `JsArrayBuffer` from a slice by copying its contents.
+    ///
+    /// This method is defined on `JsArrayBuffer` as a convenience and delegates to
+    /// [`TypedArray::from_slice`][TypedArray::from_slice].
+    pub fn from_slice<'cx, C>(cx: &mut C, slice: &[u8]) -> JsResult<'cx, Self>
+    where
+        C: Context<'cx>,
+    {
+        <JsArrayBuffer as TypedArray>::from_slice(cx, slice)
     }
 
     /// Construct a new `JsArrayBuffer` from bytes allocated by Rust

--- a/crates/neon/src/types_impl/buffer/types.rs
+++ b/crates/neon/src/types_impl/buffer/types.rs
@@ -169,6 +169,16 @@ impl TypedArray for JsBuffer {
     fn size<'cx, C: Context<'cx>>(&self, cx: &mut C) -> usize {
         unsafe { sys::buffer::size(cx.env().to_raw(), self.to_raw()) }
     }
+
+    fn from_slice<'cx, C>(cx: &mut C, slice: &[u8]) -> JsResult<'cx, Self>
+    where
+        C: Context<'cx>,
+    {
+        let mut buffer = cx.buffer(slice.len())?;
+        let target = buffer.as_mut_slice(cx);
+        target.copy_from_slice(slice);
+        Ok(buffer)
+    }
 }
 
 /// The standard JS [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) type.
@@ -204,18 +214,6 @@ impl JsArrayBuffer {
         } else {
             Err(Throw::new())
         }
-    }
-
-    /// Constructs a new `JsArrayBuffer` object from a slice by copying its contents.
-    pub fn from_slice<'cx, C>(cx: &mut C, slice: &[u8]) -> JsResult<'cx, Self>
-    where
-        C: Context<'cx>,
-    {
-        let len = slice.len();
-        let mut buffer = JsArrayBuffer::new(cx, len)?;
-        let target = buffer.as_mut_slice(cx);
-        target.copy_from_slice(slice);
-        Ok(buffer)
     }
 
     /// Construct a new `JsArrayBuffer` from bytes allocated by Rust
@@ -350,6 +348,17 @@ impl TypedArray for JsArrayBuffer {
 
     fn size<'cx, C: Context<'cx>>(&self, cx: &mut C) -> usize {
         unsafe { sys::arraybuffer::size(cx.env().to_raw(), self.to_raw()) }
+    }
+
+    fn from_slice<'cx, C>(cx: &mut C, slice: &[u8]) -> JsResult<'cx, Self>
+    where
+        C: Context<'cx>,
+    {
+        let len = slice.len();
+        let mut buffer = JsArrayBuffer::new(cx, len)?;
+        let target = buffer.as_mut_slice(cx);
+        target.copy_from_slice(slice);
+        Ok(buffer)
     }
 }
 
@@ -487,7 +496,11 @@ impl<T: Binary> Managed for JsTypedArray<T> {
     }
 }
 
-impl<T: Binary> TypedArray for JsTypedArray<T> {
+impl<T> TypedArray for JsTypedArray<T>
+where
+    T: Binary + Copy,
+    Self: Value,
+{
     type Item = T;
 
     fn as_slice<'cx, 'a, C>(&self, cx: &'a C) -> &'a [Self::Item]
@@ -558,6 +571,21 @@ impl<T: Binary> TypedArray for JsTypedArray<T> {
 
     fn size<'cx, C: Context<'cx>>(&self, cx: &mut C) -> usize {
         self.len(cx) * std::mem::size_of::<Self::Item>()
+    }
+
+    fn from_slice<'cx, C>(cx: &mut C, slice: &[T]) -> JsResult<'cx, Self>
+    where
+        C: Context<'cx>,
+    {
+        let elt_size = std::mem::size_of::<T>();
+        let size = slice.len() * elt_size;
+        let buffer = cx.array_buffer(size)?;
+
+        let mut array = Self::from_buffer(cx, buffer)?;
+        let target = array.as_mut_slice(cx);
+        target.copy_from_slice(slice);
+
+        Ok(array)
     }
 }
 
@@ -684,24 +712,6 @@ impl<T: Binary> JsTypedArray<T> {
     {
         let info = unsafe { sys::typedarray::info(cx.env().to_raw(), self.to_raw()) };
         info.length
-    }
-}
-
-impl<T: Binary + Copy> JsTypedArray<T> {
-    /// Constructs a typed array from a slice by copying its contents.
-    pub fn from_slice<'cx, C>(cx: &mut C, slice: &[T]) -> JsResult<'cx, Self>
-    where
-        C: Context<'cx>,
-    {
-        let elt_size = std::mem::size_of::<T>();
-        let size = slice.len() * elt_size;
-        let buffer = cx.array_buffer(size)?;
-
-        let mut array = Self::from_buffer(cx, buffer)?;
-        let target = array.as_mut_slice(cx);
-        target.copy_from_slice(slice);
-
-        Ok(array)
     }
 }
 

--- a/test/napi/lib/typedarrays.js
+++ b/test/napi/lib/typedarrays.js
@@ -152,6 +152,14 @@ describe("Typed arrays", function () {
     assert.ok(b.equals(Buffer.alloc(16)));
   });
 
+  it("gets a 16-byte buffer initialized from a slice", function () {
+    var b = addon.return_array_buffer_from_slice(16);
+    var a = new Uint8Array(b);
+    for (var i = 0; i < 16; i++) {
+      assert.strictEqual(a[i], i);
+    }
+  });
+
   it("gets an external Buffer", function () {
     var expected = "String to copy";
     var buf = addon.return_external_buffer(expected);
@@ -240,6 +248,13 @@ describe("Typed arrays", function () {
       [...i32],
       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     );
+  });
+
+  it("gets a typed array copied from a slice", function () {
+    var i32 = addon.return_int32array_from_slice(16);
+    for (var i = 0; i < 16; i++) {
+      assert.strictEqual(i32[i], i);
+    }
   });
 
   it("gets correct typed array info", function () {

--- a/test/napi/src/js/typedarrays.rs
+++ b/test/napi/src/js/typedarrays.rs
@@ -8,6 +8,18 @@ pub fn return_array_buffer(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
     Ok(b)
 }
 
+pub fn return_array_buffer_from_slice(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
+    let len: Handle<JsNumber> = cx.argument(0)?;
+    let len: f64 = len.value(&mut cx);
+    let len: u32 = len as u32;
+    let mut v: Vec<u8> = Vec::new();
+    for i in 0..len {
+        v.push(i as u8);
+    }
+    let b: Handle<JsArrayBuffer> = JsArrayBuffer::from_slice(&mut cx, &v)?;
+    Ok(b)
+}
+
 pub fn read_array_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let buf = cx.argument::<JsTypedArray<u32>>(0)?;
     let i = cx.argument::<JsNumber>(1)?.value(&mut cx) as usize;
@@ -148,6 +160,18 @@ pub fn return_biguint64array_from_arraybuffer(
 pub fn return_new_int32array(mut cx: FunctionContext) -> JsResult<JsInt32Array> {
     let len = cx.argument::<JsNumber>(0)?.value(&mut cx) as usize;
     JsInt32Array::new(&mut cx, len)
+}
+
+pub fn return_int32array_from_slice(mut cx: FunctionContext) -> JsResult<JsInt32Array> {
+    let len: Handle<JsNumber> = cx.argument(0)?;
+    let len: f64 = len.value(&mut cx);
+    let len: u32 = len as u32;
+    let mut v: Vec<i32> = Vec::new();
+    for i in 0..len {
+        v.push(i as i32);
+    }
+    let a: Handle<JsInt32Array> = JsInt32Array::from_slice(&mut cx, &v)?;
+    Ok(a)
 }
 
 pub fn return_uint32array_from_arraybuffer_region(

--- a/test/napi/src/js/typedarrays.rs
+++ b/test/napi/src/js/typedarrays.rs
@@ -192,12 +192,13 @@ pub fn get_arraybuffer_byte_length(mut cx: FunctionContext) -> JsResult<JsNumber
     Ok(n)
 }
 
-fn typed_array_info<'cx, C, T: Binary>(
+fn typed_array_info<'cx, C, T: Binary + Copy>(
     cx: &mut C,
     a: Handle<'cx, JsTypedArray<T>>,
 ) -> JsResult<'cx, JsObject>
 where
     C: Context<'cx>,
+    JsTypedArray<T>: Value,
 {
     let offset = a.offset(cx);
     let offset = cx.number(offset as u32);

--- a/test/napi/src/js/typedarrays.rs
+++ b/test/napi/src/js/typedarrays.rs
@@ -9,15 +9,10 @@ pub fn return_array_buffer(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
 }
 
 pub fn return_array_buffer_from_slice(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
-    let len: Handle<JsNumber> = cx.argument(0)?;
-    let len: f64 = len.value(&mut cx);
-    let len: u32 = len as u32;
-    let mut v: Vec<u8> = Vec::new();
-    for i in 0..len {
-        v.push(i as u8);
-    }
-    let b: Handle<JsArrayBuffer> = JsArrayBuffer::from_slice(&mut cx, &v)?;
-    Ok(b)
+    let len = cx.argument::<JsNumber>(0)?.value(&mut cx) as usize;
+    let v = (0..len).map(|i| i as u8).collect::<Vec<_>>();
+
+    JsArrayBuffer::from_slice(&mut cx, &v)
 }
 
 pub fn read_array_buffer_with_lock(mut cx: FunctionContext) -> JsResult<JsNumber> {

--- a/test/napi/src/js/typedarrays.rs
+++ b/test/napi/src/js/typedarrays.rs
@@ -187,7 +187,7 @@ pub fn get_arraybuffer_byte_length(mut cx: FunctionContext) -> JsResult<JsNumber
     Ok(n)
 }
 
-fn typed_array_info<'cx, C, T: Binary + Copy>(
+fn typed_array_info<'cx, C, T: Binary>(
     cx: &mut C,
     a: Handle<'cx, JsTypedArray<T>>,
 ) -> JsResult<'cx, JsObject>

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -212,7 +212,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("seal_js_object", seal_js_object)?;
 
     cx.export_function("return_array_buffer", return_array_buffer)?;
-    cx.export_function("return_array_buffer_from_slice", return_array_buffer_from_slice)?;
+    cx.export_function(
+        "return_array_buffer_from_slice",
+        return_array_buffer_from_slice,
+    )?;
     cx.export_function("read_array_buffer_with_lock", read_array_buffer_with_lock)?;
     cx.export_function(
         "read_array_buffer_with_borrow",

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -212,6 +212,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("seal_js_object", seal_js_object)?;
 
     cx.export_function("return_array_buffer", return_array_buffer)?;
+    cx.export_function("return_array_buffer_from_slice", return_array_buffer_from_slice)?;
     cx.export_function("read_array_buffer_with_lock", read_array_buffer_with_lock)?;
     cx.export_function(
         "read_array_buffer_with_borrow",
@@ -254,6 +255,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         return_biguint64array_from_arraybuffer,
     )?;
     cx.export_function("return_new_int32array", return_new_int32array)?;
+    cx.export_function("return_int32array_from_slice", return_int32array_from_slice)?;
     cx.export_function(
         "return_uint32array_from_arraybuffer_region",
         return_uint32array_from_arraybuffer_region,


### PR DESCRIPTION
This PR follows on #909 with an additional `TypedArray::from_slice()` method, making it convenient and easy to copy from a Rust slice into a new typed array.

This is not only convenient, but also mitigates the ergonomic cost of deprecating `JsArrayBuffer::external()`, which seems like it'll be necessary due to recent changes in V8 to deprecate external typed arrays.