### PR TITLE
`JsArray::new()` takes a usize

### DIFF
--- a/crates/neon/src/sys/array.rs
+++ b/crates/neon/src/sys/array.rs
@@ -5,9 +5,9 @@ use super::{
     raw::{Env, Local},
 };
 
-pub unsafe fn new(out: &mut Local, env: Env, length: u32) {
+pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
     assert_eq!(
-        napi::create_array_with_length(env, length as usize, out as *mut _),
+        napi::create_array_with_length(env, length, out as *mut _),
         napi::Status::Ok,
     );
 }

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -886,11 +886,11 @@ impl JsArray {
     /// elements to the end of the array.
     ///
     /// **See also:** [`Context::empty_array`]
-    pub fn new<'a, C: Context<'a>>(cx: &mut C, len: u32) -> Handle<'a, JsArray> {
+    pub fn new<'a, C: Context<'a>>(cx: &mut C, len: usize) -> Handle<'a, JsArray> {
         JsArray::new_internal(cx.env(), len)
     }
 
-    pub(crate) fn new_internal<'a>(env: Env, len: u32) -> Handle<'a, JsArray> {
+    pub(crate) fn new_internal<'a>(env: Env, len: usize) -> Handle<'a, JsArray> {
         unsafe {
             let mut local: raw::Local = std::mem::zeroed();
             sys::array::new(&mut local, env.to_raw(), len);


### PR DESCRIPTION
From the list of remaining [breaking changes](https://github.com/neon-bindings/neon/wiki/Candidate-Breaking-Changes-for-1.0), this PR implements the one and only remaining case where the Neon API uses a `u32` but should use a `usize`: `JsArray::new()`.

I did an audit of all other occurrences of `u32` in the codebase and all the remaining instances are fine:
- Object indexed properties -- the JS semantics explicitly defines this for u32 only
- `JsArray::len()` -- Node-API [exposes this as `u32`](https://nodejs.org/api/n-api.html#napi_get_array_length)
- `ref`/`unref` -- Node-API [exposes this as `u32`](https://nodejs.org/api/n-api.html#napi_reference_ref)
- Node-API version -- Node-API [exposes this as `u32`](https://nodejs.org/api/n-api.html#napi_get_version)
- `Finalize` implementation for `u32` -- this is just predefined on a bunch of Rust primitive types
- typed arrays -- u32 is one of the supported typed array types
- lifecycle instance ID -- implementation detail
