### PR TITLE
feat(neon): sys feature to give access to Node-API

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 neon-check = " check  --all --all-targets --features napi-experimental,futures,external-buffers"
 neon-clippy = "clippy --all --all-targets --features napi-experimental,futures,external-buffers -- -A clippy::missing_safety_doc"
 neon-test = "  test   --all               --features=doc-dependencies,doc-comment,napi-experimental,futures,external-buffers"
-neon-doc = "   rustdoc -p neon            --features=doc-dependencies,napi-experimental,futures,external-buffers -- --cfg docsrs"
+neon-doc = "   rustdoc -p neon            --features=doc-dependencies,napi-experimental,futures,external-buffers,sys -- --cfg docsrs"

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -50,6 +50,10 @@ external-buffers = []
 # https://github.com/neon-bindings/rfcs/pull/46
 futures = ["tokio"]
 
+# Enable low-level system APIs. The `sys` API allows augmenting the Neon API
+# from external crates.
+sys = []
+
 # Default N-API version. Prefer to select a minimum required version.
 # DEPRECATED: This is an alias that should be removed
 napi-runtime = ["napi-8"]

--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -2,10 +2,10 @@ use std::{cell::RefCell, ffi::c_void, mem::MaybeUninit};
 
 use crate::{
     context::ModuleContext,
-    handle::{Handle, Managed},
+    handle::Handle,
     result::NeonResult,
     sys::{self, raw},
-    types::JsObject,
+    types::{private::ValueInternal, JsObject},
 };
 
 #[repr(C)]
@@ -64,7 +64,7 @@ pub unsafe fn initialize_module(
     });
 
     let env = Env(env);
