### PR TITLE
feat(neon): `JsFunction::bind()` and `Object::prop()`

### DIFF
--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -113,9 +113,9 @@
 //!     while !done {
 //!         done = cx.execute_scoped(|mut cx| {                   // temporary scope
 //!             let obj: Handle<JsObject> = next                  // temporary object
-//!                 .call_with(&cx)
-//!                 .this(iterator)
-//!                 .apply(&mut cx)?;
+//!                 .bind(&mut cx)
+//!                 .this(iterator)?
+//!                 .call()?;
 //!             numbers.push(obj.prop(&mut cx, "value").get()?);  // temporary number
 //!             obj.prop(&mut cx, "done").get()                   // temporary boolean
 //!         })?;

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -107,7 +107,7 @@
 //! # fn iterate(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 //!     let iterator = cx.argument::<JsObject>(0)?;         // iterator object
 //!     let next: Handle<JsFunction> =                      // iterator's `next` method
-//!         iterator.get(&mut cx, "next")?;
+//!         iterator.prop(&mut cx, "next").get()?;
 //!     let mut numbers = vec![];                           // results vector
 //!     let mut done = false;                               // loop controller
 //!
@@ -117,12 +117,8 @@
 //!                 .call_with(&cx)
 //!                 .this(iterator)
 //!                 .apply(&mut cx)?;
-//!             let number: Handle<JsNumber> =                    // temporary number
-//!                 obj.get(&mut cx, "value")?;
-//!             numbers.push(number.value(&mut cx));
-//!             let done: Handle<JsBoolean> =                     // temporary boolean
-//!                 obj.get(&mut cx, "done")?;
-//!             Ok(done.value(&mut cx))
+//!             numbers.push(obj.prop(&mut cx, "value").get()?);  // temporary number
+//!             obj.prop(&mut cx, "done").get()                   // temporary boolean
 //!         })?;
 //!     }
 //! #   Ok(cx.undefined())
@@ -505,7 +501,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// #     let v: Handle<JsFunction> =
     /// {
     ///     let global = cx.global_object();
-    ///     global.get(cx, name)
+    ///     global.prop(cx, name).get()
     /// }
     /// #     ?;
     /// #     Ok(v)

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -45,10 +45,9 @@
 //! # use neon::prelude::*;
 //! fn log(cx: &mut Cx, msg: &str) -> NeonResult<()> {
 //!     cx.global::<JsObject>("console")?
-//!         .call_method_with(cx, "log")?
-//!         .arg(cx.string(msg))
-//!         .exec(cx)?;
-//!
+//!         .method(cx, "log")?
+//!         .arg(msg)?
+//!         .exec()?;
 //!     Ok(())
 //! }
 //!

--- a/crates/neon/src/event/channel.rs
+++ b/crates/neon/src/event/channel.rs
@@ -75,13 +75,12 @@ type Callback = Box<dyn FnOnce(sys::Env) + Send + 'static>;
 ///         // loop. This _will_ block the event loop while executing.
 ///         channel.send(move |mut cx| {
 ///             let callback = callback.into_inner(&mut cx);
-///             let this = cx.undefined();
-///             let args = vec![
-///                 cx.null().upcast::<JsValue>(),
-///                 cx.number(result).upcast(),
-///             ];
+///             let null = cx.null();
 ///
-///             callback.call(&mut cx, this, args)?;
+///             callback
+///                 .bind(&mut cx)
+///                 .args((null, result))?
+///                 .exec()?;
 ///
 ///             Ok(())
 ///         });

--- a/crates/neon/src/event/channel.rs
+++ b/crates/neon/src/event/channel.rs
@@ -75,11 +75,10 @@ type Callback = Box<dyn FnOnce(sys::Env) + Send + 'static>;
 ///         // loop. This _will_ block the event loop while executing.
 ///         channel.send(move |mut cx| {
 ///             let callback = callback.into_inner(&mut cx);
-///             let null = cx.null();
 ///
 ///             callback
 ///                 .bind(&mut cx)
-///                 .args((null, result))?
+///                 .args(((), result))?
 ///                 .exec()?;
 ///
 ///             Ok(())

--- a/crates/neon/src/event/mod.rs
+++ b/crates/neon/src/event/mod.rs
@@ -86,17 +86,17 @@
 //!                     .prop(&mut cx, "width").set(psd.width())?
 //!                     .prop("height").set(psd.height())?
 //!                     .this();
-//!                 let null = cx.null();
 //!
 //!                 callback
 //!                     .bind(&mut cx)
-//!                     .args((null, obj))?
+//!                     .args(((), obj))?
 //!                     .exec()?;
 //!             }
 //!             Err(err) => {
+//!                 use neon::types::extract::Error;
 //!                 callback
 //!                     .bind(&mut cx)
-//!                     .arg(err.to_string())?
+//!                     .arg(Error::from(err))?
 //!                     .exec()?;
 //!             }
 //!         }

--- a/crates/neon/src/event/mod.rs
+++ b/crates/neon/src/event/mod.rs
@@ -78,27 +78,28 @@
 //!     // loop. This _will_ block the event loop while executing.
 //!     channel.send(move |mut cx| {
 //!         let callback = callback.into_inner(&mut cx);
-//!         let this = cx.undefined();
-//!         let args = match result {
+//!
+//!         match result {
 //!             Ok(psd) => {
 //!                 // Extract data from the parsed file.
-//!                 let obj = cx.empty_object();
-//!                 obj.prop(&mut cx, "width").set(psd.width())?;
-//!                 obj.prop(&mut cx, "height").set(psd.height())?;
-//!                 vec![
-//!                     cx.null().upcast::<JsValue>(),
-//!                     obj.upcast(),
-//!                 ]
+//!                 let obj = cx.empty_object()
+//!                     .prop(&mut cx, "width").set(psd.width())?
+//!                     .prop("height").set(psd.height())?
+//!                     .this();
+//!                 let null = cx.null();
+//!
+//!                 callback
+//!                     .bind(&mut cx)
+//!                     .args((null, obj))?
+//!                     .exec()?;
 //!             }
 //!             Err(err) => {
-//!                 let err = cx.string(err.to_string());
-//!                 vec![
-//!                     err.upcast::<JsValue>(),
-//!                 ]
+//!                 callback
+//!                     .bind(&mut cx)
+//!                     .arg(err.to_string())?
+//!                     .exec()?;
 //!             }
-//!         };
-//!
-//!         callback.call(&mut cx, this, args)?;
+//!         }
 //!
 //!         Ok(())
 //!     });

--- a/crates/neon/src/event/mod.rs
+++ b/crates/neon/src/event/mod.rs
@@ -82,13 +82,9 @@
 //!         let args = match result {
 //!             Ok(psd) => {
 //!                 // Extract data from the parsed file.
-//!                 let width = cx.number(psd.width());
-//!                 let height = cx.number(psd.height());
-//!
-//!                 // Save the data in a result object.
 //!                 let obj = cx.empty_object();
-//!                 obj.set(&mut cx, "width", width)?;
-//!                 obj.set(&mut cx, "height", height)?;
+//!                 obj.prop(&mut cx, "width").set(psd.width())?;
+//!                 obj.prop(&mut cx, "height").set(psd.height())?;
 //!                 vec![
 //!                     cx.null().upcast::<JsValue>(),
 //!                     obj.upcast(),

--- a/crates/neon/src/handle/mod.rs
+++ b/crates/neon/src/handle/mod.rs
@@ -27,22 +27,18 @@
 //!
 //! ## Example
 //!
-//! This Neon function takes an object as its argument, extracts two properties,
-//! `width` and `height`, and multiplies them together as numbers. Each JavaScript
-//! value in the calculation is stored locally in a `Handle`.
+//! This Neon function takes an object as its argument, extracts an object property,
+//! `homeAddress`, and then extracts a string property, `zipCode` from that second
+//! object. Each JavaScript value in the calculation is stored locally in a `Handle`.
 //!
 //! ```
 //! # use neon::prelude::*;
-//! fn area(mut cx: FunctionContext) -> JsResult<JsNumber> {
-//!     let rect: Handle<JsObject> = cx.argument(0)?;
-//!
-//!     let width: Handle<JsNumber> = rect.get(&mut cx, "width")?;
-//!     let w: f64 = width.value(&mut cx);
-//!
-//!     let height: Handle<JsNumber> = rect.get(&mut cx, "height")?;
-//!     let h: f64 = height.value(&mut cx);
-//!
-//!     Ok(cx.number(w * h))
+//! # use neon::export;
+//! #[export]
+//! fn customer_zip_code<'cx>(cx: &mut FunctionContext<'cx>, customer: Handle<'cx, JsObject>) -> JsResult<'cx, JsString> {
+//!     let home_address: Handle<JsObject> = customer.prop(cx, "homeAddress").get()?;
+//!     let zip_code: Handle<JsString> = home_address.prop(cx, "zipCode").get()?;
+//!     Ok(zip_code)
 //! }
 //! ```
 

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -217,6 +217,14 @@ where
 /// The trait of all object types.
 pub trait Object: Value {
     /// Create a [`PropOptions`] for accessing a property.
+    ///
+    /// # Safety
+    ///
+    /// Because `cx` is a mutable reference, Neon guarantees it
+    /// is the context with the shortest possible lifetime, so
+    /// replacing the lifetime `'self` with `'cx` cannot extend
+    /// the lifetime of the property beyond the lifetime of the
+    /// object.
     fn prop<'a, 'cx: 'a, K: PropertyKey>(
         &self,
         cx: &'a mut Cx<'cx>,

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -297,7 +297,7 @@ pub trait Object: Value {
         })
     }
 
-    #[doc(hidden)]
+    #[deprecated(since = "TBD", note = "use `Object::prop()` instead")]
     fn get_opt<'a, V: Value, C: Context<'a>, K: PropertyKey>(
         &self,
         cx: &mut C,
@@ -312,7 +312,7 @@ pub trait Object: Value {
         v.downcast_or_throw(cx).map(Some)
     }
 
-    #[doc(hidden)]
+    #[deprecated(since = "TBD", note = "use `Object::prop()` instead")]
     fn get_value<'a, C: Context<'a>, K: PropertyKey>(
         &self,
         cx: &mut C,
@@ -323,7 +323,7 @@ pub trait Object: Value {
         })
     }
 
-    #[doc(hidden)]
+    #[deprecated(since = "TBD", note = "use `Object::prop()` instead")]
     fn get<'a, V: Value, C: Context<'a>, K: PropertyKey>(
         &self,
         cx: &mut C,
@@ -368,7 +368,7 @@ pub trait Object: Value {
         }
     }
 
