### PR TITLE
Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: "Found a Bug! 🐛"
+title: "🐛 [BUG] - <title>"
+description: "Use this template to report a bug. Thank you!"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks in advance for taking the time to file this issue!
+        We hope this simple template will improve issue resolution time and minimize the need for _context discovery_ discussions.
+        ______
+        **Note**: We encourage you to [submit an RFC](https://github.com/neon-bindings/rfcs) if you would like to propose a **design change** or a **new feature** for the Neon API or the Neon command-line tool.
+        ______
+        
+        In addition to the `bug` label, consider adding others you might find relevant:
+        | Label | Description |
+        |:-----:|-------------|
+        | `CI` | Continuous Integration |
+        | `CLI` | Command Line Interface |
+        | `beginner friendly` | Great for those just starting out |
+        | `Performance` | Anything that affects performance |
+        | `linux` | Specific to Linux |
+        | `macos` | Specific to MacOS |
+        | `windows` | Specific to Windows |
+        | `android` | Specific to Android |
+        | `electron` | Specific to Electron apps |     
+  - type: textarea
+    id: issue_summary
+    attributes:
+      label: Short Summary
+      description: Please provide a brief description of the issue
+      placeholder: "example: neon crashes when ..."
+    validations:
+      required: true
+  - type: textarea
+    id: issue_repro
+    attributes:
+      label: Steps to reproduce
+      description: "Help us reproduce this issue with some step-by-step instructions"
+      value: |
+        1. 
+        2. 
+        3. 
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: issue_fix
+    attributes:
+      label: Suggested fix
+      description: "If you have a proposed way to fix this bug, please summarize below. PRs work too :)"
+  - type: input
+    id: node_version
+    attributes:
+      label: "Node version: "
+      description: "Please specify the version of `node` you are running"
+      placeholder: "v18.10.0"
+  - type: input
+    id: npm_version
+    attributes:
+      label: "Node Package Manager version: "
+      description: "Please specify the version of `npm` you are running"
+      placeholder: "8.19.2"
+  - type: input
+    id: neon_version
+    attributes:
+      label: "NEON version(s): "
+      description: "Please specify the versions of `neon` that exhibit this issue"
+      placeholder: "example: v0.10.0, v0.9.x"
+  - type: input
+    id: os_version_arch
+    attributes:
+      label: OS Version
+      description: "Please provide your OS version and Architecture"
+      placeholder: "example: macOS 12.5.1 Intel"

--- a/.github/ISSUE_TEMPLATE/default_issue.yml
+++ b/.github/ISSUE_TEMPLATE/default_issue.yml
@@ -1,0 +1,67 @@
+name: New Issue
+title: Neon Issue
+description: Use this template for all issues that are not bugs.
+body: 
+  - type: markdown
+    attributes: 
+      value: |
+          Thanks in advance for taking the time to file this issue! 
+          If you think this is a 🐛 bug, please use the [bug issue template](https://github.com/neon-bindings/issues/new?assignees=&labels=&template=default_issue.yml&title=Neon+Issue).
+          
+          Otherwise, please help us stay organized by selecting one or more of the following labels as applicable to your new issue.
+          
+          | Label | Description |
+          |:-----:|-------------|
+          | `CI` | Continuous Integration |
+          | `CLI` | Command Line Interface |
+          | `beginner friendly` | Great for those just starting out |
+          | `enhancement` | For new features/design changes, use an [RFC](https://github.com/neon-bindings/rfcs) |
+          | `Performance` | Anything that affects performance |
+          | `linux` | Specific to Linux |
+          | `macos` | Specific to MacOS |
+          | `windows` | Specific to Windows |
+          | `android` | Specific to Android |
+          | `electron` | Specific to Electron apps |
+           
+          ---
+  - 
+    attributes: 
+      description: "Please provide a brief description of the issue"
+      label: "Short Summary"
+      placeholder: "example: the issue template should be dynamically generated..."
+    id: issue_summary
+    type: textarea
+    validations: 
+      required: true
+  - 
+    attributes: 
+      value: "> For context, please give us some details of your setup:\n"
+    type: markdown
+  - 
+    attributes: 
+      description: "Please specify the version of `node` you are running"
+      label: "Node version: "
+      placeholder: v18.10.0
+    id: node_version
+    type: input
+  - 
+    attributes: 
+      description: "Please specify the version of `npm` you are running"
+      label: "Node Package Manager version: "
+      placeholder: "8.19.2"
+    id: npm_version
+    type: input
+  - 
+    attributes: 
+      description: "Please specify the versions of `neon` that exhibit this issue"
+      label: "NEON version(s): "
+      placeholder: "example: v0.10.0, v0.9.x"
+    id: neon_version
+    type: input
+  - 
+    attributes: 
+      description: "Please provide your OS version and Architecture"
+      label: "OS Version"
+      placeholder: "example: macOS 12.5.1 Intel"
+    id: os_version_arch
+    type: input

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,11 @@ Neon welcomes contribution from everyone. Here are some resources to help you jo
 
 ### Issue reports
 
-We welcome issues and aim to keep the barrier low. Just [file a GitHub issue](https://github.com/neon-bindings/neon/issues)
-like normal---we don't require issue templates or have any particular process.
+We welcome issues and aim to keep the barrier low. For clarity and efficiency, we created two simple issue templates:
+ - [Bug Report](https://github.com/neon-bindings/issues/new?assignees=&labels=bug&template=bug_report.yml&title=🐛+%5BBUG%5D+-+<title>)
+ - [General Neon Issue](https://github.com/neon-bindings/issues/new?assignees=&labels=&template=default_issue.yml&title=Neon+Issue)
 
-That said, the more information you can provide to help us reproduce your issue, the better!
+The more information you can provide, the better! Thanks in advance! ❤️
 
 ### Requests For Comments
 


### PR DESCRIPTION

From issue neon-bindings/neon#865, this PR introduces two templates:
- Bugs
- Default

Sample screenshot:
<img width="1584" alt="image" src="https://user-images.githubusercontent.com/865663/195374730-95fd9c1b-815f-4f0f-bf2e-9912afdb61e9.png">

Additionally, a small update to docs (contributing.md) to reflect these changes.