### PR TITLE
Replace all generic contexts with a single Cx type

### DIFF
--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, ffi::c_void, mem::MaybeUninit};
 
 use crate::{
-    context::{Cx, ModuleContext},
+    context::ModuleContext,
     handle::Handle,
     result::NeonResult,
     sys::{self, raw},
@@ -46,10 +46,8 @@ impl Env {
     }
 }
 
-pub trait ContextInternal<'cx>: AsRef<Cx<'cx>> + AsMut<Cx<'cx>> + Sized {
-    fn env(&self) -> Env {
-        self.as_ref().env()
-    }
+pub trait ContextInternal<'cx>: Sized {
+    fn env(&self) -> Env;
 }
 
 fn default_main(mut cx: ModuleContext) -> NeonResult<()> {

--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, ffi::c_void, mem::MaybeUninit};
 
 use crate::{
-    context::ModuleContext,
+    context::{Ctx, ModuleContext},
     handle::Handle,
     result::NeonResult,
     sys::{self, raw},
@@ -46,8 +46,10 @@ impl Env {
     }
 }
 
-pub trait ContextInternal<'a>: Sized {
-    fn env(&self) -> Env;
+pub trait ContextInternal<'cx>: AsRef<Ctx<'cx>> + AsMut<Ctx<'cx>> + Sized {
+    fn env(&self) -> Env {
+        self.as_ref().env()
+    }
 }
 
 fn default_main(mut cx: ModuleContext) -> NeonResult<()> {

--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, ffi::c_void, mem::MaybeUninit};
 
 use crate::{
-    context::ModuleContext,
+    context::{Cx, ModuleContext},
     handle::Handle,
     result::NeonResult,
     sys::{self, raw},
@@ -47,7 +47,11 @@ impl Env {
 }
 
 pub trait ContextInternal<'cx>: Sized {
-    fn env(&self) -> Env;
+    fn cx(&self) -> &Cx<'cx>;
+    fn cx_mut(&mut self) -> &mut Cx<'cx>;
+    fn env(&self) -> Env {
+        self.cx().env
+    }
 }
 
 fn default_main(mut cx: ModuleContext) -> NeonResult<()> {

--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, ffi::c_void, mem::MaybeUninit};
 
 use crate::{
-    context::{Ctx, ModuleContext},
+    context::{Cx, ModuleContext},
     handle::Handle,
     result::NeonResult,
     sys::{self, raw},
@@ -46,7 +46,7 @@ impl Env {
     }
 }
 
-pub trait ContextInternal<'cx>: AsRef<Ctx<'cx>> + AsMut<Ctx<'cx>> + Sized {
+pub trait ContextInternal<'cx>: AsRef<Cx<'cx>> + AsMut<Cx<'cx>> + Sized {
     fn env(&self) -> Env {
         self.as_ref().env()
     }

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -180,21 +180,26 @@ use crate::types::date::{DateError, JsDate};
 #[cfg(feature = "napi-6")]
 use crate::lifecycle::InstanceData;
 
+#[doc(hidden)]
 /// An execution context of a task completion callback.
 pub type TaskContext<'cx> = Cx<'cx>;
 
+#[doc(hidden)]
 /// An execution context of a scope created by [`Context::execute_scoped()`](Context::execute_scoped).
 pub type ExecuteContext<'cx> = Cx<'cx>;
 
+#[doc(hidden)]
 /// An execution context of a scope created by [`Context::compute_scoped()`](Context::compute_scoped).
 pub type ComputeContext<'cx> = Cx<'cx>;
 
+#[doc(hidden)]
 /// A view of the JS engine in the context of a finalize method on garbage collection
 pub type FinalizeContext<'cx> = Cx<'cx>;
 
 /// An execution context constructed from a raw [`Env`](crate::sys::bindings::Env).
 #[cfg(feature = "sys")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sys")))]
+#[doc(hidden)]
 pub type SysContext<'cx> = Cx<'cx>;
 
 /// Context representing access to the JavaScript runtime
