### PR TITLE
fix(neon): Fix a panic when borrowing an empty buffer or typed array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Set Matrix
         id: set_matrix
         env:
-          FULL_NODE_VERSIONS: '["18.x", "20.x", "22.x"]'
+          FULL_NODE_VERSIONS: '["18.x", "20.x"]'
           FULL_RUST_TOOLCHAINS: '["stable", "nightly"]'
-          PARTIAL_NODE_VERSIONS: '["22.x"]'
+          PARTIAL_NODE_VERSIONS: '["20.x"]'
           PARTIAL_RUST_TOOLCHAINS: '["stable"]'
           HAS_FULL_MATRIX_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'full matrix') }}
           IS_PUSHED: ${{ github.event_name == 'push' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [20.x]
         rust-toolchain: [nightly]
 
     steps:

--- a/crates/neon/src/types_impl/buffer/lock.rs
+++ b/crates/neon/src/types_impl/buffer/lock.rs
@@ -58,7 +58,9 @@ impl Ledger {
         ledger: &'a RefCell<Self>,
         data: &'a [T],
     ) -> Result<Ref<'a, T>, BorrowError> {
-        ledger.borrow_mut().try_add_borrow(data)?;
+        if !data.is_empty() {
+            ledger.borrow_mut().try_add_borrow(data)?;
+        }
 
         Ok(Ref { ledger, data })
     }
@@ -69,7 +71,9 @@ impl Ledger {
         ledger: &'a RefCell<Self>,
         data: &'a mut [T],
     ) -> Result<RefMut<'a, T>, BorrowError> {
-        ledger.borrow_mut().try_add_borrow_mut(data)?;
+        if !data.is_empty() {
+            ledger.borrow_mut().try_add_borrow_mut(data)?;
+        }
 
         Ok(RefMut { ledger, data })
     }

--- a/crates/neon/src/types_impl/buffer/mod.rs
+++ b/crates/neon/src/types_impl/buffer/mod.rs
@@ -138,6 +138,10 @@ impl<'a, T> DerefMut for RefMut<'a, T> {
 
 impl<'a, T> Drop for Ref<'a, T> {
     fn drop(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
         let mut ledger = self.ledger.borrow_mut();
         let range = Ledger::slice_to_range(self.data);
         let i = ledger.shared.iter().rposition(|r| r == &range).unwrap();
@@ -148,6 +152,10 @@ impl<'a, T> Drop for Ref<'a, T> {
 
 impl<'a, T> Drop for RefMut<'a, T> {
     fn drop(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
         let mut ledger = self.ledger.borrow_mut();
         let range = Ledger::slice_to_range(self.data);
         let i = ledger.owned.iter().rposition(|r| r == &range).unwrap();

--- a/test/napi/lib/typedarrays.js
+++ b/test/napi/lib/typedarrays.js
@@ -414,6 +414,20 @@ describe("Typed arrays", function () {
     assert.equal(b[3], 55);
   });
 
+  it("copies from a source buffer to a destination with borrow API", function () {
+    for (const f of [addon.copy_buffer, addon.copy_buffer_with_borrow]) {
+      const a = Buffer.from([1, 2, 3]);
+      const b = Buffer.from([0, 0, 0, 4, 5, 6]);
+
+      // Full
+      addon.copy_buffer(a, b);
+      assert.deepEqual([...b], [1, 2, 3, 4, 5, 6]);
+
+      // Empty buffers
+      addon.copy_buffer(Buffer.alloc(0), Buffer.alloc(0));
+    }
+  });
+
   it("zeroes the byteLength when an ArrayBuffer is detached", function () {
     var buf = new ArrayBuffer(16);
     assert.strictEqual(buf.byteLength, 16);

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -285,6 +285,8 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("read_buffer_with_borrow", read_buffer_with_borrow)?;
     cx.export_function("write_buffer_with_lock", write_buffer_with_lock)?;
     cx.export_function("write_buffer_with_borrow_mut", write_buffer_with_borrow_mut)?;
+    cx.export_function("copy_buffer", copy_buffer)?;
+    cx.export_function("copy_buffer_with_borrow", copy_buffer_with_borrow)?;
     cx.export_function("byte_length", byte_length)?;
     cx.export_function("call_nullary_method", call_nullary_method)?;
     cx.export_function("call_unary_method", call_unary_method)?;


### PR DESCRIPTION
The borrow API currently panics if trying to borrow an empty buffer. This is because the pointer will be nil.

This PR adds guards for `length != 0`. Additionally, the ledger skips adding/removing empty buffers.