### PR TITLE
Remove unused `cx.null()` from channel docs

### DIFF
--- a/crates/neon/src/event/channel.rs
+++ b/crates/neon/src/event/channel.rs
@@ -76,7 +76,6 @@ type Callback = Box<dyn FnOnce(Env) + Send + 'static>;
 ///         channel.send(move |mut cx| {
 ///             let callback = callback.into_inner(&mut cx);
 ///             let this = cx.undefined();
-///             let null = cx.null();
 ///             let args = vec![
 ///                 cx.null().upcast::<JsValue>(),
 ///                 cx.number(result).upcast(),

--- a/crates/neon/src/event/mod.rs
+++ b/crates/neon/src/event/mod.rs
@@ -75,7 +75,6 @@
 //!     channel.send(move |mut cx| {
 //!         let callback = callback.into_inner(&mut cx);
 //!         let this = cx.undefined();
-//!         let null = cx.null();
 //!         let args = match result {
 //!             Ok(psd) => {
 //!                 // Extract data from the parsed file.


### PR DESCRIPTION
First of all, thank you for this awesome crate, I love it. Currently use it to build an extension for VS Code, and this crate allows me to write most of it in Rust. Awesome work!

While starting to use the event APIs to be able to do background tasks with callback, I noticed that the docs call `cx.null()`, but never actually use the created instance. Seems it's not needed, so probably a leftover or so.