@@ -208,7 +213,7 @@ impl<'cx> Cx<'cx> {
     ///
     /// # Safety
     ///
-    /// Once a `SysContext` has been created, it is unsafe to use
+    /// Once a [`Cx`] has been created, it is unsafe to use
     /// the `Env`. The handle scope for the `Env` must be valid for
     /// the lifetime `'cx`.
     #[cfg(feature = "sys")]
@@ -344,7 +349,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     fn execute_scoped<'b, T, F>(&mut self, f: F) -> T
     where
         'a: 'b,
-        F: FnOnce(ExecuteContext<'b>) -> T,
+        F: FnOnce(Cx<'b>) -> T,
     {
         let env = self.env();
         let scope = unsafe { HandleScope::new(env.to_raw()) };
@@ -364,7 +369,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     where
         'a: 'b,
         V: Value,
-        F: FnOnce(ComputeContext<'b>) -> JsResult<'b, V>,
+        F: FnOnce(Cx<'b>) -> JsResult<'b, V>,
     {
         let env = self.env();
         let scope = unsafe { EscapableHandleScope::new(env.to_raw()) };

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -233,25 +233,13 @@ impl<'cx> Cx<'cx> {
             _phantom_inner: PhantomData,
         })
     }
+}
 
+impl<'cx> ContextInternal<'cx> for Cx<'cx> {
     fn env(&self) -> Env {
         self.env
     }
 }
-
-impl<'cx> AsRef<Cx<'cx>> for Cx<'cx> {
-    fn as_ref(&self) -> &Cx<'cx> {
-        self
-    }
-}
-
-impl<'cx> AsMut<Cx<'cx>> for Cx<'cx> {
-    fn as_mut(&mut self) -> &mut Cx<'cx> {
-        self
-    }
-}
-
-impl<'cx> ContextInternal<'cx> for Cx<'cx> {}
 
 impl<'cx> Context<'cx> for Cx<'cx> {}
 
@@ -644,18 +632,6 @@ impl<'cx> DerefMut for ModuleContext<'cx> {
     }
 }
 
-impl<'cx> AsRef<Cx<'cx>> for ModuleContext<'cx> {
-    fn as_ref(&self) -> &Cx<'cx> {
-        self
-    }
-}
-
-impl<'cx> AsMut<Cx<'cx>> for ModuleContext<'cx> {
-    fn as_mut(&mut self) -> &mut Cx<'cx> {
-        self
-    }
-}
-
 impl<'cx> UnwindSafe for ModuleContext<'cx> {}
 
 impl<'cx> ModuleContext<'cx> {
@@ -708,7 +684,11 @@ impl<'cx> ModuleContext<'cx> {
     }
 }
 
-impl<'cx> ContextInternal<'cx> for ModuleContext<'cx> {}
+impl<'cx> ContextInternal<'cx> for ModuleContext<'cx> {
+    fn env(&self) -> Env {
+        self.cx.env
+    }
+}
 
 impl<'cx> Context<'cx> for ModuleContext<'cx> {}
 
@@ -733,18 +713,6 @@ impl<'cx> Deref for FunctionContext<'cx> {
 impl<'cx> DerefMut for FunctionContext<'cx> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.cx
-    }
-}
-
-impl<'cx> AsRef<Cx<'cx>> for FunctionContext<'cx> {
-    fn as_ref(&self) -> &Cx<'cx> {
-        self
-    }
-}
-
-impl<'cx> AsMut<Cx<'cx>> for FunctionContext<'cx> {
-    fn as_mut(&mut self) -> &mut Cx<'cx> {
-        self
     }
 }
 
@@ -862,6 +830,10 @@ impl<'cx> FunctionContext<'cx> {
     }
 }
 
