### PR TITLE
Relax Send constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "once_cell",
  "psd",
  "semver",
+ "send_wrapper",
  "smallvec",
  "tokio",
  "widestring",
@@ -549,6 +550,12 @@ name = "semver"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -31,6 +31,7 @@ neon-macros = { version = "=1.0.0-alpha.2", path = "../neon-macros" }
 aquamarine = { version = "0.1.11", optional = true }
 easy-cast = { version = "0.5.1", optional = true }
 doc-comment = { version = "0.3.3", optional = true }
+send_wrapper = "0.6"
 
 [dependencies.tokio]
 version = "1.24.2"

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -423,7 +423,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     ///     Ok(point)
     /// }
     /// ```
-    fn boxed<U: Finalize + Send + 'static>(&mut self, v: U) -> Handle<'a, JsBox<U>> {
+    fn boxed<U: Finalize + 'static>(&mut self, v: U) -> Handle<'a, JsBox<U>> {
         JsBox::new(self, v)
     }
 

--- a/crates/neon/src/event/task.rs
+++ b/crates/neon/src/event/task.rs
@@ -48,7 +48,7 @@ where
     /// of the `execute` callback
     pub fn and_then<F>(self, complete: F)
     where
-        F: FnOnce(TaskContext, O) -> NeonResult<()> + Send + 'static,
+        F: FnOnce(TaskContext, O) -> NeonResult<()> + 'static,
     {
         let env = self.cx.env();
         let execute = self.execute;
@@ -65,7 +65,7 @@ where
     pub fn promise<V, F>(self, complete: F) -> Handle<'a, JsPromise>
     where
         V: Value,
-        F: FnOnce(TaskContext, O) -> JsResult<V> + Send + 'static,
+        F: FnOnce(TaskContext, O) -> JsResult<V> + 'static,
     {
         let env = self.cx.env();
         let (deferred, promise) = JsPromise::new(self.cx);
@@ -82,7 +82,7 @@ fn schedule<I, O, D>(env: Env, input: I, data: D)
 where
     I: FnOnce() -> O + Send + 'static,
     O: Send + 'static,
-    D: FnOnce(TaskContext, O) -> NeonResult<()> + Send + 'static,
+    D: FnOnce(TaskContext, O) -> NeonResult<()> + 'static,
 {
     unsafe {
         async_work::schedule(env.to_raw(), input, execute::<I, O>, complete::<O, D>, data);
@@ -100,7 +100,7 @@ where
 fn complete<O, D>(env: raw::Env, output: thread::Result<O>, callback: D)
 where
     O: Send + 'static,
-    D: FnOnce(TaskContext, O) -> NeonResult<()> + Send + 'static,
+    D: FnOnce(TaskContext, O) -> NeonResult<()> + 'static,
 {
     let output = output.unwrap_or_else(|panic| {
         // If a panic was caught while executing the task on the Node Worker
@@ -118,7 +118,7 @@ fn schedule_promise<I, O, D, V>(env: Env, input: I, complete: D, deferred: Defer
 where
     I: FnOnce() -> O + Send + 'static,
     O: Send + 'static,
-    D: FnOnce(TaskContext, O) -> JsResult<V> + Send + 'static,
+    D: FnOnce(TaskContext, O) -> JsResult<V> + 'static,
     V: Value,
 {
     unsafe {
@@ -138,7 +138,7 @@ fn complete_promise<O, D, V>(
     (complete, deferred): (D, Deferred),
 ) where
     O: Send + 'static,
-    D: FnOnce(TaskContext, O) -> JsResult<V> + Send + 'static,
+    D: FnOnce(TaskContext, O) -> JsResult<V> + 'static,
     V: Value,
 {
     let env = env.into();

--- a/crates/neon/src/sys/debug_send_wrapper.rs
+++ b/crates/neon/src/sys/debug_send_wrapper.rs
@@ -1,0 +1,56 @@
+//! Wrapper that ensures types are always used from the same thread
+//! in debug builds. It is a zero-cost in release builds.
+
+pub(super) use wrapper::DebugSendWrapper;
+
+#[cfg(debug_assertions)]
+mod wrapper {
+    use std::ops::Deref;
+
+    #[repr(transparent)]
+    pub struct DebugSendWrapper<T>(send_wrapper::SendWrapper<T>);
+
+    impl<T> DebugSendWrapper<T> {
+        pub fn new(value: T) -> Self {
+            Self(send_wrapper::SendWrapper::new(value))
+        }
+
+        pub fn take(self) -> T {
+            self.0.take()
+        }
+    }
+
+    impl<T> Deref for DebugSendWrapper<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+mod wrapper {
+    use std::ops::Deref;
+
+    #[repr(transparent)]
+    pub struct DebugSendWrapper<T>(T);
+
+    impl<T> DebugSendWrapper<T> {
+        pub fn new(value: T) -> Self {
+            Self(value)
+        }
+
+        pub fn take(self) -> T {
+            self.0
+        }
+    }
+
+    impl<T> Deref for DebugSendWrapper<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+}

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -100,6 +100,7 @@ pub(crate) mod tsfn;
 #[cfg(feature = "napi-5")]
 pub(crate) mod date;
 
+mod debug_send_wrapper;
 #[cfg(feature = "napi-6")]
 pub(crate) mod lifecycle;
 

--- a/crates/neon/src/sys/no_panic.rs
+++ b/crates/neon/src/sys/no_panic.rs
@@ -18,6 +18,7 @@ use std::{
 
 use super::{
     bindings as napi,
+    debug_send_wrapper::DebugSendWrapper,
     error::fatal_error,
     raw::{Env, Local},
 };
@@ -256,7 +257,7 @@ unsafe fn external_from_panic(env: Env, panic: Panic) -> Local {
     let mut result = MaybeUninit::uninit();
     let status = napi::create_external(
         env,
-        Box::into_raw(Box::new(panic)).cast(),
+        Box::into_raw(Box::new(DebugSendWrapper::new(panic))).cast(),
         Some(finalize_panic),
         ptr::null_mut(),
         result.as_mut_ptr(),


### PR DESCRIPTION
Currently, Neon _pessimistically_ assumes that JavaScript runtimes _may_ choose to execute from different threads. The specification only defines serial execution and not necessarily single threaded execution.

In practice, this will always be one thread. V8 makes heavy usage of TLS and it would be a large lift to start doing things differently.

This PR changes Neon to _optimistically_ assume the runtime will always execute from the same thread. As a small level of protection, I added `SendWrapper` when `debug_assertions` are enabled. This will `panic` if the single-thread invariant is violated.