### PR TITLE
Fix two cases that can panic during shutdown

### DIFF
--- a/crates/neon/src/event/channel.rs
+++ b/crates/neon/src/event/channel.rs
@@ -249,7 +249,9 @@ impl Drop for Channel {
         // UV thread if strong reference count goes to 0.
         let state = Arc::clone(&self.state);
 
-        self.send(move |mut cx| {
+        // Use `try_send` instead of `send` because, if `send` fails, it means we're shutting down
+        // the VM and don't need to worry about cleanup.
+        let _ = self.try_send(move |mut cx| {
             state.unref(&mut cx);
             Ok(())
         });

--- a/test/napi/lib/workers.js
+++ b/test/napi/lib/workers.js
@@ -15,6 +15,9 @@ if (!isMainThread) {
   // succeed even if the presence of a bug.
   addon.reject_after(new Error("Oh, no!"), 200).catch(() => {});
 
+  // Reproduce another shutdown bug; this one isn't timing-dependent.
+  let boxed_channels = addon.box_channels();
+
   addon.get_or_init_thread_id(threadId);
   parentPort.once("message", (message) => {
     try {

--- a/test/napi/src/js/workers.rs
+++ b/test/napi/src/js/workers.rs
@@ -108,3 +108,20 @@ pub fn reject_after(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     Ok(promise)
 }
+
+#[allow(dead_code)]
+pub struct Channels {
+    channel_1: Channel,
+    channel_2: Channel,
+}
+impl Finalize for Channels {}
+
+pub fn box_channels(mut cx: FunctionContext) -> JsResult<JsBox<Channels>> {
+    let channel_1 = cx.channel();
+    let channel_2 = cx.channel();
+
+    Ok(cx.boxed(Channels {
+        channel_1,
+        channel_2,
+    }))
+}

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -384,6 +384,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("stash_global_object", js::workers::stash_global_object)?;
     cx.export_function("unstash_global_object", js::workers::unstash_global_object)?;
     cx.export_function("reject_after", js::workers::reject_after)?;
+    cx.export_function("box_channels", js::workers::box_channels)?;
 
     // Futures
     cx.export_function("lazy_async_add", js::futures::lazy_async_add)?;


### PR DESCRIPTION
This PR reverts the revert of #932, adding a second commit that should fix a related race condition that was causing a build failure.