-impl<'cx> ContextInternal<'cx> for FunctionContext<'cx> {}
+impl<'cx> ContextInternal<'cx> for FunctionContext<'cx> {
+    fn env(&self) -> Env {
+        self.cx.env
+    }
+}
 
 impl<'cx> Context<'cx> for FunctionContext<'cx> {}

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -175,10 +175,85 @@ use crate::types::date::{DateError, JsDate};
 #[cfg(feature = "napi-6")]
 use crate::lifecycle::InstanceData;
 
+/// An execution context of a task completion callback.
+pub type TaskContext<'cx> = Ctx<'cx>;
+
+/// An execution context of a scope created by [`Context::execute_scoped()`](Context::execute_scoped).
+pub type ExecuteContext<'cx> = Ctx<'cx>;
+
+/// An execution context of a scope created by [`Context::compute_scoped()`](Context::compute_scoped).
+pub type ComputeContext<'cx> = Ctx<'cx>;
+
+/// A view of the JS engine in the context of a finalize method on garbage collection
+pub type FinalizeContext<'cx> = Ctx<'cx>;
+
+/// An execution context constructed from a raw [`Env`](crate::sys::bindings::Env).
+#[cfg(feature = "sys")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sys")))]
+pub type SysContext<'cx> = Ctx<'cx>;
+
+/// Context representing access to the JavaScript runtime
+pub struct Ctx<'cx> {
+    env: Env,
+    _phantom_inner: PhantomData<&'cx ()>,
+}
+
+impl<'cx> Ctx<'cx> {
+    /// Creates a context from a raw `Env`.
+    ///
+    /// # Safety
+    ///
+    /// Once a `SysContext` has been created, it is unsafe to use
+    /// the `Env`. The handle scope for the `Env` must be valid for
+    /// the lifetime `'cx`.
+    #[cfg(feature = "sys")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sys")))]
+    pub unsafe fn from_raw(env: sys::Env) -> Self {
+        Self {
+            env: env.into(),
+            _phantom_inner: PhantomData,
+        }
+    }
+
+    fn new(env: Env) -> Self {
+        Self {
+            env,
+            _phantom_inner: PhantomData,
+        }
+    }
+
+    pub(crate) fn with_context<T, F: for<'b> FnOnce(Ctx<'b>) -> T>(env: Env, f: F) -> T {
+        f(Self {
+            env,
+            _phantom_inner: PhantomData,
+        })
+    }
+
+    fn env(&self) -> Env {
+        self.env
+    }
+}
+
+impl<'cx> AsRef<Ctx<'cx>> for Ctx<'cx> {
+    fn as_ref(&self) -> &Ctx<'cx> {
+        self
+    }
+}
+
+impl<'cx> AsMut<Ctx<'cx>> for Ctx<'cx> {
+    fn as_mut(&mut self) -> &mut Ctx<'cx> {
+        self
+    }
+}
+
+impl<'cx> ContextInternal<'cx> for Ctx<'cx> {}
+
+impl<'cx> Context<'cx> for Ctx<'cx> {}
+
 #[repr(C)]
-pub(crate) struct CallbackInfo<'a> {
+pub(crate) struct CallbackInfo<'cx> {
     info: raw::FunctionCallbackInfo,
-    _lifetime: PhantomData<&'a raw::FunctionCallbackInfo>,
+    _lifetime: PhantomData<&'cx raw::FunctionCallbackInfo>,
 }
 
 impl CallbackInfo<'_> {
