### PR TITLE
update the cargo-cp-artifact to make windows nice

### DIFF
--- a/pkgs/cargo-cp-artifact/src/index.js
+++ b/pkgs/cargo-cp-artifact/src/index.js
@@ -15,7 +15,7 @@ function run(argv, env) {
 
   const cp = spawn(options.cmd, options.args, {
     stdio: ["inherit", "pipe", "inherit"],
-    shell: process.platform === 'win32'
+    shell: process.platform === 'win32',
   });
 
   const rl = readline.createInterface({ input: cp.stdout });

--- a/pkgs/cargo-cp-artifact/src/index.js
+++ b/pkgs/cargo-cp-artifact/src/index.js
@@ -15,6 +15,7 @@ function run(argv, env) {
 
   const cp = spawn(options.cmd, options.args, {
     stdio: ["inherit", "pipe", "inherit"],
+    shell: process.platform === 'win32'
   });
 
   const rl = readline.createInterface({ input: cp.stdout });

--- a/pkgs/cargo-cp-artifact/src/index.js
+++ b/pkgs/cargo-cp-artifact/src/index.js
@@ -15,7 +15,7 @@ function run(argv, env) {
 
   const cp = spawn(options.cmd, options.args, {
     stdio: ["inherit", "pipe", "inherit"],
-    shell: process.platform === 'win32',
+    shell: process.platform === "win32",
   });
 
   const rl = readline.createInterface({ input: cp.stdout });


### PR DESCRIPTION
Spawn has slightly different behavior on windows causing the cp command to fail when passing it additional arguments such as `-- type output.txt` (similar to `cat`). This additive change ensures that we are spawning a shell when appropriate on a windows platform. Tested cross platform.