### PR TITLE
Fine-tune the Ordering for the atomic usages

### DIFF
--- a/crates/neon/src/lifecycle.rs
+++ b/crates/neon/src/lifecycle.rs
@@ -37,7 +37,7 @@ impl InstanceId {
     fn next() -> Self {
         static NEXT_ID: AtomicU32 = AtomicU32::new(0);
 
-        let next = NEXT_ID.fetch_add(1, Ordering::SeqCst).checked_add(1);
+        let next = NEXT_ID.fetch_add(1, Ordering::Relaxed).checked_add(1);
         match next {
             Some(id) => Self(id),
             None => panic!("u32 overflow ocurred in Lifecycle InstanceId"),

--- a/crates/neon/src/thread/mod.rs
+++ b/crates/neon/src/thread/mod.rs
@@ -112,7 +112,7 @@ use crate::lifecycle::LocalCell;
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 fn next_id() -> usize {
-    COUNTER.fetch_add(1, Ordering::SeqCst)
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 /// A JavaScript thread-local container that owns its contents, similar to


### PR DESCRIPTION
`SeqCst` is overly restrictive. I believe that the ordering can be appropriately modified.

`COUNTER` and `NEXT_ID` are used for multithreading counting purposes and don’t synchronize with other locals, so using `Relaxed` ordering is sufficient.

https://github.com/neon-bindings/neon/blob/09fce7935b50cdefb1a3eea38116946f070b077a/crates/neon/src/thread/mod.rs#L115
https://github.com/neon-bindings/neon/blob/09fce7935b50cdefb1a3eea38116946f070b077a/crates/neon/src/lifecycle.rs#L40