@@ -280,10 +355,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     {
         let env = self.env();
         let scope = unsafe { HandleScope::new(env.to_raw()) };
-        let result = f(ExecuteContext {
-            env,
-            _phantom_inner: PhantomData,
-        });
+        let result = f(Ctx::new(env));
 
         drop(scope);
 
@@ -303,10 +375,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     {
         let env = self.env();
         let scope = unsafe { EscapableHandleScope::new(env.to_raw()) };
-        let cx = ComputeContext {
-            env,
-            phantom_inner: PhantomData,
-        };
+        let cx = Ctx::new(env);
 
         let escapee = unsafe { scope.escape(f(cx)?.to_local()) };
 
@@ -551,20 +620,35 @@ pub trait Context<'a>: ContextInternal<'a> {
 }
 
 /// An execution context of module initialization.
-pub struct ModuleContext<'a> {
-    env: Env,
-    exports: Handle<'a, JsObject>,
+pub struct ModuleContext<'cx> {
+    cx: Ctx<'cx>,
+    exports: Handle<'cx, JsObject>,
 }
 
-impl<'a> UnwindSafe for ModuleContext<'a> {}
+impl<'cx> AsRef<Ctx<'cx>> for ModuleContext<'cx> {
+    fn as_ref(&self) -> &Ctx<'cx> {
+        &self.cx
+    }
+}
 
-impl<'a> ModuleContext<'a> {
+impl<'cx> AsMut<Ctx<'cx>> for ModuleContext<'cx> {
+    fn as_mut(&mut self) -> &mut Ctx<'cx> {
+        &mut self.cx
+    }
+}
+
+impl<'cx> UnwindSafe for ModuleContext<'cx> {}
+
+impl<'cx> ModuleContext<'cx> {
     pub(crate) fn with<T, F: for<'b> FnOnce(ModuleContext<'b>) -> T>(
         env: Env,
-        exports: Handle<'a, JsObject>,
+        exports: Handle<'cx, JsObject>,
         f: F,
     ) -> T {
-        f(ModuleContext { env, exports })
+        f(ModuleContext {
+            cx: Ctx::new(env),
+            exports,
+        })
     }
 
     #[cfg(not(feature = "napi-5"))]
@@ -600,60 +684,40 @@ impl<'a> ModuleContext<'a> {
     }
 
     /// Produces a handle to a module's exports object.
-    pub fn exports_object(&mut self) -> JsResult<'a, JsObject> {
+    pub fn exports_object(&mut self) -> JsResult<'cx, JsObject> {
         Ok(self.exports)
     }
 }
 
-impl<'a> ContextInternal<'a> for ModuleContext<'a> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
+impl<'cx> ContextInternal<'cx> for ModuleContext<'cx> {}
 
-impl<'a> Context<'a> for ModuleContext<'a> {}
-
-/// An execution context of a scope created by [`Context::execute_scoped()`](Context::execute_scoped).
-pub struct ExecuteContext<'a> {
-    env: Env,
-    _phantom_inner: PhantomData<&'a ()>,
-}
-
-impl<'a> ContextInternal<'a> for ExecuteContext<'a> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
-
-impl<'a> Context<'a> for ExecuteContext<'a> {}
-
-/// An execution context of a scope created by [`Context::compute_scoped()`](Context::compute_scoped).
-pub struct ComputeContext<'a> {
-    env: Env,
-    phantom_inner: PhantomData<&'a ()>,
-}
-
-impl<'a> ContextInternal<'a> for ComputeContext<'a> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
-
-impl<'a> Context<'a> for ComputeContext<'a> {}
+impl<'cx> Context<'cx> for ModuleContext<'cx> {}
 
 /// An execution context of a function call.
 ///
 /// The type parameter `T` is the type of the `this`-binding.
-pub struct FunctionContext<'a> {
-    env: Env,
-    info: &'a CallbackInfo<'a>,
+pub struct FunctionContext<'cx> {
+    cx: Ctx<'cx>,
+    info: &'cx CallbackInfo<'cx>,
 
     arguments: Option<sys::call::Arguments>,
 }
 
-impl<'a> UnwindSafe for FunctionContext<'a> {}
+impl<'cx> AsRef<Ctx<'cx>> for FunctionContext<'cx> {
+    fn as_ref(&self) -> &Ctx<'cx> {
+        &self.cx
+    }
+}
 
