### PR TITLE
Root<T>: Data race allowed on T

### DIFF
--- a/crates/neon/src/handle/root.rs
+++ b/crates/neon/src/handle/root.rs
@@ -68,9 +68,9 @@ impl<T> std::fmt::Debug for Root<T> {
 // `Root` are intended to be `Send` and `Sync`
 // Safety: `Root` contains two types. A `NapiRef` which is `Send` and `Sync` and a
 // `PhantomData` that does not impact the safety.
-unsafe impl<T> Send for Root<T> {}
+unsafe impl<T: Send> Send for Root<T> {}
 
-unsafe impl<T> Sync for Root<T> {}
+unsafe impl<T: Sync> Sync for Root<T> {}
 
 #[cfg(feature = "napi-6")]
 fn instance_id<'a, C: Context<'a>>(cx: &mut C) -> InstanceId {


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`Root<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.
https://github.com/neon-bindings/neon/blob/4c2e455a9e6814f1ba0178616d63caec7f4df317/crates/neon/src/handle/root.rs#L71-L73