### PR TITLE
Fix several of the latest reported clippy lints

### DIFF
--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -207,7 +207,7 @@ impl CallbackInfo<'_> {
         let env = cx.env();
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
-            sys::call::this(env.to_raw(), std::mem::transmute(self.info), &mut local);
+            sys::call::this(env.to_raw(), self.info, &mut local);
             local
         }
     }

--- a/crates/neon/src/sys/arraybuffer.rs
+++ b/crates/neon/src/sys/arraybuffer.rs
@@ -48,7 +48,7 @@ where
 
 #[cfg(feature = "external-buffers")]
 unsafe extern "C" fn drop_external<T>(_env: Env, _data: *mut c_void, hint: *mut c_void) {
-    Box::<T>::from_raw(hint as *mut _);
+    drop(Box::<T>::from_raw(hint as *mut _));
 }
 
 /// # Safety

--- a/crates/neon/src/sys/buffer.rs
+++ b/crates/neon/src/sys/buffer.rs
@@ -57,7 +57,7 @@ where
 
 #[cfg(feature = "external-buffers")]
 unsafe extern "C" fn drop_external<T>(_env: Env, _data: *mut c_void, hint: *mut c_void) {
-    Box::<T>::from_raw(hint as *mut _);
+    drop(Box::<T>::from_raw(hint as *mut _));
 }
 
 /// # Safety

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -23,7 +23,7 @@ where
     );
 
     if status == napi::Status::PendingException {
-        Box::from_raw(data);
+        drop(Box::from_raw(data));
 
         return Err(status);
     }
@@ -39,7 +39,7 @@ where
             _finalize_data: *mut c_void,
             finalize_hint: *mut c_void,
         ) {
-            Box::from_raw(finalize_hint.cast::<F>());
+            drop(Box::from_raw(finalize_hint.cast::<F>()));
         }
 
         let status = napi::add_finalizer(

--- a/crates/neon/src/sys/lifecycle.rs
+++ b/crates/neon/src/sys/lifecycle.rs
@@ -42,5 +42,5 @@ pub unsafe fn get_instance_data<T: Send + 'static>(env: Env) -> *mut T {
 }
 
 unsafe extern "C" fn drop_box<T>(_env: Env, data: *mut c_void, _hint: *mut c_void) {
-    Box::<T>::from_raw(data.cast());
+    drop(Box::<T>::from_raw(data.cast()));
 }

--- a/crates/neon/src/sys/no_panic.rs
+++ b/crates/neon/src/sys/no_panic.rs
@@ -51,6 +51,7 @@ impl FailureBoundary {
         F: FnOnce(Option<Env>) -> Local,
     {
         // Make `env = None` if unable to call into JS
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         let env = can_call_into_js(env).then(|| env);
 
         // Run the user supplied callback, catching panics
@@ -277,7 +278,7 @@ unsafe fn external_from_panic(env: Env, panic: Panic) -> Local {
 
 extern "C" fn finalize_panic(_env: Env, data: *mut c_void, _hint: *mut c_void) {
     unsafe {
-        Box::from_raw(data.cast::<Panic>());
+        drop(Box::from_raw(data.cast::<Panic>()));
     }
 }
 

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -271,7 +271,7 @@ impl<T: Finalize + Send + 'static> JsBox<T> {
     }
 }
 
-impl<'a, T: Send + 'static> Deref for JsBox<T> {
+impl<T: Send + 'static> Deref for JsBox<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/neon/src/types_impl/buffer/mod.rs
+++ b/crates/neon/src/types_impl/buffer/mod.rs
@@ -132,7 +132,7 @@ impl<'a, T> Deref for RefMut<'a, T> {
 
 impl<'a, T> DerefMut for RefMut<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.data
+        self.data
     }
 }
 

--- a/crates/neon/src/types_impl/date.rs
+++ b/crates/neon/src/types_impl/date.rs
@@ -59,7 +59,7 @@ impl fmt::Display for DateError {
 impl Error for DateError {}
 
 /// The error kinds corresponding to `DateError`
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
 pub enum DateErrorKind {
     Overflow,

--- a/test/napi/src/js/threads.rs
+++ b/test/napi/src/js/threads.rs
@@ -293,7 +293,7 @@ pub fn channel_panic_throw(mut cx: FunctionContext) -> JsResult<JsUndefined> {
             // Throw an exception, but ignore the `Err(Throw)`
             let _ = cx.throw_error::<_, ()>(msg);
             // Attempting to throw another error while already throwing should `panic`
-            let _ = cx.throw_error("Unreachable")?;
+            cx.throw_error("Unreachable")?;
 
             Ok(())
         })
@@ -357,7 +357,7 @@ pub fn task_panic_throw(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         // Throw an exception, but ignore the `Err(Throw)`
         let _ = cx.throw_error::<_, ()>(msg);
         // Attempting to throw another error while already throwing should `panic`
-        let _ = cx.throw_error("Unreachable")?;
+        cx.throw_error("Unreachable")?;
 
         Ok(())
     });
@@ -407,7 +407,7 @@ pub fn task_panic_throw_promise(mut cx: FunctionContext) -> JsResult<JsPromise> 
         // Throw an exception, but ignore the `Err(Throw)`
         let _ = cx.throw_error::<_, ()>(msg);
         // Attempting to throw another error while already throwing should `panic`
-        let _ = cx.throw_error("Unreachable")?;
+        cx.throw_error("Unreachable")?;
 
         Ok(cx.undefined())
     });
@@ -455,7 +455,7 @@ pub fn deferred_settle_with_panic_throw(mut cx: FunctionContext) -> JsResult<JsP
             // Throw an exception, but ignore the `Err(Throw)`
             let _ = cx.throw_error::<_, ()>(msg);
             // Attempting to throw another error while already throwing should `panic`
-            let _ = cx.throw_error("Unreachable")?;
+            cx.throw_error("Unreachable")?;
 
             Ok(cx.undefined())
         })


### PR DESCRIPTION
Fixing most of the warnings that `clippy` reports. This is almost the same as #928, but keeping the changes to a minimum with only the lints fixed.

I left out the warnings about missing `# Safety` docs, as I don't feel qualified to give a proper description of the safety guarantees that have to be held up for those functions. And completely disabling that lint felt wrong as well, because there are actually a lot of functions with a safety section.