-    let exports = Handle::new_internal(JsObject::from_raw(env, exports.cast()));
+    let exports = Handle::new_internal(JsObject::from_local(env, exports.cast()));
 
     ModuleContext::with(env, exports, |cx| {
         let _ = init(cx);

--- a/crates/neon/src/event/mod.rs
+++ b/crates/neon/src/event/mod.rs
@@ -30,9 +30,10 @@
 //!
 //! ```
 //! # use neon::prelude::*;
-//! #
+//! # #[cfg(not(feature = "napi-6"))]
+//! # type Channel = ();
 //! # fn parse(filename: String, callback: Root<JsFunction>, channel: Channel) { }
-//! #
+//! # #[cfg(feature = "napi-6")]
 //! fn parse_async(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 //!     // The types `String`, `Root<JsFunction>`, and `Channel` can all be
 //!     // sent across threads.
@@ -60,6 +61,8 @@
 //!
 //! ```
 //! # use neon::prelude::*;
+//! # #[cfg(not(feature = "napi-6"))]
+//! # type Channel = ();
 //! # use psd::Psd;
 //! # use anyhow::{Context as _, Result};
 //! #
@@ -67,6 +70,7 @@
 //!     Psd::from_bytes(&std::fs::read(&filename)?).context("invalid psd file")
 //! }
 //!
+//! # #[cfg(feature = "napi-6")]
 //! fn parse(filename: String, callback: Root<JsFunction>, channel: Channel) {
 //!     let result = psd_from_filename(filename);
 //!

--- a/crates/neon/src/handle/root.rs
+++ b/crates/neon/src/handle/root.rs
@@ -94,7 +94,7 @@ impl<T: Object> Root<T> {
     /// * N-API >= 6, Neon will drop from a global queue at a runtime cost
     pub fn new<'a, C: Context<'a>>(cx: &mut C, value: &T) -> Self {
         let env = cx.env().to_raw();
-        let internal = unsafe { reference::new(env, value.to_raw()) };
+        let internal = unsafe { reference::new(env, value.to_local()) };
 
         Self {
             internal: Some(NapiRef(internal as *mut _)),
@@ -159,7 +159,7 @@ impl<T: Object> Root<T> {
             internal.unref(env.to_raw());
         }
 
-        Handle::new_internal(T::from_raw(env, local))
+        Handle::new_internal(unsafe { T::from_local(env, local) })
     }
 
     /// Access the inner JavaScript object without consuming the `Root`
@@ -174,7 +174,7 @@ impl<T: Object> Root<T> {
         let env = cx.env();
         let local = unsafe { reference::get(env.to_raw(), self.as_napi_ref(cx).0 as *mut _) };
 
-        Handle::new_internal(T::from_raw(env, local))
+        Handle::new_internal(unsafe { T::from_local(env, local) })
     }
 
     fn as_napi_ref<'a, C: Context<'a>>(&self, cx: &mut C) -> &NapiRef {

--- a/crates/neon/src/reflect.rs
+++ b/crates/neon/src/reflect.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     context::Context,
-    handle::{Handle, Managed},
+    handle::Handle,
     result::JsResult,
-    types::{build, JsString, JsValue},
+    types::{build, private::ValueInternal, JsString, JsValue},
 };
 
 pub fn eval<'a, 'b, C: Context<'a>>(
@@ -13,6 +13,6 @@ pub fn eval<'a, 'b, C: Context<'a>>(
 ) -> JsResult<'a, JsValue> {
     let env = cx.env().to_raw();
     build(cx.env(), |out| unsafe {
-        crate::sys::string::run_script(out, env, script.to_raw())
+        crate::sys::string::run_script(out, env, script.to_local())
     })
 }

--- a/crates/neon/src/result/mod.rs
+++ b/crates/neon/src/result/mod.rs
@@ -52,7 +52,21 @@ use crate::{context::Context, handle::Handle, types::Value};
 pub struct Throw(PhantomData<*mut ()>); // *mut is !Send + !Sync, making it harder to accidentally store
 
 impl Throw {
-    pub(crate) fn new() -> Self {
+    #[cfg(feature = "sys")]
+    /// Creates a `Throw` struct representing a JavaScript exception
+    /// state.
+    ///
+    /// # Safety
+    ///
+    /// `Throw` should *only* be constructed when the JavaScript VM is in a
+    /// throwing state. I.e., when [`Status::PendingException`](crate::sys::bindings::Status::PendingException)
+    /// is returned.
+    pub unsafe fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    #[cfg(not(feature = "sys"))]
+    pub(crate) unsafe fn new() -> Self {
         Self(PhantomData)
     }
 }

--- a/crates/neon/src/sys/bindings/functions.rs
+++ b/crates/neon/src/sys/bindings/functions.rs
@@ -5,6 +5,7 @@ mod napi1 {
     use std::os::raw::{c_char, c_void};
 
     generate!(
+        #[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
         extern "C" {
             fn get_undefined(env: Env, result: *mut Value) -> Status;
 
@@ -209,7 +210,7 @@ mod napi1 {
 
             fn strict_equals(env: Env, lhs: Value, rhs: Value, result: *mut bool) -> Status;
 
-            #[cfg(feature = "external-buffers")]
+            #[cfg(any(feature = "sys", feature = "external-buffers"))]
             fn create_external_arraybuffer(
                 env: Env,
                 data: *mut c_void,
@@ -219,7 +220,7 @@ mod napi1 {
                 result: *mut Value,
             ) -> Status;
 
-            #[cfg(feature = "external-buffers")]
+            #[cfg(any(feature = "sys", feature = "external-buffers"))]
             fn create_external_buffer(
                 env: Env,
                 length: usize,
@@ -263,6 +264,7 @@ mod napi4 {
     use std::os::raw::c_void;
 
     generate!(
+        #[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
         extern "C" {
             fn create_threadsafe_function(
                 env: Env,
@@ -302,6 +304,7 @@ mod napi5 {
     use std::ffi::c_void;
 
     generate!(
+        #[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]
         extern "C" {
             fn create_date(env: Env, value: f64, result: *mut Value) -> Status;
 
@@ -327,6 +330,7 @@ mod napi6 {
     use std::os::raw::c_void;
 
     generate!(
+        #[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
         extern "C" {
             fn get_all_property_names(
                 env: Env,
@@ -388,6 +392,7 @@ mod napi8 {
     use super::super::types::*;
 
     generate!(
+        #[cfg_attr(docsrs, doc(cfg(feature = "napi-8")))]
         extern "C" {
             fn object_freeze(env: Env, object: Value) -> Status;
             fn object_seal(env: Env, object: Value) -> Status;
@@ -402,15 +407,15 @@ mod napi8 {
     );
 }
 
-pub(crate) use napi1::*;
+pub use napi1::*;
 #[cfg(feature = "napi-4")]
-pub(crate) use napi4::*;
+pub use napi4::*;
 #[cfg(feature = "napi-5")]
-pub(crate) use napi5::*;
+pub use napi5::*;
 #[cfg(feature = "napi-6")]
-pub(crate) use napi6::*;
+pub use napi6::*;
 #[cfg(feature = "napi-8")]
-pub(crate) use napi8::*;
+pub use napi8::*;
 
 use super::{Env, Status};
 
@@ -424,7 +429,7 @@ unsafe fn get_version(host: &libloading::Library, env: Env) -> Result<u32, liblo
     Ok(version)
 }
 
-pub(super) unsafe fn load(env: Env) -> Result<(), libloading::Error> {
+pub(crate) unsafe fn load(env: Env) -> Result<(), libloading::Error> {
     #[cfg(not(windows))]
     let host = libloading::os::unix::Library::this().into();
     #[cfg(windows)]

--- a/crates/neon/src/sys/bindings/types.rs
+++ b/crates/neon/src/sys/bindings/types.rs
@@ -2,68 +2,95 @@ use std::ffi::c_void;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct Env__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_env`](https://nodejs.org/api/n-api.html#napi_env)
 pub type Env = *mut Env__;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct Value__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_value`](https://nodejs.org/api/n-api.html#napi_value)
 pub type Value = *mut Value__;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct CallbackInfo__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_callback_info`](https://nodejs.org/api/n-api.html#napi_callback_info)
 pub type CallbackInfo = *mut CallbackInfo__;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct EscapableHandleScope__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_escapable_handle_scope`](https://nodejs.org/api/n-api.html#napi_escapable_handle_scope)
 pub type EscapableHandleScope = *mut EscapableHandleScope__;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct HandleScope__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_handle_scope`](https://nodejs.org/api/n-api.html#napi_handle_scope)
 pub type HandleScope = *mut HandleScope__;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct Ref__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref)
 pub type Ref = *mut Ref__;
 
 #[cfg(feature = "napi-4")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct ThreadsafeFunction__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 #[cfg(feature = "napi-4")]
+/// [`napi_threadsafe_function`](https://nodejs.org/api/n-api.html#napi_threadsafe_function)
 pub type ThreadsafeFunction = *mut ThreadsafeFunction__;
 
-pub(crate) type Callback = Option<unsafe extern "C" fn(env: Env, info: CallbackInfo) -> Value>;
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_callback`](https://nodejs.org/api/n-api.html#napi_callback)
+pub type Callback = Option<unsafe extern "C" fn(env: Env, info: CallbackInfo) -> Value>;
 
-pub(crate) type Finalize =
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_finalize`](https://nodejs.org/api/n-api.html#napi_finalize)
+pub type Finalize =
     Option<unsafe extern "C" fn(env: Env, finalize_data: *mut c_void, finalize_hint: *mut c_void)>;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 #[cfg(feature = "napi-4")]
+/// [`napi_threadsafe_function_call_js`](https://nodejs.org/api/n-api.html#napi_threadsafe_function_call_js)
 pub type ThreadsafeFunctionCallJs = Option<
     unsafe extern "C" fn(env: Env, js_callback: Value, context: *mut c_void, data: *mut c_void),
 >;
@@ -71,6 +98,8 @@ pub type ThreadsafeFunctionCallJs = Option<
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_status`](https://nodejs.org/api/n-api.html#napi_status)
 pub enum Status {
     Ok = 0,
     InvalidArg = 1,
@@ -99,7 +128,9 @@ pub enum Status {
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum ValueType {
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
+/// [`napi_valuetype`](https://nodejs.org/api/n-api.html#napi_valuetype)
+pub enum ValueType {
     Undefined = 0,
     Null = 1,
     Boolean = 2,
@@ -115,6 +146,8 @@ pub(crate) enum ValueType {
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_typedarray_type`](https://nodejs.org/api/n-api.html#napi_typedarray_type)
 pub enum TypedArrayType {
     I8 = 0,
     U8 = 1,
@@ -132,6 +165,9 @@ pub enum TypedArrayType {
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
+#[cfg(feature = "napi-6")]
+/// [`napi_key_collection_mode`](https://nodejs.org/api/n-api.html#napi_key_collection_mode)
 pub enum KeyCollectionMode {
     IncludePrototypes = 0,
     OwnOnly = 1,
@@ -140,24 +176,31 @@ pub enum KeyCollectionMode {
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
+#[cfg(feature = "napi-6")]
+/// [`napi_key_conversion`](https://nodejs.org/api/n-api.html#napi_key_conversion)
 pub enum KeyConversion {
     KeepNumbers = 0,
     NumbersToStrings = 1,
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 #[cfg(feature = "napi-4")]
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+/// [`napi_threadsafe_function_call_mode`](https://nodejs.org/api/n-api.html#napi_threadsafe_function_call_mode)
 pub enum ThreadsafeFunctionCallMode {
     NonBlocking = 0,
     Blocking = 1,
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
 #[cfg(feature = "napi-4")]
 #[allow(dead_code)]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+/// [`napi_threadsafe_function_release_mode`](https://nodejs.org/api/n-api.html#napi_threadsafe_function_release_mode)
 pub enum ThreadsafeFunctionReleaseMode {
     Release = 0,
     Abort = 1,
@@ -165,17 +208,22 @@ pub enum ThreadsafeFunctionReleaseMode {
 
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct KeyFilter(pub ::std::os::raw::c_uint);
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-6")))]
+#[cfg(feature = "napi-6")]
+/// [`napi_key_filter`](https://nodejs.org/api/n-api.html#napi_key_filter)
+pub struct KeyFilter(pub ::std::os::raw::c_uint);
 
 #[allow(dead_code)]
+#[cfg(feature = "napi-6")]
 impl KeyFilter {
-    pub(crate) const ALL_PROPERTIES: KeyFilter = KeyFilter(0);
-    pub(crate) const WRITABLE: KeyFilter = KeyFilter(1);
-    pub(crate) const CONFIGURABLE: KeyFilter = KeyFilter(4);
-    pub(crate) const SKIP_STRINGS: KeyFilter = KeyFilter(8);
-    pub(crate) const SKIP_SYMBOLS: KeyFilter = KeyFilter(16);
+    pub const ALL_PROPERTIES: KeyFilter = KeyFilter(0);
+    pub const WRITABLE: KeyFilter = KeyFilter(1);
+    pub const CONFIGURABLE: KeyFilter = KeyFilter(4);
+    pub const SKIP_STRINGS: KeyFilter = KeyFilter(8);
+    pub const SKIP_SYMBOLS: KeyFilter = KeyFilter(16);
 }
 
+#[cfg(feature = "napi-6")]
 impl std::ops::BitOr<KeyFilter> for KeyFilter {
     type Output = Self;
     #[inline]
@@ -184,6 +232,7 @@ impl std::ops::BitOr<KeyFilter> for KeyFilter {
     }
 }
 
+#[cfg(feature = "napi-6")]
 impl std::ops::BitOrAssign for KeyFilter {
     #[inline]
     fn bitor_assign(&mut self, rhs: KeyFilter) {
@@ -191,6 +240,7 @@ impl std::ops::BitOrAssign for KeyFilter {
     }
 }
 
+#[cfg(feature = "napi-6")]
 impl std::ops::BitAnd<KeyFilter> for KeyFilter {
     type Output = Self;
     #[inline]
@@ -199,6 +249,7 @@ impl std::ops::BitAnd<KeyFilter> for KeyFilter {
     }
 }
 
+#[cfg(feature = "napi-6")]
 impl std::ops::BitAndAssign for KeyFilter {
     #[inline]
     fn bitand_assign(&mut self, rhs: KeyFilter) {
@@ -208,29 +259,41 @@ impl std::ops::BitAndAssign for KeyFilter {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct AsyncWork__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_async_work`](https://nodejs.org/api/n-api.html#napi_async_work)
 pub type AsyncWork = *mut AsyncWork__;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_async_execute_callback`](https://nodejs.org/api/n-api.html#napi_async_execute_callback)
 pub type AsyncExecuteCallback = Option<unsafe extern "C" fn(env: Env, data: *mut c_void)>;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_async_complete_callback`](https://nodejs.org/api/n-api.html#napi_async_complete_callback)
 pub type AsyncCompleteCallback =
     Option<unsafe extern "C" fn(env: Env, status: Status, data: *mut c_void)>;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct Deferred__ {
     _unused: [u8; 0],
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-1")))]
+/// [`napi_deferred`](https://nodejs.org/api/n-api.html#napi_deferred)
 pub type Deferred = *mut Deferred__;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-8")))]
 #[cfg(feature = "napi-8")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+/// [`napi_type_tag`](https://nodejs.org/api/n-api.html#napi_type_tag)
 pub struct TypeTag {
-    pub(crate) lower: u64,
-    pub(crate) upper: u64,
+    pub lower: u64,
+    pub upper: u64,
 }

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -1,38 +1,107 @@
-use std::mem::MaybeUninit;
+//! Raw bindings to [Node-API][node-api]
+//!
+//! [Node-API][node-api] is Node.js's API for building native addons. Neon is
+//! predominantly a safe wrapper for Node-API and most users should prefer the
+//! the high level abstractions [outside](crate) of the sys module.
+//!
+//! However, directly using Node-API can be a useful tool for accessing low
+//! level functionality not exposed by Neon or experimenting with extensions
+//! to Neon without needing to fork the project.
+//!
+//! [node-api]: https://nodejs.org/api/n-api.html
+//!
+//! ## Initialization
+//!
+//! Before any Node-API functions may be used, [`setup`](setup) must be called at
+//! least once.
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "sys")]
+//! # {
+//! # let env = std::ptr::null_mut().cast();
+//! unsafe { neon::sys::setup(env); }
+//! # }
+//! ```
+//! **Note**: It is unnecessary to call [`setup`](setup) if
+//! [`#[neon::main]`](crate::main) is used to initialize the addon.
+//!
+//! ## Safety
+//!
+//! The following are guidelines for ensuring safe usage of Node-API in Neon
+//! but, do not represent a comprehensive set of safety rules. If possible,
+//! users should avoid calling Neon methods or holding references to structures
+//! created by Neon when calling Node-API functions directly.
+//!
+//! ### Env
+//!
+//! Neon ensures safety by carefully restricting access to [`Env`](bindings::Env)
+//! by wrapping it in a [`Context`](crate::context::Context). Usages of `Env`
+//! should follow Neon's borrowing rules of `Context`.
+//!
+//! It is unsound to use an `Env` if Rust's borrowing rules would prevent usage
+//! of the in scope `Context`.
+//!
+//! ### Values
+//!
+//! Neon [value types](crate::types) encapsulate references to
+//! [JavaScript values](bindings::Value) with a _known type_. It is unsound to
+//! construct a Neon value with a [`Value`](bindings::Value) of the incorrect type.
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "sys")]
+//! # {
+//! # let env = std::ptr::null_mut().cast();
+//! use neon::{context::SysContext, prelude::*, sys::bindings};
+//!
+//! let cx = unsafe {
+//!     neon::sys::setup(env);
+//!
+//!     SysContext::from_raw(env)
+//! };
+//!
+//! let raw_string: bindings::Value = cx.string("Hello, World!").to_raw();
+//! let js_string = unsafe { JsString::from_raw(&cx, raw_string) };
+//! # }
+//! ```
+use std::{mem::MaybeUninit, sync::Once};
 
+// Bindings are re-exported here to minimize changes.
+// Follow-up issue: https://github.com/neon-bindings/neon/issues/982
 pub(crate) use bindings::*;
 
-pub mod array;
-pub mod arraybuffer;
-pub mod async_work;
-pub mod buffer;
-pub mod call;
-pub mod convert;
-pub mod error;
-pub mod external;
-pub mod fun;
-pub mod mem;
-pub mod no_panic;
-pub mod object;
-pub mod primitive;
-pub mod promise;
-pub mod raw;
-pub mod reference;
-pub mod scope;
-pub mod string;
-pub mod tag;
-pub mod typedarray;
+pub(crate) mod array;
+pub(crate) mod arraybuffer;
+pub(crate) mod async_work;
+pub(crate) mod buffer;
+pub(crate) mod call;
+pub(crate) mod convert;
+pub(crate) mod error;
+pub(crate) mod external;
+pub(crate) mod fun;
+pub(crate) mod mem;
+pub(crate) mod no_panic;
+pub(crate) mod object;
+pub(crate) mod primitive;
+pub(crate) mod promise;
+pub(crate) mod raw;
+pub(crate) mod reference;
+pub(crate) mod scope;
+pub(crate) mod string;
+pub(crate) mod tag;
+pub(crate) mod typedarray;
 
-mod bindings;
+pub mod bindings;
 
 #[cfg(feature = "napi-4")]
-pub mod tsfn;
+pub(crate) mod tsfn;
 
 #[cfg(feature = "napi-5")]
-pub mod date;
+pub(crate) mod date;
 
 #[cfg(feature = "napi-6")]
-pub mod lifecycle;
+pub(crate) mod lifecycle;
 
 /// Create a JavaScript `String`, panicking if unsuccessful
 ///
@@ -54,4 +123,17 @@ unsafe fn string(env: Env, s: impl AsRef<str>) -> raw::Local {
     );
 
     result.assume_init()
+}
+
+static SETUP: Once = Once::new();
+
+/// Loads Node-API symbols from the host process.
+///
+/// Must be called at least once before using any functions in bindings or
+/// they will panic.
+///
+/// # Safety
+/// `env` must be a valid `napi_env` for the current thread
+pub unsafe fn setup(env: Env) {
+    SETUP.call_once(|| load(env).expect("Failed to load N-API symbols"));
 }

--- a/crates/neon/src/types_impl/bigint.rs
+++ b/crates/neon/src/types_impl/bigint.rs
@@ -4,7 +4,7 @@ use std::{error, fmt, mem::MaybeUninit};
 
 use crate::{
     context::{internal::Env, Context},
-    handle::{internal::TransparentNoCopyWrapper, Handle, Managed},
+    handle::{internal::TransparentNoCopyWrapper, Handle},
     result::{NeonResult, ResultExt},
     sys::{self, raw},
     types::{private, JsBigInt, Value},
@@ -427,22 +427,20 @@ unsafe impl TransparentNoCopyWrapper for JsBigInt {
     }
 }
 
-impl Managed for JsBigInt {
-    fn to_raw(&self) -> raw::Local {
-        self.0
-    }
-
-    fn from_raw(_: Env, h: raw::Local) -> Self {
-        Self(h)
-    }
-}
-
 impl private::ValueInternal for JsBigInt {
     fn name() -> String {
         "BigInt".to_string()
     }
 
     fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool {
-        unsafe { sys::tag::is_bigint(env.to_raw(), other.to_raw()) }
+        unsafe { sys::tag::is_bigint(env.to_raw(), other.to_local()) }
+    }
+
+    fn to_local(&self) -> raw::Local {
+        self.0
+    }
+
+    unsafe fn from_local(_env: Env, h: raw::Local) -> Self {
+        Self(h)
     }
 }

--- a/crates/neon/src/types_impl/buffer/mod.rs
+++ b/crates/neon/src/types_impl/buffer/mod.rs
@@ -232,7 +232,11 @@ pub struct Region<'cx, T: Binary> {
     phantom: PhantomData<T>,
 }
 
-impl<'cx, T: Binary> Region<'cx, T> {
+impl<'cx, T> Region<'cx, T>
+where
+    T: Binary,
+    JsTypedArray<T>: Value,
+{
     /// Returns the handle to the region's buffer.
     pub fn buffer(&self) -> Handle<'cx, JsArrayBuffer> {
         self.buffer

--- a/crates/neon/src/types_impl/date.rs
+++ b/crates/neon/src/types_impl/date.rs
@@ -7,7 +7,7 @@ use super::{private::ValueInternal, Value};
 
 use crate::{
     context::{internal::Env, Context},
-    handle::{internal::TransparentNoCopyWrapper, Handle, Managed},
+    handle::{internal::TransparentNoCopyWrapper, Handle},
     object::Object,
     result::{JsResult, ResultExt},
     sys::{self, raw},
@@ -58,16 +58,6 @@ unsafe impl TransparentNoCopyWrapper for JsDate {
 
     fn into_inner(self) -> Self::Inner {
         self.0
-    }
-}
-
-impl Managed for JsDate {
-    fn to_raw(&self) -> raw::Local {
-        self.0
-    }
-
-    fn from_raw(_: Env, h: raw::Local) -> Self {
-        JsDate(h)
     }
 }
 
@@ -158,7 +148,7 @@ impl JsDate {
     /// Gets the `Date`'s value. An invalid `Date` will return [`std::f64::NAN`].
     pub fn value<'a, C: Context<'a>>(&self, cx: &mut C) -> f64 {
         let env = cx.env().to_raw();
-        unsafe { sys::date::value(env, self.to_raw()) }
+        unsafe { sys::date::value(env, self.to_local()) }
     }
 
     /// Checks if the `Date`'s value is valid. A `Date` is valid if its value is
@@ -175,7 +165,15 @@ impl ValueInternal for JsDate {
     }
 
     fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool {
-        unsafe { sys::tag::is_date(env.to_raw(), other.to_raw()) }
+        unsafe { sys::tag::is_date(env.to_raw(), other.to_local()) }
+    }
+
+    fn to_local(&self) -> raw::Local {
+        self.0
+    }
+
+    unsafe fn from_local(_env: Env, h: raw::Local) -> Self {
+        JsDate(h)
     }
 }
 

--- a/crates/neon/src/types_impl/error.rs
+++ b/crates/neon/src/types_impl/error.rs
@@ -4,7 +4,7 @@ use std::panic::{catch_unwind, UnwindSafe};
 
 use crate::{
     context::{internal::Env, Context},
-    handle::{internal::TransparentNoCopyWrapper, Handle, Managed},
+    handle::{internal::TransparentNoCopyWrapper, Handle},
     object::Object,
     result::{NeonResult, Throw},
     sys::{self, raw},
@@ -47,23 +47,21 @@ unsafe impl TransparentNoCopyWrapper for JsError {
     }
 }
 
-impl Managed for JsError {
-    fn to_raw(&self) -> raw::Local {
-        self.0
-    }
-
-    fn from_raw(_: Env, h: raw::Local) -> Self {
-        JsError(h)
-    }
-}
-
 impl ValueInternal for JsError {
     fn name() -> String {
         "Error".to_string()
     }
 
     fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool {
-        unsafe { sys::tag::is_error(env.to_raw(), other.to_raw()) }
+        unsafe { sys::tag::is_error(env.to_raw(), other.to_local()) }
+    }
+
+    fn to_local(&self) -> raw::Local {
+        self.0
+    }
+
+    unsafe fn from_local(_env: Env, h: raw::Local) -> Self {
+        JsError(h)
     }
 }
 
@@ -81,7 +79,7 @@ impl JsError {
     ) -> NeonResult<Handle<'a, JsError>> {
         let msg = cx.string(msg.as_ref());
         build(cx.env(), |out| unsafe {
-            sys::error::new_error(cx.env().to_raw(), out, msg.to_raw());
+            sys::error::new_error(cx.env().to_raw(), out, msg.to_local());
             true
         })
     }
@@ -95,7 +93,7 @@ impl JsError {
     ) -> NeonResult<Handle<'a, JsError>> {
         let msg = cx.string(msg.as_ref());
         build(cx.env(), |out| unsafe {
-            sys::error::new_type_error(cx.env().to_raw(), out, msg.to_raw());
+            sys::error::new_type_error(cx.env().to_raw(), out, msg.to_local());
             true
         })
     }
@@ -109,7 +107,7 @@ impl JsError {
     ) -> NeonResult<Handle<'a, JsError>> {
         let msg = cx.string(msg.as_ref());
         build(cx.env(), |out| unsafe {
-            sys::error::new_range_error(cx.env().to_raw(), out, msg.to_raw());
+            sys::error::new_range_error(cx.env().to_raw(), out, msg.to_local());
             true
         })
     }

--- a/crates/neon/src/types_impl/private.rs
+++ b/crates/neon/src/types_impl/private.rs
@@ -1,24 +1,32 @@
 use crate::{
     context::internal::Env,
-    handle::{Handle, Managed},
+    handle::{internal::TransparentNoCopyWrapper, Handle},
     sys::raw,
     types::Value,
 };
 
-pub trait ValueInternal: Managed + 'static {
+pub trait ValueInternal: TransparentNoCopyWrapper + 'static {
     fn name() -> String;
 
     fn is_typeof<Other: Value>(env: Env, other: &Other) -> bool;
 
     fn downcast<Other: Value>(env: Env, other: &Other) -> Option<Self> {
         if Self::is_typeof(env, other) {
-            Some(Self::from_raw(env, other.to_raw()))
+            // # Safety
+            // `is_typeof` check ensures this is the correct JavaScript type
+            Some(unsafe { Self::from_local(env, other.to_local()) })
         } else {
             None
         }
     }
 
     fn cast<'a, T: Value, F: FnOnce(raw::Local) -> T>(self, f: F) -> Handle<'a, T> {
-        Handle::new_internal(f(self.to_raw()))
+        Handle::new_internal(f(self.to_local()))
     }
+
+    fn to_local(&self) -> raw::Local;
+
+    // # Safety
+    // JavaScript value must be of type `Self`
+    unsafe fn from_local(env: Env, h: raw::Local) -> Self;
 }


### PR DESCRIPTION
There have been [multiple](https://github.com/neon-bindings/neon/pull/801) [examples](https://github.com/neon-bindings/neon/pull/969) where users would like to do something that extends Neon, but requires direct access to Node-API. Sometimes these features to not align with Neon's philosophy.

As an escape hatch, we provide an unsafe `sys` feature that exposes Node-API and conversions to and from Neon types.