### PR TITLE
remove `JsFunction` type parameter

### DIFF
--- a/crates/neon/src/lifecycle.rs
+++ b/crates/neon/src/lifecycle.rs
@@ -74,7 +74,9 @@ pub(crate) struct LocalTable {
 
 pub(crate) type LocalCellValue = Box<dyn Any + Send + 'static>;
 
+#[derive(Default)]
 pub(crate) enum LocalCell {
+    #[default]
     /// Uninitialized state.
     Uninit,
     /// Intermediate "dirty" state representing the middle of a `get_or_try_init` transaction.
@@ -140,12 +142,6 @@ impl LocalCell {
 
         // If we're here, the transaction has succeeded, so get the result.
         Ok(LocalCell::get(cx, id).unwrap())
-    }
-}
-
-impl Default for LocalCell {
-    fn default() -> Self {
-        LocalCell::Uninit
     }
 }
 

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1116,9 +1116,7 @@ impl JsFunction {
 
         unsafe {
             if let Ok(raw) = sys::fun::new(cx.env().to_raw(), name, f) {
-                Ok(Handle::new_internal(JsFunction {
-                    raw,
-                }))
+                Ok(Handle::new_internal(JsFunction { raw }))
             } else {
                 Err(Throw::new())
             }
@@ -1167,7 +1165,11 @@ impl JsFunction {
     /// Calls this function as a constructor.
     ///
     /// **See also:** [`JsFunction::construct_with`].
-    pub fn construct<'a, 'b, C: Context<'a>, AS>(&self, cx: &mut C, args: AS) -> JsResult<'a, JsObject>
+    pub fn construct<'a, 'b, C: Context<'a>, AS>(
+        &self,
+        cx: &mut C,
+        args: AS,
+    ) -> JsResult<'a, JsObject>
     where
         AS: AsRef<[Handle<'b, JsValue>]>,
     {
@@ -1209,9 +1211,7 @@ impl JsFunction {
     /// # Safety
     /// The caller must wrap in a `Handle` with an appropriate lifetime.
     unsafe fn clone(&self) -> Self {
-        Self {
-            raw: self.raw,
-        }
+        Self { raw: self.raw }
     }
 }
 
@@ -1239,9 +1239,7 @@ impl ValueInternal for JsFunction {
     }
 
     unsafe fn from_local(_env: Env, h: raw::Local) -> Self {
-        JsFunction {
-            raw: h,
-        }
+        JsFunction { raw: h }
     }
 }
 

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -222,6 +222,28 @@ describe("JsFunction", function () {
     assert.strictEqual(addon.get_number_or_default(), 0);
   });
 
+  it("always provides an object for the this-binding", function() {
+    var meta1 = addon.assume_this_is_an_object.call(null);
+    assert.strictEqual(meta1.prototype, Object.getPrototypeOf(global));
+    assert.strictEqual(meta1.hasOwn, false);
+    assert.strictEqual(meta1.property, Object.getPrototypeOf(global).toString);
+
+    var meta2 = addon.assume_this_is_an_object.call(42);
+    assert.strictEqual(meta2.prototype, Number.prototype);
+    assert.strictEqual(meta2.hasOwn, false);
+    assert.strictEqual(meta2.property, Number.prototype.toString);
+
+    var meta3 = addon.assume_this_is_an_object.call(Object.create(null));
+    assert.strictEqual(meta3.prototype, null);
+    assert.strictEqual(meta3.hasOwn, false);
+    assert.strictEqual(meta3.property, undefined);
+
+    var meta4 = addon.assume_this_is_an_object.call({toString: 17});
+    assert.strictEqual(meta4.prototype, Object.prototype);
+    assert.strictEqual(meta4.hasOwn, true);
+    assert.strictEqual(meta4.property, 17);
+  });
+
   it("distinguishes calls from constructs", function () {
     assert.equal(addon.is_construct.call({}).wasConstructed, false);
     assert.equal(new addon.is_construct().wasConstructed, true);

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -222,7 +222,7 @@ describe("JsFunction", function () {
     assert.strictEqual(addon.get_number_or_default(), 0);
   });
 
-  it("always provides an object for the this-binding", function() {
+  it("always provides an object for the this-binding", function () {
     var meta1 = addon.assume_this_is_an_object.call(null);
     assert.strictEqual(meta1.prototype, Object.getPrototypeOf(global));
     assert.strictEqual(meta1.hasOwn, false);
@@ -238,7 +238,7 @@ describe("JsFunction", function () {
     assert.strictEqual(meta3.hasOwn, false);
     assert.strictEqual(meta3.property, undefined);
 
-    var meta4 = addon.assume_this_is_an_object.call({toString: 17});
+    var meta4 = addon.assume_this_is_an_object.call({ toString: 17 });
     assert.strictEqual(meta4.prototype, Object.prototype);
     assert.strictEqual(meta4.hasOwn, true);
     assert.strictEqual(meta4.property, 17);

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -237,6 +237,26 @@ pub fn get_number_or_default(mut cx: FunctionContext) -> JsResult<JsNumber> {
     Ok(cx.number(n))
 }
 
+pub fn assume_this_is_an_object(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let this: Handle<JsObject> = cx.this()?;
+    let result: Handle<JsObject> = cx.empty_object();
+    let global: Handle<JsObject> = cx.global();
+    let object_class: Handle<JsFunction> = global.get(&mut cx, "Object")?;
+    let get_prototype_of: Handle<JsFunction> = object_class.get(&mut cx, "getPrototypeOf")?;
+    let object_prototype: Handle<JsObject> = object_class.get(&mut cx, "prototype")?;
+    let has_own_property: Handle<JsFunction> = object_prototype.get(&mut cx, "hasOwnProperty")?;
+    let proto: Result<Handle<JsValue>, Handle<JsValue>> = cx.try_catch(|cx| {
+        get_prototype_of.call_with(cx).arg(this).apply(cx)
+    });
+    let proto: Handle<JsValue> = proto.unwrap_or_else(|_| cx.undefined().upcast());
+    let has_own: Handle<JsBoolean> = has_own_property.call_with(&cx).this(this).arg(cx.string("toString")).apply(&mut cx)?;
+    let prop: Handle<JsValue> = this.get(&mut cx, "toString")?;
+    result.set(&mut cx, "prototype", proto)?;
+    result.set(&mut cx, "hasOwn", has_own)?;
+    result.set(&mut cx, "property", prop)?;
+    Ok(result)
+}
+
 pub fn is_construct(mut cx: FunctionContext) -> JsResult<JsObject> {
     let this = cx.this::<JsObject>()?;
     let construct = matches!(cx.kind(), CallKind::Construct);

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -238,16 +238,18 @@ pub fn get_number_or_default(mut cx: FunctionContext) -> JsResult<JsNumber> {
 pub fn assume_this_is_an_object(mut cx: FunctionContext) -> JsResult<JsObject> {
     let this: Handle<JsObject> = cx.this()?;
     let result: Handle<JsObject> = cx.empty_object();
-    let global: Handle<JsObject> = cx.global();
-    let object_class: Handle<JsFunction> = global.get(&mut cx, "Object")?;
+    let object_class: Handle<JsFunction> = cx.global("Object")?;
     let get_prototype_of: Handle<JsFunction> = object_class.get(&mut cx, "getPrototypeOf")?;
     let object_prototype: Handle<JsObject> = object_class.get(&mut cx, "prototype")?;
     let has_own_property: Handle<JsFunction> = object_prototype.get(&mut cx, "hasOwnProperty")?;
-    let proto: Result<Handle<JsValue>, Handle<JsValue>> = cx.try_catch(|cx| {
-        get_prototype_of.call_with(cx).arg(this).apply(cx)
-    });
+    let proto: Result<Handle<JsValue>, Handle<JsValue>> =
+        cx.try_catch(|cx| get_prototype_of.call_with(cx).arg(this).apply(cx));
     let proto: Handle<JsValue> = proto.unwrap_or_else(|_| cx.undefined().upcast());
-    let has_own: Handle<JsBoolean> = has_own_property.call_with(&cx).this(this).arg(cx.string("toString")).apply(&mut cx)?;
+    let has_own: Handle<JsBoolean> = has_own_property
+        .call_with(&cx)
+        .this(this)
+        .arg(cx.string("toString"))
+        .apply(&mut cx)?;
     let prop: Handle<JsValue> = this.get(&mut cx, "toString")?;
     result.set(&mut cx, "prototype", proto)?;
     result.set(&mut cx, "hasOwn", has_own)?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -319,6 +319,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("throw_and_catch", throw_and_catch)?;
     cx.export_function("call_and_catch", call_and_catch)?;
     cx.export_function("get_number_or_default", get_number_or_default)?;
+    cx.export_function("assume_this_is_an_object", assume_this_is_an_object)?;
     cx.export_function("is_construct", is_construct)?;
     cx.export_function("caller_with_drop_callback", caller_with_drop_callback)?;
 


### PR DESCRIPTION
From the list of [remaining breaking changes](https://github.com/neon-bindings/neon/wiki/Candidate-Breaking-Changes-for-1.0), this PR removes the `JsFunction` type parameter. This is safe for the following reasons:

- Neon functions are non-strict, which means when they are invoked with a non-object (e.g. with `f.call(null)` or `f.call(17)`) the primitive is replaced by an object.
- The `JsObject` type does not assume the object inherits from `Object.prototype`, so it works for any JS objects, even exotic objects like `Object.create(null)`, proxies, module objects, etc.
