### PR TITLE
Global object method change

### DIFF
--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -359,6 +359,12 @@ pub trait Context<'a>: ContextInternal<'a> {
         JsDate::new(self, value)
     }
 
+    /// Convenience method for looking up a global property by name.
+    fn global<T: Value>(&mut self, name: &str) -> JsResult<'a, T> {
+        let global = self.global_object();
+        global.get(self, name)
+    }
+
     /// Produces a handle to the JavaScript global object.
     fn global_object(&mut self) -> Handle<'a, JsObject> {
         JsObject::build(|out| unsafe {

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -360,6 +360,22 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     /// Convenience method for looking up a global property by name.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```
+    /// # use neon::prelude::*;
+    /// # fn get_array_global<'cx, C: Context<'cx>>(cx: &mut C) -> JsResult<'cx, JsFunction> {
+    /// #     let name = "Array";
+    /// #     let v: Handle<JsFunction> =
+    /// {
+    ///     let global = cx.global_object();
+    ///     global.get(cx, name)
+    /// }
+    /// #     ?;
+    /// #     Ok(v)
+    /// # }
+    /// ```
     fn global<T: Value>(&mut self, name: &str) -> JsResult<'a, T> {
         let global = self.global_object();
         global.get(self, name)

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -360,7 +360,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     }
 
     /// Produces a handle to the JavaScript global object.
-    fn global(&mut self) -> Handle<'a, JsObject> {
+    fn global_object(&mut self) -> Handle<'a, JsObject> {
         JsObject::build(|out| unsafe {
             sys::scope::get_global(self.env().to_raw(), out);
         })

--- a/crates/neon/src/thread/mod.rs
+++ b/crates/neon/src/thread/mod.rs
@@ -15,8 +15,7 @@
 //!
 //! pub fn thread_id<'cx, C: Context<'cx>>(cx: &mut C) -> NeonResult<u32> {
 //!     THREAD_ID.get_or_try_init(cx, |cx| {
-//!         let global = cx.global_object();
-//!         let require: Handle<JsFunction> = global.get(cx, "require")?;
+//!         let require: Handle<JsFunction> = cx.global("require")?;
 //!         let worker: Handle<JsObject> = require.call_with(cx)
 //!             .arg(cx.string("node:worker_threads"))
 //!             .apply(cx)?;

--- a/crates/neon/src/thread/mod.rs
+++ b/crates/neon/src/thread/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! pub fn thread_id<'cx, C: Context<'cx>>(cx: &mut C) -> NeonResult<u32> {
 //!     THREAD_ID.get_or_try_init(cx, |cx| {
-//!         let global = cx.global();
+//!         let global = cx.global_object();
 //!         let require: Handle<JsFunction> = global.get(cx, "require")?;
 //!         let worker: Handle<JsObject> = require.call_with(cx)
 //!             .arg(cx.string("node:worker_threads"))

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -296,7 +296,7 @@ impl<T: 'static> Deref for JsBox<T> {
 ///
 /// impl Finalize for Point {
 ///     fn finalize<'a, C: Context<'a>>(self, cx: &mut C) {
-///         let global = cx.global();
+///         let global = cx.global_object();
 ///         let emit: Handle<JsFunction> = global
 ///             .get(cx, "emit")
 ///             .unwrap();

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod private;
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
-/// # let global = cx.global();
+/// # let global = cx.global_object();
 /// # let parse_int: Handle<JsFunction> = global.get(&mut cx, "parseInt")?;
 /// let x: Handle<JsNumber> = parse_int
 ///     .call_with(&cx)
@@ -77,7 +77,7 @@ impl<'a> CallOptions<'a> {
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
-/// # let global = cx.global();
+/// # let global = cx.global_object();
 /// # let url: Handle<JsFunction> = global.get(&mut cx, "URL")?;
 /// let obj = url
 ///     .construct_with(&cx)

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -18,8 +18,7 @@ pub(crate) mod private;
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
-/// # let global = cx.global_object();
-/// # let parse_int: Handle<JsFunction> = global.get(&mut cx, "parseInt")?;
+/// # let parse_int: Handle<JsFunction> = cx.global("parseInt")?;
 /// let x: Handle<JsNumber> = parse_int
 ///     .call_with(&cx)
 ///     .arg(cx.string("42"))
@@ -77,8 +76,7 @@ impl<'a> CallOptions<'a> {
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
-/// # let global = cx.global_object();
-/// # let url: Handle<JsFunction> = global.get(&mut cx, "URL")?;
+/// # let url: Handle<JsFunction> = cx.global("URL")?;
 /// let obj = url
 ///     .construct_with(&cx)
 ///     .arg(cx.string("https://neon-bindings.com"))

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -201,7 +201,7 @@ impl JsValue {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console object:
-/// let console: Handle<JsObject> = cx.global().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
 ///
 /// // The undefined value:
 /// let undefined = cx.undefined();
@@ -272,7 +272,7 @@ impl ValueInternal for JsUndefined {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsNull> {
-/// cx.global()
+/// cx.global_object()
 ///     .get::<JsObject, _, _>(&mut cx, "console")?
 ///     .call_method_with(&mut cx, "log")?
 ///     .arg(cx.null())
@@ -342,7 +342,7 @@ impl ValueInternal for JsNull {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // The two Boolean values:
@@ -419,7 +419,7 @@ impl ValueInternal for JsBoolean {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // Create a string:
@@ -696,7 +696,7 @@ impl JsString {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // Create a number:
@@ -772,7 +772,7 @@ impl ValueInternal for JsNumber {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // Create an object:
@@ -985,7 +985,7 @@ impl Object for JsArray {}
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
-/// # let global = cx.global();
+/// # let global = cx.global_object();
 /// // Extract the parseInt function from the global object
 /// let parse_int: Handle<JsFunction> = global.get(&mut cx, "parseInt")?;
 ///
@@ -1006,7 +1006,7 @@ impl Object for JsArray {}
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
-/// # let global = cx.global();
+/// # let global = cx.global_object();
 /// // Extract the URL constructor from the global object
 /// let url: Handle<JsFunction> = global.get(&mut cx, "URL")?;
 ///

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -201,7 +201,7 @@ impl JsValue {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console object:
-/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global("console")?;
 ///
 /// // The undefined value:
 /// let undefined = cx.undefined();
@@ -272,8 +272,7 @@ impl ValueInternal for JsUndefined {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsNull> {
-/// cx.global_object()
-///     .get::<JsObject, _, _>(&mut cx, "console")?
+/// cx.global::<JsObject>("console")?
 ///     .call_method_with(&mut cx, "log")?
 ///     .arg(cx.null())
 ///     .exec(&mut cx)?;
@@ -342,7 +341,7 @@ impl ValueInternal for JsNull {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global("console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // The two Boolean values:
@@ -419,7 +418,7 @@ impl ValueInternal for JsBoolean {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global("console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // Create a string:
@@ -696,7 +695,7 @@ impl JsString {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global("console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // Create a number:
@@ -772,7 +771,7 @@ impl ValueInternal for JsNumber {
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global_object().get(&mut cx, "console")?;
+/// let console: Handle<JsObject> = cx.global("console")?;
 /// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
 ///
 /// // Create an object:
@@ -985,9 +984,8 @@ impl Object for JsArray {}
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
-/// # let global = cx.global_object();
 /// // Extract the parseInt function from the global object
-/// let parse_int: Handle<JsFunction> = global.get(&mut cx, "parseInt")?;
+/// let parse_int: Handle<JsFunction> = cx.global("parseInt")?;
 ///
 /// // Call parseInt("42")
 /// let x: Handle<JsNumber> = parse_int
@@ -1006,9 +1004,8 @@ impl Object for JsArray {}
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
-/// # let global = cx.global_object();
 /// // Extract the URL constructor from the global object
-/// let url: Handle<JsFunction> = global.get(&mut cx, "URL")?;
+/// let url: Handle<JsFunction> = cx.global("URL")?;
 ///
 /// // Call new URL("https://neon-bindings.com")
 /// let obj = url

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -27,7 +27,7 @@ pub fn call_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<JsNum
 }
 
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {
-    let math: Handle<JsObject> = cx.global_object().get(cx, "Math")?;
+    let math: Handle<JsObject> = cx.global("Math")?;
     let max: Handle<JsFunction> = math.get(cx, "max")?;
     Ok(max)
 }
@@ -96,8 +96,7 @@ pub fn exec_js_function_with_implicit_this(mut cx: FunctionContext) -> JsResult<
 }
 
 pub fn call_js_function_with_heterogeneous_tuple(mut cx: FunctionContext) -> JsResult<JsArray> {
-    cx.global_object()
-        .get::<JsFunction, _, _>(&mut cx, "Array")?
+    cx.global::<JsFunction>("Array")?
         .call_with(&cx)
         .args((cx.number(1.0), cx.string("hello"), cx.boolean(true)))
         .apply(&mut cx)
@@ -129,8 +128,7 @@ pub fn construct_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<
 }
 
 pub fn construct_js_function_with_overloaded_result(mut cx: FunctionContext) -> JsResult<JsArray> {
-    let global = cx.global_object();
-    let f: Handle<JsFunction> = global.get(&mut cx, "Array")?;
+    let f: Handle<JsFunction> = cx.global("Array")?;
     f.construct_with(&cx)
         .arg(cx.number(1))
         .arg(cx.number(2))

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -27,7 +27,7 @@ pub fn call_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<JsNum
 }
 
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {
-    let math: Handle<JsObject> = cx.global().get(cx, "Math")?;
+    let math: Handle<JsObject> = cx.global_object().get(cx, "Math")?;
     let max: Handle<JsFunction> = math.get(cx, "max")?;
     Ok(max)
 }
@@ -96,7 +96,7 @@ pub fn exec_js_function_with_implicit_this(mut cx: FunctionContext) -> JsResult<
 }
 
 pub fn call_js_function_with_heterogeneous_tuple(mut cx: FunctionContext) -> JsResult<JsArray> {
-    cx.global()
+    cx.global_object()
         .get::<JsFunction, _, _>(&mut cx, "Array")?
         .call_with(&cx)
         .args((cx.number(1.0), cx.string("hello"), cx.boolean(true)))
@@ -129,7 +129,7 @@ pub fn construct_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<
 }
 
 pub fn construct_js_function_with_overloaded_result(mut cx: FunctionContext) -> JsResult<JsArray> {
-    let global = cx.global();
+    let global = cx.global_object();
     let f: Handle<JsFunction> = global.get(&mut cx, "Array")?;
     f.construct_with(&cx)
         .arg(cx.number(1))
@@ -225,7 +225,7 @@ pub fn throw_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
 pub fn call_and_catch(mut cx: FunctionContext) -> JsResult<JsValue> {
     let f: Handle<JsFunction> = cx.argument(0)?;
     Ok(cx
-        .try_catch(|cx| f.call_with(cx).this(cx.global()).apply(cx))
+        .try_catch(|cx| f.call_with(cx).this(cx.global_object()).apply(cx))
         .unwrap_or_else(|err| err))
 }
 

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use neon::{prelude::*, types::buffer::TypedArray};
 
 pub fn return_js_global_object(mut cx: FunctionContext) -> JsResult<JsObject> {
-    Ok(cx.global())
+    Ok(cx.global_object())
 }
 
 pub fn return_js_object(mut cx: FunctionContext) -> JsResult<JsObject> {

--- a/test/napi/src/js/workers.rs
+++ b/test/napi/src/js/workers.rs
@@ -77,7 +77,7 @@ static GLOBAL_OBJECT: LocalKey<Root<JsObject>> = LocalKey::new();
 
 pub fn stash_global_object(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     GLOBAL_OBJECT.get_or_try_init(&mut cx, |cx| {
-        let global = cx.global();
+        let global = cx.global_object();
         let global: Root<JsObject> = Root::new(cx, &global);
         Ok(global)
     })?;


### PR DESCRIPTION
From the list of remaining [breaking changes](https://github.com/neon-bindings/neon/wiki/Candidate-Breaking-Changes-for-1.0):
- Change the existing `Context::global()` method to `Context::global_object()`
- Add a convenience method `Context::global(name)` that looks up a global value by name
