### PR TITLE
Avoid leaving a dangling future when handling a rejection in JsPromise::to_future

### DIFF
--- a/crates/neon/src/handle/mod.rs
+++ b/crates/neon/src/handle/mod.rs
@@ -80,10 +80,7 @@ pub struct Handle<'a, V: Value + 'a> {
 
 impl<'a, V: Value> Clone for Handle<'a, V> {
     fn clone(&self) -> Self {
-        Self {
-            value: self.value,
-            phantom: PhantomData,
-        }
+        *self
     }
 }
 

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -164,10 +164,7 @@ unsafe fn maybe_external_deref<'a>(env: Env, local: raw::Local) -> Option<&'a Bo
 // Custom `Clone` implementation since `T` might not be `Clone`
 impl<T: 'static> Clone for JsBoxInner<T> {
     fn clone(&self) -> Self {
-        Self {
-            local: self.local,
-            raw_data: self.raw_data,
-        }
+        *self
     }
 }
 

--- a/crates/neon/src/types_impl/promise.rs
+++ b/crates/neon/src/types_impl/promise.rs
@@ -186,7 +186,6 @@ impl JsPromise {
             + 'static,
     {
         let then = self.get::<JsFunction, _, _>(cx, "then")?;
-        let catch = self.get::<JsFunction, _, _>(cx, "catch")?;
 
         let (tx, rx) = oneshot::channel();
         let take_state = {
@@ -235,8 +234,11 @@ impl JsPromise {
             }
         })?;
 
-        then.exec(cx, Handle::new_internal(Self(self.0)), [resolve.upcast()])?;
-        catch.exec(cx, Handle::new_internal(Self(self.0)), [reject.upcast()])?;
+        then.exec(
+            cx,
+            Handle::new_internal(Self(self.0)),
+            [resolve.upcast(), reject.upcast()],
+        )?;
 
         Ok(JsFuture { rx })
     }


### PR DESCRIPTION
Previously, Neon was creating a distinct promise chain for handling resolved promises in `JsPromise::to_future`. This is problematic because it causes an `unhandledRejection`, even though the user may be handling the error.

In other words, it was the equivalent of this JavaScript:

```js
const p = Promise.reject(new Error("oh, no!"));

p.then(() => console.log("Everything is good!"));
p.catch(() => console.log("Handled the error"));
```

```
Handled the error
/private/tmp/try-catch/foo.js:1
const p = Promise.reject(new Error("oh, no!"));
                         ^

Error: oh, no!
```

Instead, we use the two argument version of `.then(onResolved, onRejected)` which accepts both handlers at once, acting sort of like a `match result`. It is equivalent to the following JavaScript:

```js
let settled = false;

Promise
    .reject(new Error("oh, no!"))
    .then(() => {
        if (!settled) {
            console.log("Everything is good!")
        }
    }, () => {
        settled = true;

        console.log("Handled the error")
    });
```