### PR TITLE
feat(neon): Add tokio async runtime support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
 # Neon defines mutually exclusive feature flags which prevents using `cargo clippy --all-features`
 # The following aliases simplify linting the entire workspace
-neon-check = " check  --all --all-targets --features napi-experimental,futures,external-buffers,serde"
-neon-clippy = "clippy --all --all-targets --features napi-experimental,futures,external-buffers,serde -- -A clippy::missing_safety_doc"
-neon-test = "  test   --all               --features=doc-dependencies,doc-comment,napi-experimental,futures,external-buffers,serde"
-neon-doc = "   rustdoc -p neon            --features=doc-dependencies,napi-experimental,futures,external-buffers,sys,serde -- --cfg docsrs"
+neon-check = " check  --all --all-targets --features napi-experimental,external-buffers,serde,tokio"
+neon-clippy = "clippy --all --all-targets --features napi-experimental,external-buffers,serde,tokio -- -A clippy::missing_safety_doc"
+neon-test = "  test   --all               --features=doc-dependencies,doc-comment,napi-experimental,external-buffers,serde,tokio"
+neon-doc = "   rustdoc -p neon            --features=doc-dependencies,napi-experimental,external-buffers,sys,serde,tokio -- --cfg docsrs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "doc-comment",
  "easy-cast",
  "getrandom",
+ "itertools",
  "libloading 0.8.1",
  "linkify",
  "linkme",

--- a/crates/neon-macros/src/export/mod.rs
+++ b/crates/neon-macros/src/export/mod.rs
@@ -13,7 +13,8 @@ pub(crate) fn export(
     match item {
         // Export a function
         syn::Item::Fn(item) => {
-            let meta = syn::parse_macro_input!(attr with function::meta::Parser);
+            let parser = function::meta::Parser::new(item);
+            let (item, meta) = syn::parse_macro_input!(attr with parser);
 
             function::export(meta, item)
         }

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["neon.jpg", "doc/**/*"]
 edition = "2021"
 
 [dev-dependencies]
+itertools = "0.10.5"
 semver = "1.0.20"
 psd = "0.3.4"        # used for a doc example
 anyhow = "1.0.75"    # used for a doc example

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -56,11 +56,16 @@ external-buffers = []
 
 # Experimental Rust Futures API
 # https://github.com/neon-bindings/rfcs/pull/46
-futures = ["tokio"]
+futures = ["dep:tokio"]
 
 # Enable low-level system APIs. The `sys` API allows augmenting the Neon API
 # from external crates.
 sys = []
+
+# Enable async runtime
+tokio = ["tokio-rt-multi-thread"] # Shorter alias
+tokio-rt = ["futures", "tokio/rt"]
+tokio-rt-multi-thread = ["tokio-rt", "tokio/rt-multi-thread"]
 
 # Default N-API version. Prefer to select a minimum required version.
 # DEPRECATED: This is an alias that should be removed

--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -55,6 +55,8 @@ pub trait ContextInternal<'cx>: Sized {
 }
 
 fn default_main(mut cx: ModuleContext) -> NeonResult<()> {
+    #[cfg(feature = "tokio-rt-multi-thread")]
+    crate::executor::tokio::init(&mut cx)?;
     crate::registered().export(&mut cx)
 }
 

--- a/crates/neon/src/executor/mod.rs
+++ b/crates/neon/src/executor/mod.rs
@@ -1,0 +1,59 @@
+use std::{future::Future, pin::Pin};
+
+use crate::{context::Cx, thread::LocalKey};
+
+#[cfg(feature = "tokio-rt")]
+pub(crate) mod tokio;
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub(crate) static RUNTIME: LocalKey<Box<dyn Runtime>> = LocalKey::new();
+
+pub trait Runtime: Send + Sync + 'static {
+    fn spawn(&self, fut: BoxFuture);
+}
+
+/// Register a [`Future`] executor runtime globally to the addon.
+///
+/// Returns `Ok(())` if a global executor has not been set and `Err(runtime)` if it has.
+///
+/// If the `tokio` feature flag is enabled and the addon does not provide a
+/// [`#[neon::main]`](crate::main) function, a multithreaded tokio runtime will be
+/// automatically registered.
+///
+/// **Note**: Each instance of the addon will have its own runtime. It is recommended
+/// to initialize the async runtime once in a process global and share it across instances.
+///
+/// ```
+/// # #[cfg(feature = "tokio-rt-multi-thread")]
+/// # fn example() {
+/// # use neon::prelude::*;
+/// use once_cell::sync::OnceCell;
+/// use tokio::runtime::Runtime;
+///
+/// static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+///
+/// #[neon::main]
+/// fn main(mut cx: ModuleContext) -> NeonResult<()> {
+///     let runtime = RUNTIME
+///         .get_or_try_init(Runtime::new)
+///         .or_else(|err| cx.throw_error(err.to_string()))?;
+///
+///     let _ = neon::set_global_executor(&mut cx, runtime);
+///
+///     Ok(())
+/// }
+/// # }
+/// ```
+pub fn set_global_executor<R>(cx: &mut Cx, runtime: R) -> Result<(), R>
+where
+    R: Runtime,
+{
+    if RUNTIME.get(cx).is_some() {
+        return Err(runtime);
+    }
+
+    RUNTIME.get_or_init(cx, || Box::new(runtime));
+
+    Ok(())
+}

