### PR TITLE
RFC & WIP - Libuv powered futures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pkgs/create-neon/create-neon-manual-test-project
 test/cli/lib
 npm-debug.log
 rls*.log
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsh_libuv"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc181a3a77b87d8e49d24e02fe13d3371906bfcd13820db8cbb400e48d51e8b"
+dependencies = [
+ "bitflags 1.2.1",
+ "libuv-sys2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,7 +83,7 @@ version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 1.2.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -91,10 +101,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "bindgen"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitflags"
@@ -176,6 +206,95 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -298,6 +417,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libuv-sys2"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6125e1a220a5698a154ce76762d2ef8884baf9f77da7ceb8a3bd8c5ce27df343"
+dependencies = [
+ "bindgen 0.68.1",
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linkify"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +503,12 @@ dependencies = [
 name = "neon"
 version = "1.0.0"
 dependencies = [
+ "alsh_libuv",
  "anyhow",
  "aquamarine",
  "doc-comment",
  "easy-cast",
+ "futures",
  "getrandom",
  "libloading 0.8.1",
  "linkify",
@@ -409,7 +541,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d252ccdd7b72dd5e92ab65471d6a26ba47375139a6071ead3dbf191f60de9903"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
 ]
 
 [[package]]
@@ -505,6 +637,18 @@ name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -711,6 +855,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -35,6 +35,9 @@ doc-comment = { version = "0.3.3", optional = true }
 send_wrapper = "0.6.0"
 serde = { version = "1.0.197", optional = true }
 serde_json = { version = "1.0.114", optional = true }
+futures = { version = "0.3", optional = true }
+# Fork of libuv bindings for Rust
+libuv = { package = "alsh_libuv", version = "2", features = ["sys"], optional = true }
 
 [dependencies.tokio]
 version = "1.34.0"
@@ -43,7 +46,7 @@ features = ["sync"]
 optional = true
 
 [features]
-default = ["napi-8"]
+default = ["napi-8", "futures"]
 
 # Enable extracting values by serializing to JSON
 serde = ["dep:serde", "dep:serde_json"]
@@ -56,6 +59,8 @@ external-buffers = []
 # Experimental Rust Futures API
 # https://github.com/neon-bindings/rfcs/pull/46
 futures = ["tokio"]
+
+asynch = ["dep:futures", "dep:libuv"]
 
 # Enable low-level system APIs. The `sys` API allows augmenting the Neon API
 # from external crates.

--- a/crates/neon/src/asynch/libuv.rs
+++ b/crates/neon/src/asynch/libuv.rs
@@ -1,0 +1,26 @@
+use std::mem::MaybeUninit;
+use std::rc::Rc;
+
+use crate::context::internal::Env;
+use crate::sys::bindings::get_uv_event_loop;
+use libuv::sys::uv_loop_t;
+use libuv::Loop;
+use once_cell::unsync::OnceCell;
+
+thread_local! {
+    pub static LIB_UV: OnceCell<Rc<Loop>> = OnceCell::new();
+}
+
+/// Gets a reference to Libuv
+pub fn get_lib_uv<'a>(env: &Env) -> Rc<Loop> {
+    LIB_UV.with(move |cell| {
+        cell.get_or_init(move || {
+            let mut result = MaybeUninit::uninit();
+            unsafe { get_uv_event_loop(env.to_raw(), result.as_mut_ptr()) };
+            let ptr = unsafe { *result.as_mut_ptr() };
+            let ptr = ptr as *mut uv_loop_t;
+            Rc::new(unsafe { libuv::r#loop::Loop::from_external(ptr) })
+        })
+        .clone()
+    })
+}

--- a/crates/neon/src/asynch/mod.rs
+++ b/crates/neon/src/asynch/mod.rs
@@ -1,0 +1,6 @@
+//! This module extends Libuv to work as an executor for Rust futures
+pub mod root;
+mod libuv;
+mod runtime;
+
+pub use runtime::*;

--- a/crates/neon/src/asynch/root.rs
+++ b/crates/neon/src/asynch/root.rs
@@ -1,0 +1,76 @@
+/*
+    This is a basic method of persisting JavaScript values so
+    they are given a static lifetime and not collected by GC
+
+    This is needed because not all JsValues can be called with .root()
+    and is probably temporary
+*/
+use std::cell::RefCell;
+
+use crate::context::Context;
+use crate::handle::Handle;
+use crate::object::Object;
+use crate::types::JsObject;
+use crate::types::Value;
+use once_cell::unsync::Lazy;
+
+thread_local! {
+    pub static THREAD_LOCAL_COUNT: Lazy<RefCell<usize>> = Lazy::new(|| RefCell::new(0));
+    pub static GLOBAL_KEY: Lazy<String> = Lazy::new(|| {
+        let mut lower = [0; std::mem::size_of::<u16>()];
+        getrandom::getrandom(&mut lower).expect("Unable to generate number");
+        let lower = u16::from_ne_bytes(lower);
+        format!("__neon_root_cache_{}", lower)
+    });
+}
+
+fn ref_count_inc() -> usize {
+    THREAD_LOCAL_COUNT.with(|c| {
+        let mut c = c.borrow_mut();
+        let current = (*c).clone();
+        *c += 1;
+        current
+    })
+}
+
+pub fn root<'a>(cx: &mut impl Context<'a>) -> Handle<'a, JsObject> {
+    let global = cx.global_object();
+    let key = GLOBAL_KEY.with(|k| cx.string(&*k.as_str()));
+    match global.get_opt(cx, key).unwrap() {
+        Some(obj) => obj,
+        None => {
+            let init = cx.empty_object();
+            global.set(cx, key, init).unwrap();
+            global.get_opt(cx, key).unwrap().unwrap()
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RootGlobal {
+    inner: String,
+}
+
+impl RootGlobal {
+    pub fn new<'a, V: Value>(cx: &mut impl Context<'a>, value: Handle<V>) -> Self {
+        let index = ref_count_inc();
+        let key_str = format!("{}", index);
+        let key = cx.string(&key_str);
+        let cache = root(cx);
+        cache.set(cx, key, value).unwrap();
+        Self { inner: key_str }
+    }
+
+    pub fn into_inner<'a, V: Value>(&self, cx: &mut impl Context<'a>) -> Handle<'a, V> {
+        let key = cx.string(&self.inner);
+        let cache = root(cx);
+        cache.get(cx, key).unwrap()
+    }
+
+    pub fn remove<'a>(&self, cx: &mut impl Context<'a>) -> bool {
+        let key = cx.string(&self.inner);
+        let val = cx.undefined();
+        let cache = root(cx);
+        cache.set(cx, key, val).unwrap()
+    }
+}

