### PR TITLE
fix(cargo-cp-artifact): Hotfix for change in cargo diagnostics naming

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# `cargo-cp-artifact`
+
+`0.1.9` supports a [breaking change in `cargo`](https://github.com/rust-lang/cargo/issues/13867) that converts artifact names from `kebab-case` to `snake_case`.
+
 # Version 1.0.0
 
 ## Commitment to Compatibility

--- a/pkgs/cargo-cp-artifact/package.json
+++ b/pkgs/cargo-cp-artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cargo-cp-artifact",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Copies compiler artifacts emitted by rustc by parsing Cargo metadata",
   "main": "src/index.js",
   "files": [

--- a/test/electron/package.json
+++ b/test/electron/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/electron/electron-quick-start",
   "devDependencies": {
     "@playwright/test": "^1.40.1",
-    "cargo-cp-artifact": "^0.1.8",
+    "cargo-cp-artifact": "^0.1.9",
     "electron": "^27.1.3",
     "playwright": "^1.40.1"
   }

--- a/test/napi/package.json
+++ b/test/napi/package.json
@@ -10,7 +10,7 @@
     "test": "mocha --v8-expose-gc --timeout 5000 --recursive lib"
   },
   "devDependencies": {
-    "cargo-cp-artifact": "^0.1.8",
+    "cargo-cp-artifact": "^0.1.9",
     "chai": "^4.3.10",
     "mocha": "^10.2.0"
   }


### PR DESCRIPTION
Fix for a change in `cargo` behavior to use the `snake_case` name in artifacts.

https://github.com/rust-lang/cargo/issues/13867