--- a/crates/neon/src/executor/tokio.rs
+++ b/crates/neon/src/executor/tokio.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use super::{BoxFuture, Runtime};
+
+impl Runtime for tokio::runtime::Runtime {
+    fn spawn(&self, fut: BoxFuture) {
+        spawn(self.handle(), fut);
+    }
+}
+
+impl Runtime for Arc<tokio::runtime::Runtime> {
+    fn spawn(&self, fut: BoxFuture) {
+        spawn(self.handle(), fut);
+    }
+}
+
+impl Runtime for &'static tokio::runtime::Runtime {
+    fn spawn(&self, fut: BoxFuture) {
+        spawn(self.handle(), fut);
+    }
+}
+
+impl Runtime for tokio::runtime::Handle {
+    fn spawn(&self, fut: BoxFuture) {
+        spawn(self, fut);
+    }
+}
+
+impl Runtime for &'static tokio::runtime::Handle {
+    fn spawn(&self, fut: BoxFuture) {
+        spawn(self, fut);
+    }
+}
+
+fn spawn(handle: &tokio::runtime::Handle, fut: BoxFuture) {
+    #[allow(clippy::let_underscore_future)]
+    let _ = handle.spawn(fut);
+}
+
+#[cfg(feature = "tokio-rt-multi-thread")]
+pub(crate) fn init(cx: &mut crate::context::ModuleContext) -> crate::result::NeonResult<()> {
+    use once_cell::sync::OnceCell;
+    use tokio::runtime::{Builder, Runtime};
+
+    use crate::context::Context;
+
+    static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+    super::RUNTIME.get_or_try_init(cx, |cx| {
+        let runtime = RUNTIME
+            .get_or_try_init(|| {
+                #[cfg(feature = "tokio-rt-multi-thread")]
+                let mut builder = Builder::new_multi_thread();
+
+                #[cfg(not(feature = "tokio-rt-multi-thread"))]
+                let mut builder = Builder::new_current_thread();
+
+                builder.enable_all().build()
+            })
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(Box::new(runtime))
+    })?;
+
+    Ok(())
+}

--- a/crates/neon/src/lib.rs
+++ b/crates/neon/src/lib.rs
@@ -102,6 +102,9 @@ mod types_impl;
 #[cfg_attr(docsrs, doc(cfg(feature = "sys")))]
 pub mod sys;
 
+#[cfg(all(feature = "napi-6", feature = "futures"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "napi-6", feature = "futures"))))]
+pub use executor::set_global_executor;
 pub use types_docs::exports as types;
 
 #[doc(hidden)]
