### PR TITLE
Type tagging for arbitrary `Object`s.

### DIFF
--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -214,6 +214,33 @@ pub trait Object: Value {
         }
     }
 
+    #[cfg(feature = "napi-8")]
+    fn type_tag<'a, C: Context<'a>>(&self, cx: &mut C, tag: u128) -> NeonResult<&Self> {
+        let env = cx.env().to_raw();
+        let obj = self.to_raw();
+        unsafe {
+            match sys::object::type_tag(env, obj, tag) {
+                sys::Status::Ok => Ok(self),
+                sys::Status::PendingException => Err(Throw::new()),
+                _ => cx.throw_type_error("object cannot be type tagged (again)"),
+            }
+        }
+    }
+
+    #[cfg(feature = "napi-8")]
+    fn check_type_tag<'a, C: Context<'a>>(&self, cx: &mut C, tag: u128) -> NeonResult<bool> {
+        let env = cx.env().to_raw();
+        let obj = self.to_raw();
+        let mut result = false;
+        unsafe {
+            match sys::object::check_type_tag(&mut result, env, obj, tag) {
+                sys::Status::Ok => Ok(result),
+                sys::Status::PendingException => Err(Throw::new()),
+                _ => cx.throw_type_error("object's type tag cannot be checked"),
+            }
+        }
+    }
+
     fn set<'a, C: Context<'a>, K: PropertyKey, W: Value>(
         &self,
         cx: &mut C,

--- a/crates/neon/src/sys/object.rs
+++ b/crates/neon/src/sys/object.rs
@@ -25,6 +25,16 @@ pub unsafe fn seal(env: Env, obj: Local) -> napi::Status {
     napi::object_seal(env, obj)
 }
 
+#[cfg(feature = "napi-8")]
+pub unsafe fn type_tag(env: Env, obj: Local, tag: u128) -> napi::Status {
+    napi::type_tag_object(env, obj, &tag as *const u128 as *const _)
+}
+
+#[cfg(feature = "napi-8")]
+pub unsafe fn check_type_tag(out: &mut bool, env: Env, obj: Local, tag: u128) -> napi::Status {
+    napi::check_object_type_tag(env, obj, &tag as *const u128 as *const _, out)
+}
+
 #[cfg(feature = "napi-6")]
 /// Mutates the `out` argument to refer to a `napi_value` containing the own property names of the
 /// `object` as a JavaScript Array.

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -65,6 +65,40 @@ describe("JsObject", function () {
     });
   });
 
+  it("type tag a JsObject", function () {
+    const obj = { x: 1 };
+
+    assert.strictEqual(
+      addon.check_not_type_tag_js_object(obj),
+      false,
+      "check_not_type_tag_js_object should return false for non-tagged object"
+    );
+
+    assert.doesNotThrow(function () {
+      addon.type_tag_js_object(obj);
+    }, "type_tag_js_object should not throw");
+
+    assert.throws(
+      function () {
+        addon.type_tag_js_object(obj);
+      },
+      "object cannot be type tagged (again)",
+      "type_tag_js_object should throw when called twice"
+    );
+
+    assert.strictEqual(
+      addon.check_type_tag_js_object(obj),
+      true,
+      "check_type_tag_js_object should return true for identically tagged object"
+    );
+
+    assert.strictEqual(
+      addon.check_not_type_tag_js_object(obj),
+      false,
+      "check_not_type_tag_js_object should return false for object with different type tag"
+    );
+  });
+
   it("returns only own properties from get_own_property_names", function () {
     var superObject = {
       a: 1,

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -49,6 +49,25 @@ pub fn seal_js_object(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     }
 }
 
+static TYPE_TAG: u128 = u128::from_be_bytes(*b"neon-bindings-ty");
+
+pub fn type_tag_js_object(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    obj.type_tag(&mut cx, TYPE_TAG).map(|_| cx.undefined())
+}
+
+pub fn check_type_tag_js_object(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    obj.check_type_tag(&mut cx, TYPE_TAG)
+        .map(|value| cx.boolean(value))
+}
+
+pub fn check_not_type_tag_js_object(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    obj.check_type_tag(&mut cx, !TYPE_TAG)
+        .map(|value| cx.boolean(value))
+}
+
 // Accepts either a `JsString` or `JsBuffer` and returns the contents as
 // as bytes; avoids copying.
 fn get_bytes<'cx, 'a, C>(cx: &'a mut C, v: Handle<JsValue>) -> NeonResult<Cow<'a, [u8]>>

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -213,6 +213,9 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     )?;
     cx.export_function("freeze_js_object", freeze_js_object)?;
     cx.export_function("seal_js_object", seal_js_object)?;
+    cx.export_function("type_tag_js_object", type_tag_js_object)?;
+    cx.export_function("check_type_tag_js_object", check_type_tag_js_object)?;
+    cx.export_function("check_not_type_tag_js_object", check_not_type_tag_js_object)?;
 
     cx.export_function("return_array_buffer", return_array_buffer)?;
     cx.export_function(


### PR DESCRIPTION
This PR implements type tagging for arbitrary `Object`s. My use case for this is that I have two Node modules written in Rust that share an ABI-safe `JsObject`-like value. Instead of using `TypeId<T>` (which is not equal across builds), I generate a `u128` for each ABI version and tag ABI-safe objects with this number.

__Example code:__
```rust
let obj: Handle<JsObject> = cx.empty_object();

// Checking an untagged object always returns false.
assert_eq!(obj.check_type_tag(42)?, false);

// Tagging this object a first time.
obj.type_tag(&mut cx, 42)?;

// Now, checking with the same tag will return true.
assert_eq!(obj.check_type_tag(42)?, true);

// Checking with a different tag will return false.
assert_eq!(obj.check_type_tag(24)?, false);

// Tagging this object a second time will fail.
obj.type_tag(&mut cx, 42).err().unwrap();
obj.type_tag(&mut cx, 24).err().unwrap();
```