-impl<'a> FunctionContext<'a> {
+impl<'cx> AsMut<Ctx<'cx>> for FunctionContext<'cx> {
+    fn as_mut(&mut self) -> &mut Ctx<'cx> {
+        &mut self.cx
+    }
+}
+
+impl<'cx> UnwindSafe for FunctionContext<'cx> {}
+
+impl<'cx> FunctionContext<'cx> {
     /// Indicates whether the function was called with `new`.
     pub fn kind(&self) -> CallKind {
         self.info.kind(self)
@@ -661,11 +725,11 @@ impl<'a> FunctionContext<'a> {
 
     pub(crate) fn with<U, F: for<'b> FnOnce(FunctionContext<'b>) -> U>(
         env: Env,
-        info: &'a CallbackInfo<'a>,
+        info: &'cx CallbackInfo<'cx>,
         f: F,
     ) -> U {
         f(FunctionContext {
-            env,
+            cx: Ctx::new(env),
             info,
             arguments: None,
         })
@@ -682,7 +746,7 @@ impl<'a> FunctionContext<'a> {
     }
 
     /// Produces the `i`th argument, or `None` if `i` is greater than or equal to `self.len()`.
-    pub fn argument_opt(&mut self, i: usize) -> Option<Handle<'a, JsValue>> {
+    pub fn argument_opt(&mut self, i: usize) -> Option<Handle<'cx, JsValue>> {
         let argv = if let Some(argv) = self.arguments.as_ref() {
             argv
         } else {
@@ -695,7 +759,7 @@ impl<'a> FunctionContext<'a> {
     }
 
     /// Produces the `i`th argument and casts it to the type `V`, or throws an exception if `i` is greater than or equal to `self.len()` or cannot be cast to `V`.
-    pub fn argument<V: Value>(&mut self, i: usize) -> JsResult<'a, V> {
+    pub fn argument<V: Value>(&mut self, i: usize) -> JsResult<'cx, V> {
         match self.argument_opt(i) {
             Some(v) => v.downcast_or_throw(self),
             None => self.throw_type_error("not enough arguments"),
@@ -706,12 +770,12 @@ impl<'a> FunctionContext<'a> {
     /// Equivalent to calling `cx.this_value().downcast_or_throw(&mut cx)`.
     ///
     /// Throws an exception if the value is a different type.
-    pub fn this<T: Value>(&mut self) -> JsResult<'a, T> {
+    pub fn this<T: Value>(&mut self) -> JsResult<'cx, T> {
         self.this_value().downcast_or_throw(self)
     }
 
     /// Produces a handle to the function's [`this`-binding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#function_context).
-    pub fn this_value(&mut self) -> Handle<'a, JsValue> {
+    pub fn this_value(&mut self) -> Handle<'cx, JsValue> {
         JsValue::new_internal(self.info.this(self))
     }
 
@@ -731,7 +795,7 @@ impl<'a> FunctionContext<'a> {
     /// ```
     pub fn args<T>(&mut self) -> NeonResult<T>
     where
-        T: FromArgs<'a>,
+        T: FromArgs<'cx>,
     {
         T::from_args(self)
     }
@@ -755,104 +819,16 @@ impl<'a> FunctionContext<'a> {
     /// ```
     pub fn args_opt<T>(&mut self) -> NeonResult<Option<T>>
     where
-        T: FromArgs<'a>,
+        T: FromArgs<'cx>,
     {
         T::from_args_opt(self)
     }
 
-    pub(crate) fn argv<const N: usize>(&mut self) -> [Handle<'a, JsValue>; N] {
+    pub(crate) fn argv<const N: usize>(&mut self) -> [Handle<'cx, JsValue>; N] {
         self.info.argv_exact(self)
     }
 }
 
-impl<'a> ContextInternal<'a> for FunctionContext<'a> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
+impl<'cx> ContextInternal<'cx> for FunctionContext<'cx> {}
 
-impl<'a> Context<'a> for FunctionContext<'a> {}
-
-/// An execution context of a task completion callback.
-pub struct TaskContext<'a> {
-    env: Env,
-    _phantom_inner: PhantomData<&'a ()>,
-}
-
-impl<'a> TaskContext<'a> {
-    pub(crate) fn with_context<T, F: for<'b> FnOnce(TaskContext<'b>) -> T>(env: Env, f: F) -> T {
-        f(Self {
-            env,
-            _phantom_inner: PhantomData,
-        })
-    }
-}
-
-impl<'a> ContextInternal<'a> for TaskContext<'a> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
-
-impl<'a> Context<'a> for TaskContext<'a> {}
-
-/// A view of the JS engine in the context of a finalize method on garbage collection
-pub(crate) struct FinalizeContext<'a> {
-    env: Env,
-    _phantom_inner: PhantomData<&'a ()>,
-}
-
-impl<'a> FinalizeContext<'a> {
-    pub(crate) fn with<T, F: for<'b> FnOnce(FinalizeContext<'b>) -> T>(env: Env, f: F) -> T {
-        f(Self {
-            env,
-            _phantom_inner: PhantomData,
-        })
-    }
-}
-
-impl<'a> ContextInternal<'a> for FinalizeContext<'a> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
-
-impl<'a> Context<'a> for FinalizeContext<'a> {}
-
-#[cfg(feature = "sys")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sys")))]
-/// An execution context constructed from a raw [`Env`](crate::sys::bindings::Env).
-pub struct SysContext<'cx> {
-    env: Env,
-    _phantom_inner: PhantomData<&'cx ()>,
-}
-
-#[cfg(feature = "sys")]
-impl<'cx> SysContext<'cx> {
-    /// Creates a context from a raw `Env`.
-    ///
-    /// # Safety
-    ///
-    /// Once a `SysContext` has been created, it is unsafe to use
-    /// the `Env`. The handle scope for the `Env` must be valid for
-    /// the lifetime `'cx`.
-    pub unsafe fn from_raw(env: sys::Env) -> Self {
-        Self {
-            env: env.into(),
-            _phantom_inner: PhantomData,
-        }
-    }
-}
-
-#[cfg(feature = "sys")]
-impl<'cx> SysContext<'cx> {}
-
-#[cfg(feature = "sys")]
-impl<'cx> ContextInternal<'cx> for SysContext<'cx> {
-    fn env(&self) -> Env {
-        self.env
-    }
-}
-
-#[cfg(feature = "sys")]
-impl<'cx> Context<'cx> for SysContext<'cx> {}
+impl<'cx> Context<'cx> for FunctionContext<'cx> {}

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -266,8 +266,12 @@ impl<'cx> Cx<'cx> {
 }
 
 impl<'cx> ContextInternal<'cx> for Cx<'cx> {