@@ -114,12 +117,15 @@ use crate::{context::ModuleContext, handle::Handle, result::NeonResult, types::J
 #[cfg(feature = "napi-6")]
 mod lifecycle;
 
+#[cfg(all(feature = "napi-6", feature = "futures"))]
+mod executor;
+
 #[cfg(feature = "napi-8")]
 static MODULE_TAG: once_cell::sync::Lazy<crate::sys::TypeTag> = once_cell::sync::Lazy::new(|| {
     let mut lower = [0; std::mem::size_of::<u64>()];
 
     // Generating a random module tag at runtime allows Neon builds to be reproducible. A few
-    //  alternativeswere considered:
+    //  alternatives considered:
     // * Generating a random value at build time; this reduces runtime dependencies but, breaks
     //   reproducible builds
     // * A static random value; this solves the previous issues, but does not protect against ABI

--- a/crates/neon/src/lib.rs
+++ b/crates/neon/src/lib.rs
@@ -149,18 +149,21 @@ pub struct Exports(());
 impl Exports {
     /// Export all values exported with [`neon::export`](export)
     ///
-    /// ```ignore
+    /// ```
+    /// # fn main() {
     /// # use neon::prelude::*;
     /// #[neon::main]
     /// fn main(mut cx: ModuleContext) -> NeonResult<()> {
     ///     neon::registered().export(&mut cx)?;
     ///     Ok(())
     /// }
+    /// # }
     /// ```
     ///
     /// For more control, iterate over exports.
     ///
-    /// ```ignore
+    /// ```
+    /// # fn main() {
     /// # use neon::prelude::*;
     /// #[neon::main]
     /// fn main(mut cx: ModuleContext) -> NeonResult<()> {
@@ -172,6 +175,7 @@ impl Exports {
     ///
     ///     Ok(())
     /// }
+    /// # }
     /// ```
     pub fn export(self, cx: &mut ModuleContext) -> NeonResult<()> {
         for create in self {
@@ -202,33 +206,18 @@ pub fn registered() -> Exports {
 }
 
 #[test]
-#[ignore]
 fn feature_matrix() {
     use std::{env, process::Command};
 
-    const EXTERNAL_BUFFERS: &str = "external-buffers";
-    const FUTURES: &str = "futures";
-    const SERDE: &str = "serde";
     const NODE_API_VERSIONS: &[&str] = &[
         "napi-1", "napi-2", "napi-3", "napi-4", "napi-5", "napi-6", "napi-7", "napi-8",
     ];
 
-    // If the number of features in Neon grows, we can use `itertools` to generate permutations.
-    // https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.permutations
-    const FEATURES: &[&[&str]] = &[
-        &[],
-        &[EXTERNAL_BUFFERS],
-        &[FUTURES],
-        &[SERDE],
-        &[EXTERNAL_BUFFERS, FUTURES],
-        &[EXTERNAL_BUFFERS, SERDE],
-        &[FUTURES, SERDE],
-        &[EXTERNAL_BUFFERS, FUTURES, SERDE],
-    ];
+    const FEATURES: &[&str] = &["external-buffers", "futures", "serde", "tokio", "tokio-rt"];
 
     let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
 
-    for features in FEATURES {
+    for features in itertools::Itertools::powerset(FEATURES.iter()) {
         for version in NODE_API_VERSIONS.iter().map(|f| f.to_string()) {
             let features = features.iter().fold(version, |f, s| f + "," + s);
             let status = Command::new(&cargo)

--- a/crates/neon/src/macro_internal/futures.rs
+++ b/crates/neon/src/macro_internal/futures.rs
@@ -1,0 +1,29 @@
+use std::future::Future;
+
+use crate::{
+    context::{Context, Cx, TaskContext},
+    result::JsResult,
+    types::JsValue,
+};
+
+pub fn spawn<'cx, F, S>(cx: &mut Cx<'cx>, fut: F, settle: S) -> JsResult<'cx, JsValue>
+where
+    F: Future + Send + 'static,
+    F::Output: Send,
+    S: FnOnce(TaskContext, F::Output) -> JsResult<JsValue> + Send + 'static,
+{
+    let rt = match crate::executor::RUNTIME.get(cx) {
+        Some(rt) => rt,
+        None => return cx.throw_error("must initialize with neon::set_global_executor"),
+    };
+
+    let ch = cx.channel();
+    let (d, promise) = cx.promise();
+
+    rt.spawn(Box::pin(async move {
+        let res = fut.await;
+        let _ = d.try_settle_with(&ch, move |cx| settle(cx, res));
+    }));
+
+    Ok(promise.upcast())
+}

--- a/test/napi/Cargo.toml
+++ b/test/napi/Cargo.toml
@@ -17,4 +17,4 @@ tokio = { version = "1.34.0", features = ["rt-multi-thread"] }
 [dependencies.neon]
 version = "1.0.0"
 path = "../../crates/neon"
-features = ["futures", "napi-experimental", "external-buffers", "serde"]
+features = ["futures", "napi-experimental", "external-buffers", "serde", "tokio"]

--- a/test/napi/lib/futures.js
+++ b/test/napi/lib/futures.js
@@ -55,4 +55,63 @@ describe("Futures", () => {
       }, /exception/i);
     });
   });
+
+  describe("Exported Async Functions", () => {
+    it("should be able to call `async fn`", async () => {
+      assert.strictEqual(await addon.async_fn_add(1, 2), 3);
+    });
+
+    it("should be able to call fn with async block", async () => {
+      assert.strictEqual(await addon.async_add(1, 2), 3);
+    });
+
+    it("should be able to call fallible `async fn`", async () => {
+      assert.strictEqual(await addon.async_fn_div(10, 2), 5);
+
+      await assertRejects(() => addon.async_fn_div(10, 0), /Divide by zero/);
+    });
+
+    it("should be able to call fallible `async fn`", async () => {
+      assert.strictEqual(await addon.async_fn_div(10, 2), 5);
+
+      await assertRejects(() => addon.async_fn_div(10, 0), /Divide by zero/);
+    });
+
+    it("should be able to call fallible fn with async block", async () => {
+      assert.strictEqual(await addon.async_div(10, 2), 5);
+
+      await assertRejects(() => addon.async_div(10, 0), /Divide by zero/);
+    });
+
+    it("should be able to code on the event loop before and after async", async () => {
+      let startCalled = false;
+      let endCalled = false;
+      const eventHandler = (event) => {
+        switch (event) {
+          case "start":
+            startCalled = true;
+            break;
+          case "end":
+            endCalled = true;
+            break;
+        }
+      };
+
+      process.on("async_with_events", eventHandler);
+
+      try {
+        let res = await addon.async_with_events([
+          [1, 2],
+          [3, 4],
+          [5, 6],
+        ]);
+
+        assert.deepStrictEqual([...res], [2, 12, 30]);
+        assert.ok(startCalled, "Did not emit start event");
+        assert.ok(endCalled, "Did not emit end event");
+      } finally {
+        process.off("async_with_events", eventHandler);
+      }
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support for exporting `async fn` and future return `fn` in `#[neon::export]`.

```rust
#[neon::export]
async fn example1(a: f64, b: f64) -> f64 {
    a + b
}

#[neon::export(async)]
fn example2(a: f64, b: f64) -> impl Future<Output = f64> {
    async move {
        a + b
    }
}
```

It is intentionally very conservative in semver guarantees. It requires registering a global future executor. The executor must implement the _private_ `Runtime` trait. Currently, only a `tokio` implementation is included. Additionally, `Future` trait bounds are strict enough to allow for multi-threaded executors.

As we see demand, we can add support for additional executors (e.g., `async-std`) and possibly even single threaded executors (`#[neon::export(?Sync)]`) or a built-in `libuv` driven executor. The eventual goal is to make the `Runtime` trait public so that users can bring their own executor.

* [x] ~~Depends on https://github.com/neon-bindings/neon/pull/1057~~ (Merged)