-    #[doc(hidden)]
+    #[deprecated(since = "TBD", note = "use `Object::prop()` instead")]
     fn set<'a, C: Context<'a>, K: PropertyKey, W: Value>(
         &self,
         cx: &mut C,
@@ -389,7 +389,7 @@ pub trait Object: Value {
         Root::new(cx, self)
     }
 
-    #[doc(hidden)]
+    #[deprecated(since = "TBD", note = "use `Object::method()` instead")]
     fn call_method_with<'a, C, K>(&self, cx: &mut C, method: K) -> NeonResult<CallOptions<'a>>
     where
         C: Context<'a>,

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -38,11 +38,8 @@ use crate::{
     result::{NeonResult, Throw},
     sys::{self, raw},
     types::{
-        build,
-        extract::{TryFromJs, TryIntoJs},
-        function::{BindOptions, CallOptions},
-        utf8::Utf8,
-        JsFunction, JsUndefined, JsValue, Value,
+        build, extract::{TryFromJs, TryIntoJs}, function::{BindOptions, CallOptions}, utf8::Utf8, JsFunction, JsObject, JsUndefined, JsValue, Value,
+        private::ValueInternal
     },
 };
 
@@ -161,21 +158,19 @@ impl<'a> PropertyKey for &'a str {
 /// # Ok(cx.string(s))
 /// # }
 /// ```
-pub struct PropOptions<'a, 'cx, O, K>
+pub struct PropOptions<'a, 'cx, K>
 where
     'cx: 'a,
-    O: Object,
     K: PropertyKey,
 {
     pub(crate) cx: &'a mut Cx<'cx>,
-    pub(crate) this: Handle<'cx, O>,
+    pub(crate) this: Handle<'cx, JsObject>,
     pub(crate) key: K,
 }
 
-impl<'a, 'cx, O, K> PropOptions<'a, 'cx, O, K>
+impl<'a, 'cx, K> PropOptions<'a, 'cx, K>
 where
     'cx: 'a,
-    O: Object,
     K: PropertyKey,
 {
     /// Gets the property from the object and attempts to convert it to a Rust value.
@@ -216,8 +211,8 @@ pub trait Object: Value {
         &self,
         cx: &'a mut Cx<'cx>,
         key: K,
-    ) -> PropOptions<'a, 'cx, Self, K> {
-        let this = Handle::new_internal(unsafe { Self::from_local(cx.env(), self.to_local()) });
+    ) -> PropOptions<'a, 'cx, K> {
+        let this: Handle<'_, JsObject> = Handle::new_internal(unsafe { ValueInternal::from_local(cx.env(), self.to_local()) });
         PropOptions { cx, this, key }
     }
 

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -33,7 +33,7 @@
 //! [symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 
 use crate::{
-    context::Context,
+    context::{Cx, Context, internal::ContextInternal},
     handle::{Handle, Root},
     result::{NeonResult, Throw},
     sys::{self, raw},
@@ -161,13 +161,13 @@ impl<'a> PropertyKey for &'a str {
 /// # Ok(cx.string(s))
 /// # }
 /// ```
-pub struct PropOptions<'a, 'cx: 'a, C: Context<'cx>, O: Object, K: PropertyKey> {
-    pub(crate) cx: &'a mut C,
+pub struct PropOptions<'a, 'cx: 'a, O: Object, K: PropertyKey> {
+    pub(crate) cx: &'a mut Cx<'cx>,
     pub(crate) this: Handle<'cx, O>,
     pub(crate) key: K,
 }
 
-impl<'a, 'cx: 'a, C: Context<'cx>, O: Object, K: PropertyKey> PropOptions<'a, 'cx, C, O, K> {
+impl<'a, 'cx: 'a, O: Object, K: PropertyKey> PropOptions<'a, 'cx, O, K> {
     /// Gets the property from the object and attempts to convert it to a Rust value.
     /// Equivalent to calling `R::from_js(cx, obj.get(cx)?)`.
     ///
@@ -191,7 +191,7 @@ impl<'a, 'cx: 'a, C: Context<'cx>, O: Object, K: PropertyKey> PropOptions<'a, 'c
     ///
     /// May throw an exception either during accessing the property or downcasting it
     /// to a function.
-    pub fn bind(&'a mut self) -> NeonResult<BindOptions<'a, 'cx, C>> {
+    pub fn bind(&'a mut self) -> NeonResult<BindOptions<'a, 'cx>> {
         let callee: Handle<JsFunction> = self.this.get(self.cx, self.key)?;
         let mut bind = callee.bind(self.cx);
         bind.this(self.this);
@@ -202,11 +202,11 @@ impl<'a, 'cx: 'a, C: Context<'cx>, O: Object, K: PropertyKey> PropOptions<'a, 'c
 /// The trait of all object types.
 pub trait Object: Value {
     /// Create a [`PropOptions`] for accessing a property.
-    fn prop<'a, 'cx: 'a, C: Context<'cx>, K: PropertyKey>(
+    fn prop<'a, 'cx: 'a, K: PropertyKey>(
         &self,
-        cx: &'a mut C,
+        cx: &'a mut Cx<'cx>,
         key: K,
-    ) -> PropOptions<'a, 'cx, C, Self, K> {
+    ) -> PropOptions<'a, 'cx, Self, K> {
         let this = Handle::new_internal(unsafe { Self::from_local(cx.env(), self.to_local()) });
         PropOptions { cx, this, key }
     }

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -151,8 +151,10 @@ impl<'a> PropertyKey for &'a str {
 /// let x: f64 = obj
 ///     .prop(&mut cx, "x")
 ///     .get()?;
+///
 /// obj.prop(&mut cx, "y")
 ///     .set(x)?;
+///
 /// let s: String = obj.prop(&mut cx, "toString")
 ///     .bind()?
 ///     .apply()?;

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -167,7 +167,11 @@ pub struct PropOptions<'a, 'cx: 'a, O: Object, K: PropertyKey> {
     pub(crate) key: K,
 }
 
-impl<'a, 'cx: 'a, O: Object, K: PropertyKey> PropOptions<'a, 'cx, O, K> {
+impl<'a, 'cx: 'a, O, K> PropOptions<'a, 'cx, O, K>
+where
+    O: Object,
+    K: PropertyKey,
+{
     /// Gets the property from the object and attempts to convert it to a Rust value.
     /// Equivalent to calling `R::from_js(cx, obj.get(cx)?)`.
     ///

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -161,14 +161,20 @@ impl<'a> PropertyKey for &'a str {
 /// # Ok(cx.string(s))
 /// # }
 /// ```
-pub struct PropOptions<'a, 'cx: 'a, O: Object, K: PropertyKey> {
+pub struct PropOptions<'a, 'cx, O, K>
+where
+    'cx: 'a,
+    O: Object,
+    K: PropertyKey,
+{
     pub(crate) cx: &'a mut Cx<'cx>,
     pub(crate) this: Handle<'cx, O>,
     pub(crate) key: K,
 }
 
-impl<'a, 'cx: 'a, O, K> PropOptions<'a, 'cx, O, K>
+impl<'a, 'cx, O, K> PropOptions<'a, 'cx, O, K>
 where
+    'cx: 'a,
     O: Object,
     K: PropertyKey,
 {

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -33,7 +33,7 @@
 //! [symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 
 use crate::{
-    context::{Cx, Context, internal::ContextInternal},
+    context::{internal::ContextInternal, Context, Cx},
     handle::{Handle, Root},
     result::{NeonResult, Throw},
     sys::{self, raw},

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         function::{BindOptions, CallOptions},
         private::ValueInternal,
         utf8::Utf8,
-        JsFunction, JsObject, JsUndefined, JsValue, Value,
+        JsFunction, JsUndefined, JsValue, Value,
     },
 };
 
@@ -225,6 +225,20 @@ where
     /// May throw an exception either during converting the value or setting the property.
     pub fn set<V: TryIntoJs<'cx>>(&mut self, v: V) -> NeonResult<&mut Self> {
         let v = v.try_into_js(self.cx)?;
+        self.this.set(self.cx, self.key, v)?;
+        Ok(self)
+    }
+
+    /// Sets the property on the object to a value computed from a closure.
+    /// Equivalent to calling `obj.set(cx, f(cx).try_into_js(cx)?)`.
+    ///
+    /// May throw an exception either during converting the value or setting the property.
+    pub fn set_with<R, F>(&mut self, f: F) -> NeonResult<&mut Self>
+    where
+        R: TryIntoJs<'cx>,
+        F: FnOnce(&mut Cx<'cx>) -> R,
+    {
+        let v = f(self.cx).try_into_js(self.cx)?;
         self.this.set(self.cx, self.key, v)?;
         Ok(self)
     }

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -285,9 +285,7 @@ pub trait Object: Value {
         cx: &'a mut Cx<'cx>,
         key: K,
     ) -> NeonResult<BindOptions<'a, 'cx>> {
-        let callee: Handle<JsValue> = self
-            .prop(cx, key)
-            .get()?;
+        let callee: Handle<JsValue> = self.prop(cx, key).get()?;
         let this = Some(self.as_value(cx));
         Ok(BindOptions {
             cx,

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -204,7 +204,7 @@ where
     pub fn bind(&'a mut self) -> NeonResult<BindOptions<'a, 'cx>> {
         let callee: Handle<JsFunction> = self.this.get(self.cx, self.key)?;
         let mut bind = callee.bind(self.cx);
-        bind.this(self.this);
+        bind.this(self.this)?;
         Ok(bind)
     }
 }

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -193,9 +193,10 @@ where
     /// Equivalent to calling `obj.set(cx, v.try_into_js(cx)?)`.
     ///
     /// May throw an exception either during converting the value or setting the property.
-    pub fn set<V: TryIntoJs<'cx>>(&mut self, v: V) -> NeonResult<bool> {
+    pub fn set<V: TryIntoJs<'cx>>(&mut self, v: V) -> NeonResult<&mut Self> {
         let v = v.try_into_js(self.cx)?;
-        self.this.set(self.cx, self.key, v)
+        self.this.set(self.cx, self.key, v)?;
+        Ok(self)
     }
 
     /// Gets the property from the object as a method and binds `this` to the object.

--- a/crates/neon/src/result/mod.rs
+++ b/crates/neon/src/result/mod.rs
@@ -26,8 +26,7 @@
 //! # use neon::prelude::*;
 //! fn get_message(mut cx: FunctionContext) -> JsResult<JsValue> {
 //!     let obj: Handle<JsObject> = cx.argument(0)?;
-//!     let prop: Handle<JsValue> = obj.get(&mut cx, "message")?;
-//!     Ok(prop)
+//!     obj.prop(&mut cx, "message").get()
 //! }
 //! ```
 //!

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -83,26 +83,6 @@ where
     callback(env, info)
 }
 
-pub unsafe fn call(
-    out: &mut Local,
-    env: Env,
-    fun: Local,
-    this: Local,
-    argc: i32,
-    argv: *const c_void,
-) -> bool {
-    let status = napi::call_function(
-        env,
-        this,
-        fun,
-        argc as usize,
-        argv as *const _,
-        out as *mut _,
-    );
-
-    status == napi::Status::Ok
-}
-
 pub unsafe fn construct(
     out: &mut Local,
     env: Env,

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -87,10 +87,10 @@ pub unsafe fn construct(
     out: &mut Local,
     env: Env,
     fun: Local,
-    argc: i32,
+    argc: usize,
     argv: *const c_void,
 ) -> bool {
-    let status = napi::new_instance(env, fun, argc as usize, argv as *const _, out as *mut _);
+    let status = napi::new_instance(env, fun, argc, argv as *const _, out as *mut _);
 
     status == napi::Status::Ok
 }

--- a/crates/neon/src/thread/mod.rs
+++ b/crates/neon/src/thread/mod.rs
@@ -16,9 +16,10 @@
 //! pub fn thread_id(cx: &mut Cx) -> NeonResult<u32> {
 //!     THREAD_ID.get_or_try_init(cx, |cx| {
 //!         let require: Handle<JsFunction> = cx.global("require")?;
-//!         let worker: Handle<JsObject> = require.call_with(cx)
-//!             .arg(cx.string("node:worker_threads"))
-//!             .apply(cx)?;
+//!         let worker: Handle<JsObject> = require
+//!             .bind(cx)
+//!             .arg("node:worker_threads")?
+//!             .call()?;
 //!         let thread_id: f64 = worker.prop(cx, "threadId").get()?;
 //!         Ok(thread_id as u32)
 //!     }).cloned()

--- a/crates/neon/src/thread/mod.rs
+++ b/crates/neon/src/thread/mod.rs
@@ -19,8 +19,8 @@
 //!         let worker: Handle<JsObject> = require.call_with(cx)
 //!             .arg(cx.string("node:worker_threads"))
 //!             .apply(cx)?;
-//!         let thread_id: Handle<JsNumber> = worker.get(cx, "threadId")?;
-//!         Ok(thread_id.value(cx) as u32)
+//!         let thread_id: f64 = worker.prop(cx, "threadId").get()?;
+//!         Ok(thread_id as u32)
 //!     }).cloned()
 //! }
 //! ```

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -295,7 +295,8 @@ impl<T: 'static> Deref for JsBox<T> {
 ///     fn finalize<'a, C: Context<'a>>(self, cx: &mut C) {
 ///         let global = cx.global_object();
 ///         let emit: Handle<JsFunction> = global
-///             .get(cx, "emit")
+///             .prop(cx.cx_mut(), "emit")
+///             .get()
 ///             .unwrap();
 ///
 ///         let args = vec![

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -293,19 +293,10 @@ impl<T: 'static> Deref for JsBox<T> {
 ///
 /// impl Finalize for Point {
 ///     fn finalize<'a, C: Context<'a>>(self, cx: &mut C) {
-///         let global = cx.global_object();
-///         let emit: Handle<JsFunction> = global
-///             .prop(cx.cx_mut(), "emit")
-///             .get()
-///             .unwrap();
-///
-///         let args = vec![
-///             cx.string("gc_point").upcast::<JsValue>(),
-///             cx.number(self.0).upcast(),
-///             cx.number(self.1).upcast(),
-///         ];
-///
-///         emit.call(cx, global, args).unwrap();
+///         cx.global_object()
+///             .method(cx.cx_mut(), "emit").unwrap()
+///             .args(("gc_point", self.0, self.1)).unwrap()
+///             .exec().unwrap();
 ///     }
 /// }
 /// ```

--- a/crates/neon/src/types_impl/error.rs
+++ b/crates/neon/src/types_impl/error.rs
@@ -24,11 +24,8 @@ use crate::{
 /// let err = cx.type_error("expected a number, found a string")?;
 ///
 /// // Add some custom diagnostic properties to the error:
-/// let expected = cx.string("number");
-/// err.set(&mut cx, "expected", expected)?;
-///
-/// let found = cx.string("string");
-/// err.set(&mut cx, "found", found)?;
+/// err.prop(&mut cx, "expected").set("number")?;
+/// err.prop(&mut cx, "found").set("string")?;
 ///
 /// // Throw the error:
 /// cx.throw(err)?;

--- a/crates/neon/src/types_impl/extract/with.rs
+++ b/crates/neon/src/types_impl/extract/with.rs
@@ -1,14 +1,4 @@
-use crate::{
-    context::Cx,
-    result::{JsResult, NeonResult},
-    types::{
-        extract::TryIntoJs,
-        function::{
-            private::{ArgsVec, TryIntoArgumentsInternal},
-            TryIntoArguments,
-        },
-    },
-};
+use crate::{context::Cx, result::JsResult, types::extract::TryIntoJs};
 
 /// Wraps a closure that will be lazily evaluated when [`TryIntoJs::try_into_js`] is
 /// called.
@@ -56,23 +46,6 @@ where
     fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         (self.0)(cx).try_into_js(cx)
     }
-}
-
-impl<'cx, F, O> TryIntoArgumentsInternal<'cx> for With<F, O>
-where
-    F: FnOnce(&mut Cx) -> O,
-    O: TryIntoArgumentsInternal<'cx>,
-{
-    fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<ArgsVec<'cx>> {
-        (self.0)(cx).try_into_args_vec(cx)
-    }
-}
-
-impl<'cx, F, O> TryIntoArguments<'cx> for With<F, O>
-where
-    F: FnOnce(&mut Cx) -> O,
-    O: TryIntoArguments<'cx>,
-{
 }
 
 impl<F, O> super::private::Sealed for With<F, O> where for<'cx> F: FnOnce(&mut Cx<'cx>) -> O {}

--- a/crates/neon/src/types_impl/extract/with.rs
+++ b/crates/neon/src/types_impl/extract/with.rs
@@ -20,9 +20,9 @@ use crate::{context::Cx, result::JsResult, types::extract::TryIntoJs};
 ///
 ///     With(move |cx| -> NeonResult<_> {
 ///         cx.global::<JsObject>("console")?
-///             .call_method_with(cx, "log")?
-///             .arg(cx.string(log))
-///             .exec(cx)?;
+///             .method(cx, "log")?
+///             .arg(&log)?
+///             .exec()?;
 ///
 ///         Ok(sum)
 ///     })

--- a/crates/neon/src/types_impl/extract/with.rs
+++ b/crates/neon/src/types_impl/extract/with.rs
@@ -1,4 +1,14 @@
-use crate::{context::Cx, result::JsResult, types::extract::TryIntoJs};
+use crate::{
+    context::Cx,
+    result::{JsResult, NeonResult},
+    types::{
+        extract::TryIntoJs,
+        function::{
+            private::{ArgsVec, TryIntoArgumentsInternal},
+            TryIntoArguments,
+        },
+    },
+};
 
 /// Wraps a closure that will be lazily evaluated when [`TryIntoJs::try_into_js`] is
 /// called.
@@ -46,6 +56,23 @@ where
     fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         (self.0)(cx).try_into_js(cx)
     }
+}
+
+impl<'cx, F, O> TryIntoArgumentsInternal<'cx> for With<F, O>
+where
+    F: FnOnce(&mut Cx) -> O,
+    O: TryIntoArgumentsInternal<'cx>,
+{
+    fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<ArgsVec<'cx>> {
+        (self.0)(cx).try_into_args_vec(cx)
+    }
+}
+
+impl<'cx, F, O> TryIntoArguments<'cx> for With<F, O>
+where
+    F: FnOnce(&mut Cx) -> O,
+    O: TryIntoArguments<'cx>,
+{
 }
 
 impl<F, O> super::private::Sealed for With<F, O> where for<'cx> F: FnOnce(&mut Cx<'cx>) -> O {}

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -73,9 +73,8 @@ impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
     /// is converted to a Rust value with `TryFromJs::from_js`.
     pub fn apply<R: TryFromJs<'cx>>(&mut self) -> NeonResult<R> {
         let this = self.this.unwrap_or_else(|| self.cx.undefined().upcast());
-        let v: Handle<JsValue> = unsafe {
-            call_local(self.cx, self.callee.to_local(), this, &self.args)?
-        };
+        let v: Handle<JsValue> =
+            unsafe { call_local(self.cx, self.callee.to_local(), this, &self.args)? };
         R::from_js(self.cx, v)
     }
 }

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -117,6 +117,7 @@ impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
 /// # Ok(x)
 /// # }
 /// ```
+#[deprecated(since = "TBD", note = "use `JsFunction::bind()` instead")]
 #[derive(Clone)]
 pub struct CallOptions<'a> {
     pub(crate) callee: Handle<'a, JsFunction>,
@@ -175,6 +176,7 @@ impl<'a> CallOptions<'a> {
 /// # Ok(obj)
 /// # }
 /// ```
+#[deprecated(since = "TBD", note = "use `JsFunction::bind()` instead")]
 #[derive(Clone)]
 pub struct ConstructOptions<'a> {
     pub(crate) callee: Handle<'a, JsFunction>,

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     object::Object,
     result::{JsResult, NeonResult},
     types::{
-        call_local,
         extract::{TryFromJs, TryIntoJs},
         private::ValueInternal,
         JsFunction, JsObject, JsValue, Value,
@@ -84,8 +83,7 @@ impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
     /// is converted to a Rust value with `TryFromJs::from_js`.
     pub fn apply<R: TryFromJs<'cx>>(&mut self) -> NeonResult<R> {
         let this = self.this.unwrap_or_else(|| self.cx.undefined().upcast());
-        let v: Handle<JsValue> =
-            unsafe { call_local(self.cx, self.callee.to_local(), this, &self.args)? };
+        let v: Handle<JsValue> = unsafe { self.callee.try_call(self.cx, this, &self.args)? };
         R::from_js(self.cx, v)
     }
 }

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -202,93 +202,57 @@ impl<'cx> private::TryIntoArgumentsInternal<'cx> for () {
     }
 }
 
-macro_rules! impl_into_arguments {
+macro_rules! impl_into_arguments_expand {
     {
-        [ $(($tprefix:ident, $vprefix:ident), )* ];
+        $(#[$attrs:meta])?
+        [ $($prefix:ident ),* ];
         [];
     } => {};
 
     {
-        [ $(($tprefix:ident, $vprefix:ident), )* ];
-        [ $(#[$attr1:meta])? ($tname1:ident, $vname1:ident), $($(#[$attrs:meta])? ($tnames:ident, $vnames:ident), )* ];
+        $(#[$attrs:meta])?
+        [ $($prefix:ident),* ];
+        [ $head:ident $(, $tail:ident)* ];
     } => {
-        $(#[$attr1])?
-        impl<'cx, $($tprefix: TryIntoJs<'cx> + 'cx, )* $tname1: TryIntoJs<'cx> + 'cx> private::TryIntoArgumentsInternal<'cx> for ($($tprefix, )* $tname1, ) {
+        $(#[$attrs])?
+        impl<'cx, $($prefix: TryIntoJs<'cx> + 'cx, )* $head: TryIntoJs<'cx> + 'cx> private::TryIntoArgumentsInternal<'cx> for ($($prefix, )* $head, ) {
+            #[allow(non_snake_case)]
             fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<private::ArgsVec<'cx>> {
-                let ($($vprefix, )* $vname1, ) = self;
-                Ok(smallvec![ $($vprefix.try_into_js(cx)?.upcast(),)* $vname1.try_into_js(cx)?.upcast() ])
+                let ($($prefix, )* $head, ) = self;
+                Ok(smallvec![ $($prefix.try_into_js(cx)?.upcast(),)* $head.try_into_js(cx)?.upcast() ])
              }
          }
 
-         $(#[$attr1])?
-         impl<'cx, $($tprefix: TryIntoJs<'cx> + 'cx, )* $tname1: TryIntoJs<'cx> + 'cx> TryIntoArguments<'cx> for ($($tprefix, )* $tname1, ) {}
+         $(#[$attrs])?
+         impl<'cx, $($prefix: TryIntoJs<'cx> + 'cx, )* $head: TryIntoJs<'cx> + 'cx> TryIntoArguments<'cx> for ($($prefix, )* $head, ) {}
 
-         impl_into_arguments! {
-             [ $(($tprefix, $vprefix), )* ($tname1, $vname1), ];
-             [ $($(#[$attrs])? ($tnames, $vnames), )* ];
-         }
-     };
+        impl_into_arguments_expand! {
+            $(#[$attrs])?
+            [ $($prefix, )* $head ];
+            [ $($tail),* ];
+        }
+   }
+}
+
+macro_rules! impl_into_arguments {
+    {
+        [ $($show:ident),* ];
+        [ $($hide:ident),* ];
+    } => {
+        impl_into_arguments_expand! { []; [ $($show),* ]; }
+        impl_into_arguments_expand! { #[doc(hidden)] [ $($show),* ]; [ $($hide),* ]; }
+    }
 }
 
 impl_into_arguments! {
-    [];
+    // Tuples up to length 8 are included in the docs.
+    [V1, V2, V3, V4, V5, V6, V7, V8];
+
+    // Tuples up to length 32 are not included in the docs.
     [
-        (V1, v1),
-        (V2, v2),
-        (V3, v3),
-        (V4, v4),
-        (V5, v5),
-        (V6, v6),
-        (V7, v7),
-        (V8, v8),
-        #[doc(hidden)]
-        (V9, v9),
-        #[doc(hidden)]
-        (V10, v10),
-        #[doc(hidden)]
-        (V11, v11),
-        #[doc(hidden)]
-        (V12, v12),
-        #[doc(hidden)]
-        (V13, v13),
-        #[doc(hidden)]
-        (V14, v14),
-        #[doc(hidden)]
-        (V15, v15),
-        #[doc(hidden)]
-        (V16, v16),
-        #[doc(hidden)]
-        (V17, v17),
-        #[doc(hidden)]
-        (V18, v18),
-        #[doc(hidden)]
-        (V19, v19),
-        #[doc(hidden)]
-        (V20, v20),
-        #[doc(hidden)]
-        (V21, v21),
-        #[doc(hidden)]
-        (V22, v22),
-        #[doc(hidden)]
-        (V23, v23),
-        #[doc(hidden)]
-        (V24, v24),
-        #[doc(hidden)]
-        (V25, v25),
-        #[doc(hidden)]
-        (V26, v26),
-        #[doc(hidden)]
-        (V27, v27),
-        #[doc(hidden)]
-        (V28, v28),
-        #[doc(hidden)]
-        (V29, v29),
-        #[doc(hidden)]
-        (V30, v30),
-        #[doc(hidden)]
-        (V31, v31),
-        #[doc(hidden)]
-        (V32, v32),
+        V9, V10, V11, V12, V13, V14, V15, V16,
+        V17, V18, V19, V20, V21, V22, V23, V24,
+        V25, V26, V27, V28, V29, V30, V31, V32
     ];
 }
 
@@ -307,92 +271,56 @@ impl<'a> private::ArgumentsInternal<'a> for () {
 
 impl<'a> Arguments<'a> for () {}
 
-macro_rules! impl_arguments {
+macro_rules! impl_arguments_expand {
     {
-        [ $(($tprefix:ident, $vprefix:ident), )* ];
+        $(#[$attrs:meta])?
+        [ $($prefix:ident),* ];
         [];
     } => {};
 
     {
-        [ $(($tprefix:ident, $vprefix:ident), )* ];
-        [ $(#[$attr1:meta])? ($tname1:ident, $vname1:ident), $($(#[$attrs:meta])? ($tnames:ident, $vnames:ident), )* ];
+        $(#[$attrs:meta])?
+        [ $($prefix:ident),* ];
+        [ $head:ident $(, $tail:ident)* ];
     } => {
-        $(#[$attr1])?
-        impl<'a, $($tprefix: Value, )* $tname1: Value> private::ArgumentsInternal<'a> for ($(Handle<'a, $tprefix>, )* Handle<'a, $tname1>, ) {
+        $(#[$attrs])?
+        impl<'a, $($prefix: Value, )* $head: Value> private::ArgumentsInternal<'a> for ($(Handle<'a, $prefix>, )* Handle<'a, $head>, ) {
+            #[allow(non_snake_case)]
             fn into_args_vec(self) -> private::ArgsVec<'a> {
-                let ($($vprefix, )* $vname1, ) = self;
-                smallvec![$($vprefix.upcast(),)* $vname1.upcast()]
+                let ($($prefix, )* $head, ) = self;
+                smallvec![$($prefix.upcast(),)* $head.upcast()]
              }
          }
 
-         $(#[$attr1])?
-         impl<'a, $($tprefix: Value, )* $tname1: Value> Arguments<'a> for ($(Handle<'a, $tprefix>, )* Handle<'a, $tname1>, ) {}
+         $(#[$attrs])?
+         impl<'a, $($prefix: Value, )* $head: Value> Arguments<'a> for ($(Handle<'a, $prefix>, )* Handle<'a, $head>, ) {}
 
-         impl_arguments! {
-             [ $(($tprefix, $vprefix), )* ($tname1, $vname1), ];
-             [ $($(#[$attrs])? ($tnames, $vnames), )* ];
+         impl_arguments_expand! {
+            $(#[$attrs])?
+            [ $($prefix, )* $head ];
+            [ $($tail),* ];
          }
-     };
- }
+    };
+}
+
+macro_rules! impl_arguments {
+    {
+        [ $($show:ident),* ];
+        [ $($hide:ident),* ];
+    } => {
+        impl_arguments_expand! { []; [ $($show),* ]; }
+        impl_arguments_expand! { #[doc(hidden)] [ $($show),* ]; [ $($hide),* ]; }
+    }
+}
 
 impl_arguments! {
-    [];
+    // Tuples up to length 8 are included in the docs.
+    [V1, V2, V3, V4, V5, V6, V7, V8];
+
+    // Tuples up to length 32 are not included in the docs.
     [
-        (V1, v1),
-        (V2, v2),
-        (V3, v3),
-        (V4, v4),
-        (V5, v5),
-        (V6, v6),
-        (V7, v7),
-        (V8, v8),
-        #[doc(hidden)]
-        (V9, v9),
-        #[doc(hidden)]
-        (V10, v10),
-        #[doc(hidden)]
-        (V11, v11),
-        #[doc(hidden)]
-        (V12, v12),
-        #[doc(hidden)]
-        (V13, v13),
-        #[doc(hidden)]
-        (V14, v14),
-        #[doc(hidden)]
-        (V15, v15),
-        #[doc(hidden)]
-        (V16, v16),
-        #[doc(hidden)]
-        (V17, v17),
-        #[doc(hidden)]
-        (V18, v18),
-        #[doc(hidden)]
-        (V19, v19),
-        #[doc(hidden)]
-        (V20, v20),
-        #[doc(hidden)]
-        (V21, v21),
-        #[doc(hidden)]
-        (V22, v22),
-        #[doc(hidden)]
-        (V23, v23),
-        #[doc(hidden)]
-        (V24, v24),
-        #[doc(hidden)]
-        (V25, v25),
-        #[doc(hidden)]
-        (V26, v26),
-        #[doc(hidden)]
-        (V27, v27),
-        #[doc(hidden)]
-        (V28, v28),
-        #[doc(hidden)]
-        (V29, v29),
-        #[doc(hidden)]
-        (V30, v30),
-        #[doc(hidden)]
-        (V31, v31),
-        #[doc(hidden)]
-        (V32, v32),
+        V9, V10, V11, V12, V13, V14, V15, V16,
+        V17, V18, V19, V20, V21, V22, V23, V24,
+        V25, V26, V27, V28, V29, V30, V31, V32
     ];
 }

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -87,6 +87,13 @@ impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
         R::from_js(self.cx, v)
     }
 
+    /// Make the function call as a constructor. If the function returns without throwing, the
+    /// result value is converted to a Rust value with `TryFromJs::from_js`.
+    pub fn construct<R: TryFromJs<'cx>>(&mut self) -> NeonResult<R> {
+        let v: Handle<JsValue> = unsafe { self.callee.try_construct(self.cx, &self.args)? };
+        R::from_js(self.cx, v)
+    }
+
     /// Make the function call for side effect, discarding the result value. This method is
     /// preferable to [`call()`](BindOptions::call) when the result value isn't needed,
     /// since it doesn't require specifying a result type.

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -225,6 +225,26 @@ where
 {
 }
 
+impl<'cx, T, E> private::TryIntoArgumentsInternal<'cx> for Result<T, E>
+where
+    T: private::TryIntoArgumentsInternal<'cx>,
+    E: TryIntoJs<'cx>,
+{
+    fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<private::ArgsVec<'cx>> {
+        match self {
+            Ok(v) => v.try_into_args_vec(cx),
+            Err(err) => err.try_into_js(cx).and_then(|err| cx.throw(err)),
+        }
+    }
+}
+
+impl<'cx, T, E> TryIntoArguments<'cx> for Result<T, E>
+where
+    T: TryIntoArguments<'cx>,
+    E: TryIntoJs<'cx>,
+{
+}
+
 macro_rules! impl_into_arguments_expand {
     {
         $(#[$attrs:meta])?

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -52,6 +52,16 @@ impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
         Ok(self)
     }
 
+    /// Replaces the arguments list with a list computed from a closure.
+    pub fn args_with<R, F>(&mut self, f: F) -> NeonResult<&mut Self>
+    where
+        R: TryIntoArguments<'cx>,
+        F: FnOnce(&mut Cx<'cx>) -> R,
+    {
+        self.args = f(self.cx).try_into_args_vec(self.cx)?;
+        Ok(self)
+    }
+
     /// Add an argument to the arguments list.
     pub fn arg<A: TryIntoJs<'cx>>(&mut self, a: A) -> NeonResult<&mut Self> {
         let v = a.try_into_js(self.cx)?;

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -7,10 +7,56 @@ use crate::{
     handle::Handle,
     object::Object,
     result::{JsResult, NeonResult},
-    types::{JsFunction, JsObject, JsValue, Value},
+    types::{extract::{TryFromJs, TryIntoJs}, JsFunction, JsObject, JsValue, Value},
 };
 
 pub(crate) mod private;
+
+pub struct BindOptions<'a, 'cx: 'a, C: Context<'cx>> {
+    pub(crate) cx: &'a mut C,
+    pub(crate) callee: Handle<'cx, JsFunction>,
+    pub(crate) this: Option<Handle<'cx, JsValue>>,
+    pub(crate) args: private::ArgsVec<'cx>,
+}
+
+impl<'a, 'cx: 'a, C: Context<'cx>> BindOptions<'a, 'cx, C> {
+    /// Set the value of `this` for the function call.
+    pub fn this<V: Value>(&mut self, this: Handle<'cx, V>) -> &mut Self {
+        self.this = Some(this.upcast());
+        self
+    }
+
+    /// Replaces the arguments list with the given arguments.
+    pub fn args<A: TryIntoArguments<'cx>>(&mut self, a: A) -> NeonResult<&mut Self> {
+        self.args = a.try_into_args_vec(self.cx)?;
+        Ok(self)
+    }
+
+    /// Add an argument to the arguments list.
+    pub fn arg<A: TryIntoJs<'cx>>(&mut self, a: A) -> NeonResult<&mut Self> {
+        let v = a.try_into_js(self.cx)?;
+        self.args.push(v.upcast());
+        Ok(self)
+    }
+
+    /// Add an argument to the arguments list, computed from a closure.
+    pub fn arg_with<R, F>(&mut self, f: F) -> NeonResult<&mut Self>
+      where R: TryIntoJs<'cx>,
+            F: FnOnce(&mut C) -> NeonResult<R>
+    {
+        let v = f(self.cx)?.try_into_js(self.cx)?;
+        self.args.push(v.upcast());
+        Ok(self)
+    }
+
+    /// Make the function call. If the function returns without throwing, the result value
+    /// is converted to a Rust value with `TryFromJs::from_js`.
+    pub fn apply<R: TryFromJs<'cx>>(&mut self) -> NeonResult<R> {
+        let this = self.this.unwrap_or_else(|| self.cx.undefined().upcast());
+        let v: Handle<JsValue> = self.callee.call(self.cx, this, &self.args)?;
+        R::from_js(self.cx, v)
+    }
+}
 
 /// A builder for making a JavaScript function call like `parseInt("42")`.
 ///
@@ -109,6 +155,109 @@ impl<'a> ConstructOptions<'a> {
         let v: Handle<JsObject> = self.callee.construct(cx, &self.args)?;
         v.downcast_or_throw(cx)
     }
+}
+
+/// The trait for specifying values to be converted into arguments for a function call.
+/// This trait is sealed and cannot be implemented by types outside of the Neon crate.
+///
+/// **Note:** This trait is implemented for tuples of up to 32 JavaScript values,
+/// but for the sake of brevity, only tuples up to size 8 are shown in this documentation.
+pub trait TryIntoArguments<'cx>: private::TryIntoArgumentsInternal<'cx> {}
+
+impl<'cx> private::TryIntoArgumentsInternal<'cx> for () {
+    fn try_into_args_vec<C: Context<'cx>>(self, _cx: &mut C) -> NeonResult<private::ArgsVec<'cx>> {
+        Ok(smallvec![])
+    }
+}
+
+macro_rules! impl_into_arguments {
+    {
+        [ $(($tprefix:ident, $vprefix:ident), )* ];
+        [];
+    } => {};
+
+    {
+        [ $(($tprefix:ident, $vprefix:ident), )* ];
+        [ $(#[$attr1:meta])? ($tname1:ident, $vname1:ident), $($(#[$attrs:meta])? ($tnames:ident, $vnames:ident), )* ];
+    } => {
+        $(#[$attr1])?
+        impl<'cx, $($tprefix: TryIntoJs<'cx> + 'cx, )* $tname1: TryIntoJs<'cx> + 'cx> private::TryIntoArgumentsInternal<'cx> for ($($tprefix, )* $tname1, ) {
+            fn try_into_args_vec<C: Context<'cx>>(self, cx: &mut C) -> NeonResult<private::ArgsVec<'cx>> {
+                let ($($vprefix, )* $vname1, ) = self;
+                Ok(smallvec![ $($vprefix.try_into_js(cx)?.upcast(),)* $vname1.try_into_js(cx)?.upcast() ])
+             }
+         }
+
+         $(#[$attr1])?
+         impl<'cx, $($tprefix: TryIntoJs<'cx> + 'cx, )* $tname1: TryIntoJs<'cx> + 'cx> TryIntoArguments<'cx> for ($($tprefix, )* $tname1, ) {}
+
+         impl_into_arguments! {
+             [ $(($tprefix, $vprefix), )* ($tname1, $vname1), ];
+             [ $($(#[$attrs])? ($tnames, $vnames), )* ];
+         }
+     };
+}
+
+impl_into_arguments! {
+    [];
+    [
+        (V1, v1),
+        (V2, v2),
+        (V3, v3),
+        (V4, v4),
+        (V5, v5),
+        (V6, v6),
+        (V7, v7),
+        (V8, v8),
+        #[doc(hidden)]
+        (V9, v9),
+        #[doc(hidden)]
+        (V10, v10),
+        #[doc(hidden)]
+        (V11, v11),
+        #[doc(hidden)]
+        (V12, v12),
+        #[doc(hidden)]
+        (V13, v13),
+        #[doc(hidden)]
+        (V14, v14),
+        #[doc(hidden)]
+        (V15, v15),
+        #[doc(hidden)]
+        (V16, v16),
+        #[doc(hidden)]
+        (V17, v17),
+        #[doc(hidden)]
+        (V18, v18),
+        #[doc(hidden)]
+        (V19, v19),
+        #[doc(hidden)]
+        (V20, v20),
+        #[doc(hidden)]
+        (V21, v21),
+        #[doc(hidden)]
+        (V22, v22),
+        #[doc(hidden)]
+        (V23, v23),
+        #[doc(hidden)]
+        (V24, v24),
+        #[doc(hidden)]
+        (V25, v25),
+        #[doc(hidden)]
+        (V26, v26),
+        #[doc(hidden)]
+        (V27, v27),
+        #[doc(hidden)]
+        (V28, v28),
+        #[doc(hidden)]
+        (V29, v29),
+        #[doc(hidden)]
+        (V30, v30),
+        #[doc(hidden)]
+        (V31, v31),
+        #[doc(hidden)]
+        (V32, v32),
+    ];
 }
 
 /// The trait for specifying arguments for a function call. This trait is sealed and cannot

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -62,9 +62,9 @@ impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
     pub fn arg_with<R, F>(&mut self, f: F) -> NeonResult<&mut Self>
     where
         R: TryIntoJs<'cx>,
-        F: FnOnce(&mut Cx<'cx>) -> NeonResult<R>,
+        F: FnOnce(&mut Cx<'cx>) -> R,
     {
-        let v = f(self.cx)?.try_into_js(self.cx)?;
+        let v = f(self.cx).try_into_js(self.cx)?;
         self.args.push(v.upcast());
         Ok(self)
     }

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -7,7 +7,10 @@ use crate::{
     handle::Handle,
     object::Object,
     result::{JsResult, NeonResult},
-    types::{extract::{TryFromJs, TryIntoJs}, JsFunction, JsObject, JsValue, Value},
+    types::{
+        extract::{TryFromJs, TryIntoJs},
+        JsFunction, JsObject, JsValue, Value,
+    },
 };
 
 pub(crate) mod private;
@@ -41,8 +44,9 @@ impl<'a, 'cx: 'a, C: Context<'cx>> BindOptions<'a, 'cx, C> {
 
     /// Add an argument to the arguments list, computed from a closure.
     pub fn arg_with<R, F>(&mut self, f: F) -> NeonResult<&mut Self>
-      where R: TryIntoJs<'cx>,
-            F: FnOnce(&mut C) -> NeonResult<R>
+    where
+        R: TryIntoJs<'cx>,
+        F: FnOnce(&mut C) -> NeonResult<R>,
     {
         let v = f(self.cx)?.try_into_js(self.cx)?;
         self.args.push(v.upcast());

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     object::Object,
     result::{JsResult, NeonResult},
     types::{
-        extract::{TryFromJs, TryIntoJs},
+        extract::{TryFromJs, TryIntoJs, With},
         private::ValueInternal,
         JsFunction, JsObject, JsValue, Value,
     },
@@ -198,6 +198,23 @@ impl<'cx> private::TryIntoArgumentsInternal<'cx> for () {
     fn try_into_args_vec(self, _cx: &mut Cx<'cx>) -> NeonResult<private::ArgsVec<'cx>> {
         Ok(smallvec![])
     }
+}
+
+impl<'cx, F, O> private::TryIntoArgumentsInternal<'cx> for With<F, O>
+where
+    F: FnOnce(&mut Cx) -> O,
+    O: private::TryIntoArgumentsInternal<'cx>,
+{
+    fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<private::ArgsVec<'cx>> {
+        (self.0)(cx).try_into_args_vec(cx)
+    }
+}
+
+impl<'cx, F, O> TryIntoArguments<'cx> for With<F, O>
+where
+    F: FnOnce(&mut Cx) -> O,
+    O: TryIntoArguments<'cx>,
+{
 }
 
 macro_rules! impl_into_arguments_expand {

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -15,6 +15,20 @@ use crate::{
 
 pub(crate) mod private;
 
+/// A builder for making a JavaScript function call like `parseInt("42")`.
+///
+/// The builder methods make it convenient to assemble the call from parts:
+/// ```
+/// # use neon::prelude::*;
+/// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
+/// # let parse_int: Handle<JsFunction> = cx.global("parseInt")?;
+/// let x: f64 = parse_int
+///     .bind(&mut cx)
+///     .arg("42")?
+///     .apply()?;
+/// # Ok(cx.number(x))
+/// # }
+/// ```
 pub struct BindOptions<'a, 'cx: 'a, C: Context<'cx>> {
     pub(crate) cx: &'a mut C,
     pub(crate) callee: Handle<'cx, JsFunction>,

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -40,9 +40,10 @@ pub struct BindOptions<'a, 'cx: 'a> {
 
 impl<'a, 'cx: 'a> BindOptions<'a, 'cx> {
     /// Set the value of `this` for the function call.
-    pub fn this<V: Value>(&mut self, this: Handle<'cx, V>) -> &mut Self {
-        self.this = Some(this.upcast());
-        self
+    pub fn this<T: TryIntoJs<'cx>>(&mut self, this: T) -> NeonResult<&mut Self> {
+        let v = this.try_into_js(self.cx)?;
+        self.this = Some(v.upcast());
+        Ok(self)
     }
 
     /// Replaces the arguments list with the given arguments.

--- a/crates/neon/src/types_impl/function/private.rs
+++ b/crates/neon/src/types_impl/function/private.rs
@@ -1,8 +1,13 @@
 use smallvec::SmallVec;
 
-use crate::{handle::Handle, types::JsValue};
+use crate::{context::Context, handle::Handle, result::NeonResult, types::JsValue};
 
 pub type ArgsVec<'a> = SmallVec<[Handle<'a, JsValue>; 8]>;
+
+/// This type marks the `TryIntoArguments` trait as sealed.
+pub trait TryIntoArgumentsInternal<'cx> {
+    fn try_into_args_vec<C: Context<'cx>>(self, cx: &mut C) -> NeonResult<ArgsVec<'cx>>;
+}
 
 /// This type marks the `Arguments` trait as sealed.
 pub trait ArgumentsInternal<'a> {

--- a/crates/neon/src/types_impl/function/private.rs
+++ b/crates/neon/src/types_impl/function/private.rs
@@ -1,12 +1,12 @@
 use smallvec::SmallVec;
 
-use crate::{context::Context, handle::Handle, result::NeonResult, types::JsValue};
+use crate::{context::Cx, handle::Handle, result::NeonResult, types::JsValue};
 
 pub type ArgsVec<'a> = SmallVec<[Handle<'a, JsValue>; 8]>;
 
 /// This type marks the `TryIntoArguments` trait as sealed.
 pub trait TryIntoArgumentsInternal<'cx> {
-    fn try_into_args_vec<C: Context<'cx>>(self, cx: &mut C) -> NeonResult<ArgsVec<'cx>>;
+    fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<ArgsVec<'cx>>;
 }
 
 /// This type marks the `Arguments` trait as sealed.

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -342,16 +342,12 @@ impl ValueInternal for JsNull {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-/// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
-///
 /// // The two Boolean values:
 /// let t = cx.boolean(true);
 /// let f = cx.boolean(false);
 ///
 /// // Call console.log(true, false):
-/// log.call_with(&cx).arg(t).arg(f).exec(&mut cx)?;
+/// cx.global::<JsObject>("console")?.method(&mut cx, "log")?.args((t, f))?.exec()?;
 /// # Ok(cx.undefined())
 /// # }
 /// ```
@@ -419,15 +415,11 @@ impl ValueInternal for JsBoolean {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-/// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
-///
 /// // Create a string:
 /// let s = cx.string("hello 🥹");
 ///
 /// // Call console.log(s):
-/// log.call_with(&cx).arg(s).exec(&mut cx)?;
+/// cx.global::<JsObject>("console")?.method(&mut cx, "log")?.arg(s)?.exec()?;
 /// # Ok(cx.undefined())
 /// # }
 /// ```
@@ -696,15 +688,11 @@ impl JsString {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-/// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
-///
 /// // Create a number:
 /// let n = cx.number(17.0);
 ///
 /// // Call console.log(n):
-/// log.call_with(&cx).arg(n).exec(&mut cx)?;
+/// cx.global::<JsObject>("console")?.method(&mut cx, "log")?.arg(n)?.exec()?;
 /// # Ok(cx.undefined())
 /// # }
 /// ```
@@ -772,10 +760,6 @@ impl ValueInternal for JsNumber {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-/// // Extract the console.log function:
-/// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
-///
 /// // Create an object:
 /// let obj = cx.empty_object()
 ///     .prop(&mut cx, "name")
@@ -785,7 +769,7 @@ impl ValueInternal for JsNumber {
 ///     .this();
 ///
 /// // Call console.log(obj):
-/// log.call_with(&cx).arg(obj).exec(&mut cx)?;
+/// cx.global::<JsObject>("console")?.method(&mut cx, "log")?.arg(obj)?.exec()?;
 /// # Ok(cx.undefined())
 /// # }
 /// ```
@@ -975,7 +959,7 @@ impl Object for JsArray {}
 /// ## Calling functions
 ///
 /// Neon provides a convenient syntax for calling JavaScript functions with the
-/// [`call_with()`](JsFunction::call_with) method, which produces a [`CallOptions`](CallOptions)
+/// [`bind()`](JsFunction::bind) method, which produces a [`BindOptions`](BindOptions)
 /// struct that can be used to provide the function arguments (and optionally, the binding for
 /// `this`) before calling the function:
 /// ```
@@ -986,9 +970,9 @@ impl Object for JsArray {}
 ///
 /// // Call parseInt("42")
 /// let x: Handle<JsNumber> = parse_int
-///     .call_with(&mut cx)
-///     .arg(cx.string("42"))
-///     .apply(&mut cx)?;
+///     .bind(&mut cx)
+///     .arg("42")?
+///     .call()?;
 /// # Ok(x)
 /// # }
 /// ```
@@ -997,7 +981,7 @@ impl Object for JsArray {}
 ///
 /// A `JsFunction` can be called as a constructor (like `new Array(16)` or
 /// `new URL("https://neon-bindings.com")`) with the
-/// [`construct_with()`](JsFunction::construct_with) method:
+/// [`construct()`](BindOptions::construct) method:
 /// ```
 /// # use neon::prelude::*;
 /// # fn foo(mut cx: FunctionContext) -> JsResult<JsObject> {
@@ -1006,9 +990,9 @@ impl Object for JsArray {}
 ///
 /// // Call new URL("https://neon-bindings.com")
 /// let obj = url
-///     .construct_with(&cx)
-///     .arg(cx.string("https://neon-bindings.com"))
-///     .apply(&mut cx)?;
+///     .bind(&mut cx)
+///     .arg("https://neon-bindings.com")?
+///     .construct()?;
 /// # Ok(obj)
 /// # }
 /// ```

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -343,7 +343,7 @@ impl ValueInternal for JsNull {
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
 /// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
+/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
 ///
 /// // The two Boolean values:
 /// let t = cx.boolean(true);
@@ -420,7 +420,7 @@ impl ValueInternal for JsBoolean {
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
 /// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
+/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
 ///
 /// // Create a string:
 /// let s = cx.string("hello 🥹");
@@ -697,7 +697,7 @@ impl JsString {
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
 /// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
+/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
 ///
 /// // Create a number:
 /// let n = cx.number(17.0);
@@ -773,16 +773,15 @@ impl ValueInternal for JsNumber {
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 /// // Extract the console.log function:
 /// let console: Handle<JsObject> = cx.global("console")?;
-/// let log: Handle<JsFunction> = console.get(&mut cx, "log")?;
+/// let log: Handle<JsFunction> = console.prop(&mut cx, "log").get()?;
 ///
 /// // Create an object:
-/// let obj = cx.empty_object();
-///
-/// let name = cx.string("Neon");
-/// obj.set(&mut cx, "name", name)?;
-///
-/// let url = cx.string("https://neon-bindings.com");
-/// obj.set(&mut cx, "url", url)?;
+/// let obj = cx.empty_object()
+///     .prop(&mut cx, "name")
+///     .set("Neon")?
+///     .prop("url")
+///     .set("https://neon-bindings.com")?
+///     .this();
 ///
 /// // Call console.log(obj):
 /// log.call_with(&cx).arg(obj).exec(&mut cx)?;
@@ -860,13 +859,9 @@ impl JsObject {
 /// // Create a new empty array:
 /// let a: Handle<JsArray> = cx.empty_array();
 ///
-/// // Create some new values to push onto the array:
-/// let n = cx.number(17);
-/// let s = cx.string("hello");
-///
-/// // Push the elements onto the array:
-/// a.set(&mut cx, 0, n)?;
-/// a.set(&mut cx, 1, s)?;
+/// // Push some values onto the array:
+/// a.prop(&mut cx, 0).set(17)?;
+/// a.prop(&mut cx, 1).set("hello")?;
 /// # Ok(a)
 /// # }
 /// ```

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     result::{JsResult, NeonResult, ResultExt, Throw},
     sys::{self, raw},
     types::{
-        function::{CallOptions, ConstructOptions},
+        function::{BindOptions, CallOptions, ConstructOptions},
         private::ValueInternal,
         utf8::Utf8,
     },
@@ -1208,6 +1208,17 @@ impl JsFunction {
         build(cx.env(), |out| unsafe {
             sys::fun::construct(out, env, self.to_local(), argc, argv)
         })
+    }
+}
+
+impl JsFunction {
+    pub fn bind<'a, 'cx: 'a, C: Context<'cx>>(&self, cx: &'a mut C) -> BindOptions<'a, 'cx, C> {
+        BindOptions {
+            cx,
+            callee: Handle::new_internal(unsafe { self.clone() }),
+            this: None,
+            args: smallvec![],
+        }
     }
 }
 

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1136,6 +1136,7 @@ impl JsFunction {
     /// Calls this function.
     ///
     /// **See also:** [`JsFunction::call_with`].
+    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
     pub fn call<'a, 'b, C: Context<'a>, T, AS>(
         &self,
         cx: &mut C,
@@ -1152,6 +1153,7 @@ impl JsFunction {
     /// Calls this function for side effect, discarding its result.
     ///
     /// **See also:** [`JsFunction::call_with`].
+    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
     pub fn exec<'a, 'b, C: Context<'a>, T, AS>(
         &self,
         cx: &mut C,
@@ -1169,6 +1171,7 @@ impl JsFunction {
     /// Calls this function as a constructor.
     ///
     /// **See also:** [`JsFunction::construct_with`].
+    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
     pub fn construct<'a, 'b, C: Context<'a>, AS>(
         &self,
         cx: &mut C,
@@ -1199,6 +1202,7 @@ impl JsFunction {
 
 impl JsFunction {
     /// Create a [`CallOptions`](function::CallOptions) for calling this function.
+    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
     pub fn call_with<'a, C: Context<'a>>(&self, _cx: &C) -> CallOptions<'a> {
         CallOptions {
             this: None,
@@ -1213,6 +1217,7 @@ impl JsFunction {
 
     /// Create a [`ConstructOptions`](function::ConstructOptions) for calling this function
     /// as a constructor.
+    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
     pub fn construct_with<'a, C: Context<'a>>(&self, _cx: &C) -> ConstructOptions<'a> {
         ConstructOptions {
             // # Safety

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1179,11 +1179,8 @@ where
     );
 
     match status {
-        sys::Status::InvalidArg => {
-            if !sys::tag::is_function(env.to_raw(), callee) {
-                return cx.throw_error("not a function");
-            }
-            panic!("invalid argument");
+        sys::Status::InvalidArg if !sys::tag::is_function(env.to_raw(), callee) => {
+            return cx.throw_error("not a function");
         }
         sys::Status::PendingException => {
             return Err(Throw::new());

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1251,9 +1251,10 @@ impl JsFunction {
 
 impl JsFunction {
     pub fn bind<'a, 'cx: 'a>(&self, cx: &'a mut Cx<'cx>) -> BindOptions<'a, 'cx> {
+        let callee = self.as_value(cx);
         BindOptions {
             cx,
-            callee: Handle::new_internal(JsValue(self.to_local())),
+            callee,
             this: None,
             args: smallvec![],
         }

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1173,6 +1173,20 @@ impl JsFunction {
 }
 
 impl JsFunction {
+    /// Create a [`BindOptions`] builder for calling this function.
+    ///
+    /// The builder methods make it convenient to assemble the call from parts:
+    /// ```
+    /// # use neon::prelude::*;
+    /// # fn foo(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    /// # let parse_int: Handle<JsFunction> = cx.global("parseInt")?;
+    /// let x: f64 = parse_int
+    ///     .bind(&mut cx)
+    ///     .arg("42")?
+    ///     .call()?;
+    /// # Ok(cx.number(x))
+    /// # }
+    /// ```
     pub fn bind<'a, 'cx: 'a>(&self, cx: &'a mut Cx<'cx>) -> BindOptions<'a, 'cx> {
         let callee = self.as_value(cx);
         BindOptions {

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -16,7 +16,10 @@ pub(crate) mod private;
 pub(crate) mod utf8;
 
 use std::{
-    any, fmt::{self, Debug}, mem::MaybeUninit, os::raw::c_void
+    any,
+    fmt::{self, Debug},
+    mem::MaybeUninit,
+    os::raw::c_void,
 };
 
 use smallvec::smallvec;
@@ -1156,7 +1159,7 @@ pub(crate) unsafe fn call_local<'a, 'b, C: Context<'a>, T, AS>(
     cx: &mut C,
     callee: raw::Local,
     this: Handle<'b, T>,
-    args: AS
+    args: AS,
 ) -> JsResult<'a, JsValue>
 where
     T: Value,
@@ -1173,7 +1176,7 @@ where
         argc as usize,
         argv.cast(),
         result.as_mut_ptr(),
-     );
+    );
 
     match status {
         sys::Status::FunctionExpected => {
@@ -1187,7 +1190,10 @@ where
         }
     }
 
-    Ok(Handle::new_internal(JsValue::from_local(env, result.assume_init())))
+    Ok(Handle::new_internal(JsValue::from_local(
+        env,
+        result.assume_init(),
+    )))
 }
 
 impl JsFunction {
@@ -1204,9 +1210,7 @@ impl JsFunction {
         T: Value,
         AS: AsRef<[Handle<'b, JsValue>]>,
     {
-        unsafe {
-            call_local(cx, self.to_local(), this, args)
-        }
+        unsafe { call_local(cx, self.to_local(), this, args) }
     }
 
     /// Calls this function for side effect, discarding its result.

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -208,7 +208,7 @@ impl JsValue {
 /// let undefined = cx.undefined();
 ///
 /// // Call console.log(undefined):
-/// console.call_method_with(&mut cx, "log")?.arg(undefined).exec(&mut cx)?;
+/// console.method(&mut cx, "log")?.arg(undefined)?.exec()?;
 /// # Ok(undefined)
 /// # }
 /// ```
@@ -273,11 +273,12 @@ impl ValueInternal for JsUndefined {
 /// ```
 /// # use neon::prelude::*;
 /// # fn test(mut cx: FunctionContext) -> JsResult<JsNull> {
+/// let null = cx.null();
 /// cx.global::<JsObject>("console")?
-///     .call_method_with(&mut cx, "log")?
-///     .arg(cx.null())
-///     .exec(&mut cx)?;
-/// # Ok(cx.null())
+///     .method(&mut cx, "log")?
+///     .arg(null)?
+///     .exec()?;
+/// # Ok(null)
 /// # }
 /// ```
 #[derive(Debug)]

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1179,8 +1179,11 @@ where
     );
 
     match status {
-        sys::Status::FunctionExpected => {
-            return cx.throw_type_error("not a function");
+        sys::Status::InvalidArg => {
+            if !sys::tag::is_function(env.to_raw(), callee) {
+                return cx.throw_error("not a function");
+            }
+            panic!("invalid argument");
         }
         sys::Status::PendingException => {
             return Err(Throw::new());

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1051,7 +1051,7 @@ const V8_ARGC_LIMIT: usize = 65535;
 unsafe fn prepare_call<'a, 'b, C: Context<'a>>(
     cx: &mut C,
     args: &[Handle<'b, JsValue>],
-) -> NeonResult<(i32, *const c_void)> {
+) -> NeonResult<(usize, *const c_void)> {
     // Note: This cast is only save because `Handle<'_, JsValue>` is
     // guaranteed to have the same layout as a pointer because `Handle`
     // and `JsValue` are both `repr(C)` newtypes.
@@ -1060,7 +1060,7 @@ unsafe fn prepare_call<'a, 'b, C: Context<'a>>(
     if argc > V8_ARGC_LIMIT {
         return cx.throw_range_error("too many arguments");
     }
-    Ok((argc as i32, argv))
+    Ok((argc, argv))
 }
 
 impl JsFunction {
@@ -1173,7 +1173,7 @@ where
         env.to_raw(),
         this.to_local(),
         callee,
-        argc as usize,
+        argc,
         argv.cast(),
         result.as_mut_ptr(),
     );

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -24,7 +24,7 @@ use std::{
 use smallvec::smallvec;
 
 use crate::{
-    context::{internal::Env, Context, FunctionContext},
+    context::{internal::Env, Context, Cx, FunctionContext},
     handle::{
         internal::{SuperType, TransparentNoCopyWrapper},
         Handle,
@@ -1227,7 +1227,7 @@ impl JsFunction {
 }
 
 impl JsFunction {
-    pub fn bind<'a, 'cx: 'a, C: Context<'cx>>(&self, cx: &'a mut C) -> BindOptions<'a, 'cx, C> {
+    pub fn bind<'a, 'cx: 'a>(&self, cx: &'a mut Cx<'cx>) -> BindOptions<'a, 'cx> {
         BindOptions {
             cx,
             callee: Handle::new_internal(JsValue(self.to_local())),

--- a/crates/neon/src/types_impl/private.rs
+++ b/crates/neon/src/types_impl/private.rs
@@ -77,21 +77,54 @@ pub trait ValueInternal: TransparentNoCopyWrapper + 'static {
             result.as_mut_ptr(),
         );
 
-        match status {
-            sys::Status::InvalidArg if !sys::tag::is_function(env.to_raw(), callee) => {
-                return cx.throw_error("not a function");
-            }
-            sys::Status::PendingException => {
-                return Err(Throw::new());
-            }
-            status => {
-                assert_eq!(status, sys::Status::Ok);
-            }
-        }
+        check_call_status(cx, callee, status)?;
 
         Ok(Handle::new_internal(JsValue::from_local(
             env,
             result.assume_init(),
         )))
     }
+
+    unsafe fn try_construct<'a, 'b, C: Context<'a>, AS>(
+        &self,
+        cx: &mut C,
+        args: AS,
+    ) -> JsResult<'a, JsValue>
+    where
+        AS: AsRef<[Handle<'b, JsValue>]>,
+    {
+        let callee = self.to_local();
+        let (argc, argv) = unsafe { prepare_call(cx, args.as_ref()) }?;
+        let env = cx.env();
+        let mut result: MaybeUninit<raw::Local> = MaybeUninit::zeroed();
+        let status =
+            napi::new_instance(env.to_raw(), callee, argc, argv.cast(), result.as_mut_ptr());
+
+        check_call_status(cx, callee, status)?;
+
+        Ok(Handle::new_internal(JsValue::from_local(
+            env,
+            result.assume_init(),
+        )))
+    }
+}
+
+unsafe fn check_call_status<'a, C: Context<'a>>(
+    cx: &mut C,
+    callee: raw::Local,
+    status: sys::Status,
+) -> NeonResult<()> {
+    match status {
+        sys::Status::InvalidArg if !sys::tag::is_function(cx.env().to_raw(), callee) => {
+            return cx.throw_error("not a function");
+        }
+        sys::Status::PendingException => {
+            return Err(Throw::new());
+        }
+        status => {
+            assert_eq!(status, sys::Status::Ok);
+        }
+    }
+
+    Ok(())
 }

--- a/crates/neon/src/types_impl/promise.rs
+++ b/crates/neon/src/types_impl/promise.rs
@@ -123,10 +123,12 @@ const BOUNDARY: FailureBoundary = FailureBoundary {
 ///         .promise(|mut cx, (indices, kinds)| {
 ///             let indices = JsUint32Array::from_slice(&mut cx, &indices)?;
 ///             let kinds = JsUint8Array::from_slice(&mut cx, &kinds)?;
-///             let result = cx.empty_object();
-///             result.set(&mut cx, "indices", indices)?;
-///             result.set(&mut cx, "kinds", kinds)?;
-///             Ok(result)
+///             Ok(cx.empty_object()
+///                 .prop(&mut cx, "indices")
+///                 .set(indices)?
+///                 .prop("kinds")
+///                 .set(kinds)?
+///                 .this())
 ///         });
 ///
 ///     Ok(promise)

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -28,6 +28,15 @@ describe("JsFunction", function () {
     );
   });
 
+  it("call a JsFunction built in JS with .bind().apply()", function () {
+    assert.equal(
+      addon.call_js_function_with_bind(function (a, b, c, d, e) {
+        return a * b * c * d * e;
+      }),
+      (1 * 2 * 3 * 4 * 5)
+    );
+  });
+
   it("call a JsFunction with zero args", function () {
     assert.equal(addon.call_js_function_with_zero_args(), -Infinity);
   });

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -1,8 +1,11 @@
 var addon = require("..");
 var assert = require("chai").assert;
 
-const STRICT = function() { "use strict"; return this; };
-const SLOPPY = Function('return this;');
+const STRICT = function () {
+  "use strict";
+  return this;
+};
+const SLOPPY = Function("return this;");
 
 function isStrict(f) {
   try {
@@ -61,7 +64,7 @@ describe("JsFunction", function () {
     assert.equal(result, 42);
   });
 
-  it("bind a strict JsFunction to a number", function() {
+  it("bind a strict JsFunction to a number", function () {
     assert.isTrue(isStrict(STRICT));
 
     // strict mode functions are allowed to have a primitive this binding
@@ -70,7 +73,7 @@ describe("JsFunction", function () {
     assert.strictEqual(result, 42);
   });
 
-  it("bind a sloppy JsFunction to a primitive", function() {
+  it("bind a sloppy JsFunction to a primitive", function () {
     assert.isFalse(isStrict(SLOPPY));
 
     // legacy JS functions (aka "sloppy mode") replace primitive this bindings
@@ -78,7 +81,7 @@ describe("JsFunction", function () {
     const result = addon.bind_js_function_to_number(SLOPPY);
 
     assert.instanceOf(result, Number);
-    assert.strictEqual(typeof result, 'object');
+    assert.strictEqual(typeof result, "object");
     assert.strictEqual(result.valueOf(), 42);
   });
 

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -52,6 +52,24 @@ describe("JsFunction", function () {
     );
   });
 
+  it("call a JsFunction build in JS with .bind and .args_with", function () {
+    assert.equal(
+      addon.call_js_function_with_bind_and_args_with(function (a, b, c) {
+        return a + b + c;
+      }),
+      1 + 2 + 3
+    );
+  });
+
+  it("call a JsFunction build in JS with .bind and .args and With", function () {
+    assert.equal(
+      addon.call_js_function_with_bind_and_args_and_with(function (a, b, c) {
+        return a + b + c;
+      }),
+      1 + 2 + 3
+    );
+  });
+
   it("call parseInt with .bind().apply()", function () {
     assert.equal(addon.call_parse_int_with_bind(), 42);
   });

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -33,7 +33,7 @@ describe("JsFunction", function () {
       addon.call_js_function_with_bind(function (a, b, c, d, e) {
         return a * b * c * d * e;
       }),
-      (1 * 2 * 3 * 4 * 5)
+      1 * 2 * 3 * 4 * 5
     );
   });
 

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -37,6 +37,10 @@ describe("JsFunction", function () {
     );
   });
 
+  it("call parseInt with .bind().apply()", function () {
+    assert.equal(addon.call_parse_int_with_bind(), 42);
+  });
+
   it("call a JsFunction with zero args", function () {
     assert.equal(addon.call_js_function_with_zero_args(), -Infinity);
   });

--- a/test/napi/lib/functions.js
+++ b/test/napi/lib/functions.js
@@ -74,6 +74,27 @@ describe("JsFunction", function () {
     assert.equal(addon.call_parse_int_with_bind(), 42);
   });
 
+  it("call a JsFunction built in JS with .bind and .exec", function () {
+    let local = 41;
+    addon.call_js_function_with_bind_and_exec(function (x) {
+      local += x;
+    });
+    assert.equal(local, 42);
+  });
+
+  it("call a JsFunction built in JS as a constructor with .bind and .construct", function () {
+    function MyClass(number, string) {
+      this.number = number;
+      this.string = string;
+    }
+
+    const obj = addon.call_js_constructor_with_bind(MyClass);
+
+    assert.instanceOf(obj, MyClass);
+    assert.equal(obj.number, 42);
+    assert.equal(obj.string, "hello");
+  });
+
   it("bind a JsFunction to an object", function () {
     const result = addon.bind_js_function_to_object(function () {
       return this.prop;

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -157,4 +157,12 @@ describe("JsObject", function () {
     );
     assert.strictEqual(obj.toString(), "[object Wonder Woman]");
   });
+
+  it("throws a TypeError when calling a non-method with .prop()", function () {
+    const obj = {
+      number: 42
+    };
+
+    assert.throws(() => { addon.call_non_method_with_prop(obj) }, /failed to downcast/);
+  });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -152,7 +152,7 @@ describe("JsObject", function () {
 
     assert.strictEqual(obj.toString(), "[object Diana Prince]");
     assert.strictEqual(
-      addon.call_method_with_prop(obj),
+      addon.call_methods_with_prop(obj),
       "[object Wonder Woman]"
     );
     assert.strictEqual(obj.toString(), "[object Wonder Woman]");

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -165,6 +165,6 @@ describe("JsObject", function () {
 
     assert.throws(() => {
       addon.call_non_method_with_prop(obj);
-    }, /failed to downcast/);
+    }, /not a function/);
   });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -124,4 +124,37 @@ describe("JsObject", function () {
 
     assert.strictEqual(addon.call_symbol_method(obj, sym), "hello");
   });
+
+  it("extracts an object property with .prop()", function () {
+    const obj = { number: 3.141593 };
+
+    assert.strictEqual(addon.get_property_with_prop(obj), 3.141593);
+  });
+
+  it("sets an object property with .prop()", function () {
+    const obj = { number: 3.141593 };
+
+    addon.set_property_with_prop(obj);
+
+    assert.strictEqual(obj.number, 42);
+  });
+
+  it("calls a method with .prop()", function () {
+    const obj = {
+      name: "Diana Prince",
+      setName(name) {
+        this.name = name;
+      },
+      toString() {
+        return `[object ${this.name}]`;
+      },
+    };
+
+    assert.strictEqual(obj.toString(), "[object Diana Prince]");
+    assert.strictEqual(
+      addon.call_method_with_prop(obj),
+      "[object Wonder Woman]"
+    );
+    assert.strictEqual(obj.toString(), "[object Wonder Woman]");
+  });
 });

--- a/test/napi/lib/objects.js
+++ b/test/napi/lib/objects.js
@@ -160,9 +160,11 @@ describe("JsObject", function () {
 
   it("throws a TypeError when calling a non-method with .prop()", function () {
     const obj = {
-      number: 42
+      number: 42,
     };
 
-    assert.throws(() => { addon.call_non_method_with_prop(obj) }, /failed to downcast/);
+    assert.throws(() => {
+      addon.call_non_method_with_prop(obj);
+    }, /failed to downcast/);
   });
 });

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -43,6 +43,18 @@ pub fn call_parse_int_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber> {
     Ok(cx.number(x + 1.0))
 }
 
+pub fn bind_js_function_to_object(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let f = cx.argument::<JsFunction>(0)?;
+    let obj = cx.empty_object();
+    obj.prop(&mut cx, "prop").set(42)?;
+    f.bind(&mut cx).this(obj)?.apply()
+}
+
+pub fn bind_js_function_to_number(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let f = cx.argument::<JsFunction>(0)?;
+    f.bind(&mut cx).this(42)?.apply()
+}
+
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {
     let math: Handle<JsObject> = cx.global("Math")?;
     let max: Handle<JsFunction> = math.get(cx, "max")?;

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -26,6 +26,17 @@ pub fn call_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<JsNum
         .apply(&mut cx)
 }
 
+pub fn call_js_function_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let f = cx.argument::<JsFunction>(0)?;
+    let n: f64 = f
+        .bind(&mut cx)
+        .args((1, 2, 3))?
+        .arg(4)?
+        .arg_with(|cx| Ok(cx.number(5)))?
+        .apply()?;
+    Ok(cx.number(n))
+}
+
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {
     let math: Handle<JsObject> = cx.global("Math")?;
     let max: Handle<JsFunction> = math.get(cx, "max")?;

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -33,7 +33,7 @@ pub fn call_js_function_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber>
         .args((1, 2, 3))?
         .arg(4)?
         .arg_with(|cx| cx.number(5))?
-        .apply()?;
+        .call()?;
     Ok(cx.number(n))
 }
 
@@ -42,7 +42,7 @@ pub fn call_js_function_with_bind_and_args_with(mut cx: FunctionContext) -> JsRe
         .argument::<JsFunction>(0)?
         .bind(&mut cx)
         .args_with(|_| (1, 2, 3))?
-        .apply()?;
+        .call()?;
     Ok(cx.number(n))
 }
 
@@ -51,13 +51,13 @@ pub fn call_js_function_with_bind_and_args_and_with(mut cx: FunctionContext) -> 
         .argument::<JsFunction>(0)?
         .bind(&mut cx)
         .args(With(|_| (1, 2, 3)))?
-        .apply()?;
+        .call()?;
     Ok(cx.number(n))
 }
 
 pub fn call_parse_int_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let parse_int: Handle<JsFunction> = cx.global("parseInt")?;
-    let x: f64 = parse_int.bind(&mut cx).arg("41")?.apply()?;
+    let x: f64 = parse_int.bind(&mut cx).arg("41")?.call()?;
     Ok(cx.number(x + 1.0))
 }
 
@@ -65,12 +65,12 @@ pub fn bind_js_function_to_object(mut cx: FunctionContext) -> JsResult<JsValue> 
     let f = cx.argument::<JsFunction>(0)?;
     let obj = cx.empty_object();
     obj.prop(&mut cx, "prop").set(42)?;
-    f.bind(&mut cx).this(obj)?.apply()
+    f.bind(&mut cx).this(obj)?.call()
 }
 
 pub fn bind_js_function_to_number(mut cx: FunctionContext) -> JsResult<JsValue> {
     let f = cx.argument::<JsFunction>(0)?;
-    f.bind(&mut cx).this(42)?.apply()
+    f.bind(&mut cx).this(42)?.call()
 }
 
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -41,7 +41,7 @@ pub fn call_js_function_with_bind_and_args_with(mut cx: FunctionContext) -> JsRe
     let n: f64 = cx
         .argument::<JsFunction>(0)?
         .bind(&mut cx)
-        .args_with(|cx| (1, 2, 3))?
+        .args_with(|_| (1, 2, 3))?
         .apply()?;
     Ok(cx.number(n))
 }

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -32,7 +32,7 @@ pub fn call_js_function_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber>
         .bind(&mut cx)
         .args((1, 2, 3))?
         .arg(4)?
-        .arg_with(|cx| Ok(cx.number(5)))?
+        .arg_with(|cx| cx.number(5))?
         .apply()?;
     Ok(cx.number(n))
 }

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -1,4 +1,4 @@
-use neon::prelude::*;
+use neon::{prelude::*, types::extract::With};
 
 fn add1(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let x = cx.argument::<JsNumber>(0)?.value(&mut cx);
@@ -33,6 +33,24 @@ pub fn call_js_function_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber>
         .args((1, 2, 3))?
         .arg(4)?
         .arg_with(|cx| cx.number(5))?
+        .apply()?;
+    Ok(cx.number(n))
+}
+
+pub fn call_js_function_with_bind_and_args_with(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let n: f64 = cx
+        .argument::<JsFunction>(0)?
+        .bind(&mut cx)
+        .args_with(|cx| (1, 2, 3))?
+        .apply()?;
+    Ok(cx.number(n))
+}
+
+pub fn call_js_function_with_bind_and_args_and_with(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let n: f64 = cx
+        .argument::<JsFunction>(0)?
+        .bind(&mut cx)
+        .args(With(|_| (1, 2, 3)))?
         .apply()?;
     Ok(cx.number(n))
 }

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -61,6 +61,18 @@ pub fn call_parse_int_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber> {
     Ok(cx.number(x + 1.0))
 }
 
+pub fn call_js_function_with_bind_and_exec(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    cx.argument::<JsFunction>(0)?.bind(&mut cx).arg(1)?.exec()?;
+    Ok(cx.undefined())
+}
+
+pub fn call_js_constructor_with_bind(mut cx: FunctionContext) -> JsResult<JsObject> {
+    cx.argument::<JsFunction>(0)?
+        .bind(&mut cx)
+        .args((42, "hello"))?
+        .construct()
+}
+
 pub fn bind_js_function_to_object(mut cx: FunctionContext) -> JsResult<JsValue> {
     let f = cx.argument::<JsFunction>(0)?;
     let obj = cx.empty_object();

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -27,14 +27,20 @@ pub fn call_js_function_idiomatically(mut cx: FunctionContext) -> JsResult<JsNum
 }
 
 pub fn call_js_function_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber> {
-    let f = cx.argument::<JsFunction>(0)?;
-    let n: f64 = f
+    let n: f64 = cx
+        .argument::<JsFunction>(0)?
         .bind(&mut cx)
         .args((1, 2, 3))?
         .arg(4)?
         .arg_with(|cx| Ok(cx.number(5)))?
         .apply()?;
     Ok(cx.number(n))
+}
+
+pub fn call_parse_int_with_bind(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let parse_int: Handle<JsFunction> = cx.global("parseInt")?;
+    let x: f64 = parse_int.bind(&mut cx).arg("41")?.apply()?;
+    Ok(cx.number(x + 1.0))
 }
 
 fn get_math_max<'a>(cx: &mut FunctionContext<'a>) -> JsResult<'a, JsFunction> {

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -102,10 +102,10 @@ pub fn get_property_with_prop(mut cx: FunctionContext) -> JsResult<JsNumber> {
     Ok(cx.number(n))
 }
 
-pub fn set_property_with_prop(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+pub fn set_property_with_prop(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
-    let b = obj.prop(&mut cx, "number").set(42)?;
-    Ok(cx.boolean(b))
+    obj.prop(&mut cx, "number").set(42)?;
+    Ok(cx.undefined())
 }
 
 pub fn call_methods_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -95,3 +95,24 @@ pub fn call_symbol_method(mut cx: FunctionContext) -> JsResult<JsString> {
     let sym: Handle<JsValue> = cx.argument::<JsValue>(1)?;
     obj.call_method_with(&mut cx, sym)?.apply(&mut cx)
 }
+
+pub fn get_property_with_prop(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    let n: f64 = obj.prop(&mut cx, "number").get()?;
+    Ok(cx.number(n))
+}
+
+pub fn set_property_with_prop(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    let b = obj.prop(&mut cx, "number").set(42)?;
+    Ok(cx.boolean(b))
+}
+
+pub fn call_method_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    obj.prop(&mut cx, "setName")
+        .bind()?
+        .arg("Wonder Woman")?
+        .apply()?;
+    obj.prop(&mut cx, "toString").bind()?.apply()
+}

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -116,3 +116,11 @@ pub fn call_methods_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {
         .apply()?;
     obj.prop(&mut cx, "toString").bind()?.apply()
 }
+
+pub fn call_non_method_with_prop(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
+    obj.prop(&mut cx, "number")
+        .bind()?
+        .apply()?;
+    Ok(cx.undefined())
+}

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -108,7 +108,7 @@ pub fn set_property_with_prop(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     Ok(cx.boolean(b))
 }
 
-pub fn call_method_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {
+pub fn call_methods_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
     obj.prop(&mut cx, "setName")
         .bind()?

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -113,12 +113,12 @@ pub fn call_methods_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {
     obj.prop(&mut cx, "setName")
         .bind()?
         .arg("Wonder Woman")?
-        .apply()?;
-    obj.prop(&mut cx, "toString").bind()?.apply()
+        .call()?;
+    obj.prop(&mut cx, "toString").bind()?.call()
 }
 
 pub fn call_non_method_with_prop(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
-    obj.prop(&mut cx, "number").bind()?.apply()?;
+    obj.prop(&mut cx, "number").bind()?.call()?;
     Ok(cx.undefined())
 }

--- a/test/napi/src/js/objects.rs
+++ b/test/napi/src/js/objects.rs
@@ -119,8 +119,6 @@ pub fn call_methods_with_prop(mut cx: FunctionContext) -> JsResult<JsString> {
 
 pub fn call_non_method_with_prop(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let obj: Handle<JsObject> = cx.argument::<JsObject>(0)?;
-    obj.prop(&mut cx, "number")
-        .bind()?
-        .apply()?;
+    obj.prop(&mut cx, "number").bind()?.apply()?;
     Ok(cx.undefined())
 }

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -155,6 +155,8 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     )?;
     cx.export_function("call_js_function_with_bind", call_js_function_with_bind)?;
     cx.export_function("call_parse_int_with_bind", call_parse_int_with_bind)?;
+    cx.export_function("bind_js_function_to_object", bind_js_function_to_object)?;
+    cx.export_function("bind_js_function_to_number", bind_js_function_to_number)?;
     cx.export_function(
         "call_js_function_with_zero_args",
         call_js_function_with_zero_args,

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -154,6 +154,14 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         call_js_function_idiomatically,
     )?;
     cx.export_function("call_js_function_with_bind", call_js_function_with_bind)?;
+    cx.export_function(
+        "call_js_function_with_bind_and_args_with",
+        call_js_function_with_bind_and_args_with,
+    )?;
+    cx.export_function(
+        "call_js_function_with_bind_and_args_and_with",
+        call_js_function_with_bind_and_args_and_with,
+    )?;
     cx.export_function("call_parse_int_with_bind", call_parse_int_with_bind)?;
     cx.export_function("bind_js_function_to_object", bind_js_function_to_object)?;
     cx.export_function("bind_js_function_to_number", bind_js_function_to_number)?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -300,7 +300,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("call_symbol_method", call_symbol_method)?;
     cx.export_function("get_property_with_prop", get_property_with_prop)?;
     cx.export_function("set_property_with_prop", set_property_with_prop)?;
-    cx.export_function("call_method_with_prop", call_method_with_prop)?;
+    cx.export_function("call_methods_with_prop", call_methods_with_prop)?;
 
     cx.export_function("create_date", create_date)?;
     cx.export_function("get_date_value", get_date_value)?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -154,6 +154,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         call_js_function_idiomatically,
     )?;
     cx.export_function(
+        "call_js_function_with_bind",
+        call_js_function_with_bind
+    )?;
+    cx.export_function(
         "call_js_function_with_zero_args",
         call_js_function_with_zero_args,
     )?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -163,6 +163,14 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         call_js_function_with_bind_and_args_and_with,
     )?;
     cx.export_function("call_parse_int_with_bind", call_parse_int_with_bind)?;
+    cx.export_function(
+        "call_js_function_with_bind_and_exec",
+        call_js_function_with_bind_and_exec,
+    )?;
+    cx.export_function(
+        "call_js_constructor_with_bind",
+        call_js_constructor_with_bind,
+    )?;
     cx.export_function("bind_js_function_to_object", bind_js_function_to_object)?;
     cx.export_function("bind_js_function_to_number", bind_js_function_to_number)?;
     cx.export_function(

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -301,6 +301,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("get_property_with_prop", get_property_with_prop)?;
     cx.export_function("set_property_with_prop", set_property_with_prop)?;
     cx.export_function("call_methods_with_prop", call_methods_with_prop)?;
+    cx.export_function("call_non_method_with_prop", call_non_method_with_prop)?;
 
     cx.export_function("create_date", create_date)?;
     cx.export_function("get_date_value", get_date_value)?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -154,6 +154,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         call_js_function_idiomatically,
     )?;
     cx.export_function("call_js_function_with_bind", call_js_function_with_bind)?;
+    cx.export_function("call_parse_int_with_bind", call_parse_int_with_bind)?;
     cx.export_function(
         "call_js_function_with_zero_args",
         call_js_function_with_zero_args,
@@ -297,6 +298,9 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("call_nullary_method", call_nullary_method)?;
     cx.export_function("call_unary_method", call_unary_method)?;
     cx.export_function("call_symbol_method", call_symbol_method)?;
+    cx.export_function("get_property_with_prop", get_property_with_prop)?;
+    cx.export_function("set_property_with_prop", set_property_with_prop)?;
+    cx.export_function("call_method_with_prop", call_method_with_prop)?;
 
     cx.export_function("create_date", create_date)?;
     cx.export_function("get_date_value", get_date_value)?;

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -153,10 +153,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "call_js_function_idiomatically",
         call_js_function_idiomatically,
     )?;
-    cx.export_function(
-        "call_js_function_with_bind",
-        call_js_function_with_bind
-    )?;
+    cx.export_function("call_js_function_with_bind", call_js_function_with_bind)?;
     cx.export_function(
         "call_js_function_with_zero_args",
         call_js_function_with_zero_args,


### PR DESCRIPTION
This PR implements `JsFunction::bind()`, which creates a builder for calling a function using the `Try{From,Into}Js` traits.

```rust
let n = f.bind(&mut cx)
    .args((1, 2, 3))?
    .arg(4)?
    .arg_with(|cx| Ok(cx.number(5)))?
    .call::<f64>()?;
```

It also implements `Object::prop()`, which creates a builder for accessing object properties using the `Try{From,Into}Js` traits.

```rust
let x: f64 = obj
    .prop(&mut cx, "x")
    .get()?;

obj.prop(&mut cx, "y")
    .set(x)?;

let s: String = obj.prop(&mut cx, "toString")
    .bind()?
    .call()?;
```

Finally, it offers a shorthand convenience method `Object::method()`, which extracts an object property and binds it as a method:

```rust
let s: String = obj.method(&mut cx, "toString").call()?;
```