-    fn env(&self) -> Env {
-        self.env
+    fn cx(&self) -> &Cx<'cx> {
+        self
+    }
+
+    fn cx_mut(&mut self) -> &mut Cx<'cx> {
+        self
     }
 }
 
@@ -664,13 +668,13 @@ impl<'cx> Deref for ModuleContext<'cx> {
     type Target = Cx<'cx>;
 
     fn deref(&self) -> &Self::Target {
-        &self.cx
+        self.cx()
     }
 }
 
 impl<'cx> DerefMut for ModuleContext<'cx> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.cx
+        self.cx_mut()
     }
 }
 
@@ -727,8 +731,12 @@ impl<'cx> ModuleContext<'cx> {
 }
 
 impl<'cx> ContextInternal<'cx> for ModuleContext<'cx> {
-    fn env(&self) -> Env {
-        self.cx.env
+    fn cx(&self) -> &Cx<'cx> {
+        &self.cx
+    }
+
+    fn cx_mut(&mut self) -> &mut Cx<'cx> {
+        &mut self.cx
     }
 }
 
@@ -873,8 +881,12 @@ impl<'cx> FunctionContext<'cx> {
 }
 
 impl<'cx> ContextInternal<'cx> for FunctionContext<'cx> {
-    fn env(&self) -> Env {
-        self.cx.env
+    fn cx(&self) -> &Cx<'cx> {
+        &self.cx
+    }
+
+    fn cx_mut(&mut self) -> &mut Cx<'cx> {
+        &mut self.cx
     }
 }
 