--- a/crates/neon/src/asynch/runtime.rs
+++ b/crates/neon/src/asynch/runtime.rs
@@ -1,0 +1,64 @@
+use std::cell::RefCell;
+use std::future::Future;
+
+use crate::context::internal::Env;
+use futures::task::LocalSpawnExt;
+use futures::executor::LocalSpawner;
+use futures::executor::LocalPool;
+use once_cell::unsync::Lazy;
+
+use super::libuv::get_lib_uv;
+
+thread_local! {
+    static LOCAL_POOL: Lazy<RefCell<LocalPool>> = Lazy::new(|| RefCell::new(LocalPool::new()));
+    static SPAWNER: Lazy<LocalSpawner> = Lazy::new(|| LOCAL_POOL.with(|ex| ex.borrow().spawner()) );
+    static TASK_COUNT: Lazy<RefCell<usize>> = Lazy::new(|| Default::default() );
+}
+
+pub fn spawn_async_local(env: &Env, future: impl Future<Output = ()> + 'static) {
+    SPAWNER.with(|ls| {
+        ls.spawn_local(async {
+            future.await;
+            task_count_dec();
+        })
+        .unwrap();
+    });
+
+    // Delegate non-blocking polling of futures to libuv
+    if task_count_inc() != 0 {
+        return;
+    }
+
+    // Idle handle refers to a libuv task that runs while "idling".
+    // This is not an idle state, rather an analogy to a car engine
+    let uv = get_lib_uv(env);
+    let mut task = uv.idle().unwrap();
+
+    // The idle task will conduct a non-blocking poll of all local futures
+    // and continue on pending futures allowing the poll to be non-blocking.
+    // This repeats until no more futures are pending in the local set.
+    task.start(move |mut task: libuv::IdleHandle| {
+        if task_count() != 0 {
+            LOCAL_POOL.with(|lp| lp.borrow_mut().run_until_stalled());
+        } else {
+            task.stop().unwrap();
+        }
+    })
+    .unwrap();
+}
+
+fn task_count() -> usize {
+    TASK_COUNT.with(|c| *c.borrow_mut())
+}
+
+fn task_count_inc() -> usize {
+    let current = task_count();
+    TASK_COUNT.with(|c| *c.borrow_mut() += 1);
+    current
+}
+
+fn task_count_dec() -> usize {
+    let current = task_count();
+    TASK_COUNT.with(|c| *c.borrow_mut() -= 1);
+    current
+}

--- a/crates/neon/src/lib.rs
+++ b/crates/neon/src/lib.rs
@@ -78,6 +78,8 @@
 //! [supported]: https://github.com/neon-bindings/neon#platform-support
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "asynch")]
+mod asynch;
 pub mod context;
 pub mod event;
 pub mod handle;

