### PR TITLE
improve(neon): Use autoref specialization for JSON wrapping return values in exported functions

### DIFF
--- a/crates/neon-macros/src/export/function/meta.rs
+++ b/crates/neon-macros/src/export/function/meta.rs
@@ -4,7 +4,6 @@ pub(crate) struct Meta {
     pub(super) name: Option<syn::LitStr>,
     pub(super) json: bool,
     pub(super) context: bool,
-    pub(super) result: bool,
 }
 
 #[derive(Default)]
@@ -38,12 +37,6 @@ impl Meta {
         Ok(())
     }
 
-    fn force_result(&mut self, _meta: syn::meta::ParseNestedMeta) -> syn::Result<()> {
-        self.result = true;
-
-        Ok(())
-    }
-
     fn make_task(&mut self, meta: syn::meta::ParseNestedMeta) -> syn::Result<()> {
         if self.context {
             return Err(meta.error(super::TASK_CX_ERROR));
@@ -73,10 +66,6 @@ impl syn::parse::Parser for Parser {
 
             if meta.path.is_ident("context") {
                 return attr.force_context(meta);
-            }
-
-            if meta.path.is_ident("result") {
-                return attr.force_result(meta);
             }
 
             if meta.path.is_ident("task") {

--- a/crates/neon/src/macros.rs
+++ b/crates/neon/src/macros.rs
@@ -194,21 +194,4 @@ pub use neon_macros::main;
 ///     a + b
 /// }
 /// ```
-///
-/// ### `result`
-///
-/// The `#[neon::export]` macro will infer an exported function returns a [`Result`]
-/// if the type is named [`Result`], [`NeonResult`](crate::result::NeonResult) or
-/// [`JsResult`](crate::result::JsResult).
-///
-/// If a type alias is used for [`Result`], the `result` attribute can be added to
-/// inform the generated code.
-///
-/// ```
-/// use neon::result::{NeonResult as Res};
-///
-/// fn add(a: f64, b: f64) -> Res<f64> {
-///     Ok(a + b)
-/// }
-/// ```
 pub use neon_macros::export;

--- a/crates/neon/src/sys/raw.rs
+++ b/crates/neon/src/sys/raw.rs
@@ -47,6 +47,3 @@ impl Default for EscapableHandleScope {
         Self::new()
     }
 }
-
-#[derive(Clone, Copy)]
-pub struct InheritedHandleScope;


### PR DESCRIPTION
Currently, the `#[neon::export]` macro attempts to determine if the return value is a `Result` by parsing the signature and reading the name. This is only used in combination with the `json` attribute to determine how to properly wrap with the `Json` extract helper.

However, we can leverage [autoref specialization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md) for much more reliable handling. This is *very* important for supporting [async functions](https://github.com/neon-bindings/neon/pull/1055) because we can not easily see the output type in the signature.

This PR introduces new macro hidden trait types that can be used to extract the Rust value into a JS value. The `Json` variant is specialized for `Result<T, E>` while having a blanket implementation for `&T`. Since we have an owned `self`, autoref specialization will *prefer* our specialized type and fallback to the blanket impl. 

This works because the `Serialize` trait only needs to borrow the data. However, if owned data is needed, it's possible to extend this pattern with the technique `anyhow` uses--the specialized trait takes a reference and returns a sigil that then in turn takes the owned value.