--- a/crates/neon/src/event/channel.rs
+++ b/crates/neon/src/event/channel.rs
@@ -161,7 +161,7 @@ impl Channel {
         let callback = Box::new(move |env| {
             let env = unsafe { mem::transmute(env) };
 
-            // Note: It is sufficient to use `TaskContext`'s `InheritedHandleScope` because
+            // Note: It is sufficient to use `TaskContext` because
             // N-API creates a `HandleScope` before calling the callback.
             TaskContext::with_context(env, move |cx| {
                 // Error can be ignored; it only means the user didn't join

--- a/crates/neon/src/prelude.rs
+++ b/crates/neon/src/prelude.rs
@@ -2,10 +2,7 @@
 
 #[doc(no_inline)]
 pub use crate::{
-    context::{
-        CallKind, ComputeContext, Context, ExecuteContext, FunctionContext, ModuleContext,
-        TaskContext,
-    },
+    context::{CallKind, Context, Cx, FunctionContext, ModuleContext},
     handle::{Handle, Root},
     object::Object,
     result::{JsResult, NeonResult, ResultExt as NeonResultExt},
@@ -17,6 +14,9 @@ pub use crate::{
         JsUint32Array, JsUint8Array, JsUndefined, JsValue, Value,
     },
 };
+
+#[doc(hidden)]
+pub use crate::context::{ComputeContext, ExecuteContext, TaskContext};
 
 #[cfg(feature = "napi-4")]
 #[doc(no_inline)]

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -53,12 +53,12 @@
 //! # #[cfg(feature = "sys")]
 //! # {
 //! # let env = std::ptr::null_mut().cast();
-//! use neon::{context::SysContext, prelude::*, sys::bindings};
+//! use neon::{context::Cx, prelude::*, sys::bindings};
 //!
 //! let cx = unsafe {
 //!     neon::sys::setup(env);
 //!
-//!     SysContext::from_raw(env)
+//!     Cx::from_raw(env)
 //! };
 //!
 //! let raw_string: bindings::Value = cx.string("Hello, World!").to_raw();

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    context::{internal::Env, Context, FinalizeContext},
+    context::{internal::Env, Context, Cx},
     handle::{internal::TransparentNoCopyWrapper, Handle},
     object::Object,
     sys::{external, raw},
@@ -244,7 +244,7 @@ impl<T: Finalize + 'static> JsBox<T> {
             let data = *data.downcast::<U>().unwrap();
             let env = unsafe { std::mem::transmute(env) };
 
-            FinalizeContext::with_context(env, move |mut cx| data.finalize(&mut cx));
+            Cx::with_context(env, move |mut cx| data.finalize(&mut cx));
         }
 
         let v = Box::new(value) as BoxAny;

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -244,7 +244,7 @@ impl<T: Finalize + 'static> JsBox<T> {
             let data = *data.downcast::<U>().unwrap();
             let env = unsafe { std::mem::transmute(env) };
 
-            FinalizeContext::with(env, move |mut cx| data.finalize(&mut cx));
+            FinalizeContext::with_context(env, move |mut cx| data.finalize(&mut cx));
         }
 
         let v = Box::new(value) as BoxAny;


### PR DESCRIPTION
This allows users to take `Cx` as an argument instead of being generic over the `Context` trait. For example, this will allow us to implement `TryIntoJs` for closures.

This is technically a breaking change because several context types have been replaced by type aliases; if a user were implementing a trait over multiple of these types, it would now cause a conflict. In practice, users either didn't do this at all or implemented it generically over the `Context` trait.

We **could** keep the existing types, it just makes it harder to deprecate them in the future. For a Neon 2.0, I would want to eliminate the `Context` trait and *only* make it concrete. The special needs of function and module would become additional arguments.