--- a/crates/neon/src/sys/bindings/functions.rs
+++ b/crates/neon/src/sys/bindings/functions.rs
@@ -266,6 +266,11 @@ mod napi4 {
     generate!(
         #[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
         extern "C" {
+            fn get_uv_event_loop(
+                env: Env,
+                uv_loop: *mut UvEventLoop,
+            );
+
             fn create_threadsafe_function(
                 env: Env,
                 func: Value,

--- a/crates/neon/src/sys/bindings/mod.rs
+++ b/crates/neon/src/sys/bindings/mod.rs
@@ -42,7 +42,7 @@ macro_rules! napi_name {
 /// ```ignore
 /// extern "C" {
 ///     fn get_undefined(env: Env, result: *mut Value) -> Status;
-///     /* Additional functions may be included */  
+///     /* Additional functions may be included */
 /// }
 /// ```
 ///
@@ -177,3 +177,4 @@ pub use self::{functions::*, types::*};
 
 mod functions;
 mod types;
+mod libuv;

--- a/crates/neon/src/sys/bindings/types.rs
+++ b/crates/neon/src/sys/bindings/types.rs
@@ -70,6 +70,19 @@ pub type Ref = *mut Ref__;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[doc(hidden)]
+pub struct UvEventLoop__ {
+    _unused: [u8; 0],
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "napi-4")))]
+#[cfg(feature = "napi-4")]
+/// [`napi_threadsafe_function`](https://nodejs.org/api/n-api.html#napi_threadsafe_function)
+pub type UvEventLoop = *mut UvEventLoop__;
+
+#[cfg(feature = "napi-4")]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct ThreadsafeFunction__ {
     _unused: [u8; 0],
 }


### PR DESCRIPTION
This PR is a WIP that introduces Rust future execution managed by libuv with a working implementation.
This allows for Rust code to run concurrently on the main thread without blocking the JavaScript thread.

It's still a work in progress, requesting comments for ways I can improve the implementation if it's a good candidate for contribution.

It might be a bit confusing for consumers given the API might conflict with the tokio runtime - so there's probably a discussion to be had there.

~I only actually changed 5 files, the other changes are vendoring in `libuv-rs` to reuse their C bindings. In the future the relevant bindings can be brought over rather than vendoring in the whole crate.~ Published my fork of libuv for Rust to reduce the diff.


## Examples

### Async Function Declaration

#### Simple Async

Declare an async function that returns a promise and does not block the main thread.

```javascript
import napi from './napi.node'
napi.foo().then(() => console.log('Hi'))
```

```rust
async fn foo<'a>(mut cx: AsyncFunctionContext) -> JsResult<'a, JsUndefined> {
  println!("Rust started");
  task::sleep(Duration::from_secs(1)).await;
  println!("Rust sleeped");
  Ok(cx.undefined())
}

#[neon::main]
fn main(mut cx: ModuleContext) -> NeonResult<()> {
  cx.export_function_async("foo", foo)?;
  Ok(())
}
```

#### Async MPSC Channel

This also enables the use of async channels on the main thread

```rust
async fn foo<'a>(mut cx: AsyncFunctionContext) -> JsResult<'a, JsUndefined> {
  let callback: Handle<JsFunction> = cx.argument(0)?;
  let (tx, rx) = unbounded::<u32>();

  thread::spawn(move || {
    thread::sleep(Duration::from_secs(1));
    tx.send_blocking(42).unwrap();
  });

  rx.recv().await.unwrap();
  callback.call_with(&cx).exec(&mut cx)?;
  Ok(cx.undefined())
}
```

## Function Async Closure

You can spawn an async future within a closure using `cx.execute_async(|| async {})`.

```rust
fn foo(mut cx: FunctionContext) -> JsResult<JsUndefined> {
  let callback = cx.argument::<JsFunction>(0)?.root(&mut cx);

  cx.execute_async(|mut cx| async move {
    let callback = callback.into_inner(&mut cx);
    task::sleep(Duration::from_secs(1)).await;
    callback.call_with(&cx).exec(&mut cx).unwrap();
  });
  
  Ok(cx.undefined())
}

#[neon::main]
fn main(mut cx: ModuleContext) -> NeonResult<()> {
  cx.export_function("foo", foo)?;
  Ok(())
}
```

## How does this work? Tokio?

This works by essentially bolting a Rust futures executor onto Nodejs's libuv. It uses libuv hooks to trigger the Rust future executor. The futures executor runs until Rust futures are pending then yields back to nodejs's event loop.

This means that the Rust event loop will never block Nodejs's event loop and vice versa, yet both can drive their tasks forward.

I'm using the lightweight local thread executor from the [futures](https://docs.rs/futures-executor/latest/futures_executor/struct.LocalPool.html) crate.

For channels, sleep, and other common async tasks, utilities from [async-std](https://docs.rs/async-std/latest/async_std/) can be used.

Tokio is not suitable for this use case as it's designed to be the only executor running and cannot be driven (or at least I cannot figure out how to drive it) from an external executor.

TODO:
[] Tests
[] Error handing
[] Documentation
[] Missing functionality