### PR TITLE
change(neon): Change TryIntoJs and TryFromJs accept Cx instead of being generic over Context

### DIFF
--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -500,7 +500,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     ///
     /// ```
     /// # use neon::prelude::*;
-    /// # fn get_array_global<'cx, C: Context<'cx>>(cx: &mut C) -> JsResult<'cx, JsFunction> {
+    /// # fn get_array_global<'cx>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     /// #     let name = "Array";
     /// #     let v: Handle<JsFunction> =
     /// {

--- a/crates/neon/src/macro_internal/mod.rs
+++ b/crates/neon/src/macro_internal/mod.rs
@@ -3,7 +3,7 @@
 pub use linkme;
 
 use crate::{
-    context::{Context, ModuleContext},
+    context::{Cx, ModuleContext},
     handle::Handle,
     result::{JsResult, NeonResult},
     types::{extract::TryIntoJs, JsValue},
@@ -19,19 +19,14 @@ pub static MAIN: [for<'cx> fn(ModuleContext<'cx>) -> NeonResult<()>];
 
 // Provides an identically named method to `NeonExportReturnJson` for easy swapping in macros
 pub trait NeonExportReturnValue<'cx> {
-    fn try_neon_export_return<C>(self, cx: &mut C) -> JsResult<'cx, JsValue>
-    where
-        C: Context<'cx>;
+    fn try_neon_export_return(self, cx: &mut Cx<'cx>) -> JsResult<'cx, JsValue>;
 }
 
 impl<'cx, T> NeonExportReturnValue<'cx> for T
 where
     T: TryIntoJs<'cx>,
 {
-    fn try_neon_export_return<C>(self, cx: &mut C) -> JsResult<'cx, JsValue>
-    where
-        C: Context<'cx>,
-    {
+    fn try_neon_export_return(self, cx: &mut Cx<'cx>) -> JsResult<'cx, JsValue> {
         self.try_into_js(cx).map(|v| v.upcast())
     }
 }
@@ -40,9 +35,7 @@ where
 // Trait used for specializing `Json` wrapping of `T` or `Result<T, _>` in macros
 // Leverages the [autoref specialization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md) technique
 pub trait NeonExportReturnJson<'cx> {
-    fn try_neon_export_return<C>(self, cx: &mut C) -> JsResult<'cx, JsValue>
-    where
-        C: Context<'cx>;
+    fn try_neon_export_return(self, cx: &mut Cx<'cx>) -> JsResult<'cx, JsValue>;
 }
 
 #[cfg(feature = "serde")]
@@ -52,10 +45,7 @@ where
     T: serde::Serialize,
     E: TryIntoJs<'cx>,
 {
-    fn try_neon_export_return<C>(self, cx: &mut C) -> JsResult<'cx, JsValue>
-    where
-        C: Context<'cx>,
-    {
+    fn try_neon_export_return(self, cx: &mut Cx<'cx>) -> JsResult<'cx, JsValue> {
         self.map(crate::types::extract::Json).try_into_js(cx)
     }
 }
@@ -66,10 +56,7 @@ impl<'cx, T> NeonExportReturnJson<'cx> for &T
 where
     T: serde::Serialize,
 {
-    fn try_neon_export_return<C>(self, cx: &mut C) -> JsResult<'cx, JsValue>
-    where
-        C: Context<'cx>,
-    {
+    fn try_neon_export_return(self, cx: &mut Cx<'cx>) -> JsResult<'cx, JsValue> {
         crate::types::extract::Json(self).try_into_js(cx)
     }
 }

--- a/crates/neon/src/thread/mod.rs
+++ b/crates/neon/src/thread/mod.rs
@@ -13,7 +13,7 @@
 //! # use neon::thread::LocalKey;
 //! static THREAD_ID: LocalKey<u32> = LocalKey::new();
 //!
-//! pub fn thread_id<'cx, C: Context<'cx>>(cx: &mut C) -> NeonResult<u32> {
+//! pub fn thread_id(cx: &mut Cx) -> NeonResult<u32> {
 //!     THREAD_ID.get_or_try_init(cx, |cx| {
 //!         let require: Handle<JsFunction> = cx.global("require")?;
 //!         let worker: Handle<JsObject> = require.call_with(cx)

--- a/crates/neon/src/types_impl/extract/error.rs
+++ b/crates/neon/src/types_impl/extract/error.rs
@@ -1,7 +1,7 @@
 use std::{error, fmt};
 
 use crate::{
-    context::Context,
+    context::{Context, Cx},
     result::JsResult,
     types::{extract::TryIntoJs, JsError},
 };
@@ -114,10 +114,7 @@ impl fmt::Display for Error {
 impl<'cx> TryIntoJs<'cx> for Error {
     type Value = JsError;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         let message = self.cause.to_string();
 
         match self.kind {

--- a/crates/neon/src/types_impl/extract/json.rs
+++ b/crates/neon/src/types_impl/extract/json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::Context,
+    context::{Context, Cx},
     handle::Handle,
     object::Object,
     result::{JsResult, NeonResult},
@@ -12,10 +12,7 @@ use crate::{
 #[cfg(feature = "napi-6")]
 use crate::{handle::Root, thread::LocalKey};
 
-fn global_json_stringify<'cx, C>(cx: &mut C) -> JsResult<'cx, JsFunction>
-where
-    C: Context<'cx>,
-{
+fn global_json_stringify<'cx>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     cx.global::<JsObject>("JSON")?.get(cx, "stringify")
 }
 
@@ -24,18 +21,12 @@ where
 // method could cause differences between calls. However, threading a `Root` through
 // would require a significant refactor and "don't do this or things will break" is
 // fairly common in JS.
-fn json_stringify<'cx, C>(cx: &mut C) -> JsResult<'cx, JsFunction>
-where
-    C: Context<'cx>,
-{
+fn json_stringify<'cx, C>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     global_json_stringify(cx)
 }
 
 #[cfg(feature = "napi-6")]
-fn json_stringify<'cx, C>(cx: &mut C) -> JsResult<'cx, JsFunction>
-where
-    C: Context<'cx>,
-{
+fn json_stringify<'cx>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     static STRINGIFY: LocalKey<Root<JsFunction>> = LocalKey::new();
 
     STRINGIFY
@@ -43,36 +34,24 @@ where
         .map(|f| f.to_inner(cx))
 }
 
-fn stringify<'cx, C>(cx: &mut C, v: Handle<JsValue>) -> NeonResult<String>
-where
-    C: Context<'cx>,
-{
+fn stringify<'cx>(cx: &mut Cx<'cx>, v: Handle<JsValue>) -> NeonResult<String> {
     json_stringify(cx)?
         .call(cx, v, [v])?
         .downcast_or_throw::<JsString, _>(cx)
         .map(|s| s.value(cx))
 }
 
-fn global_json_parse<'cx, C>(cx: &mut C) -> JsResult<'cx, JsFunction>
-where
-    C: Context<'cx>,
-{
+fn global_json_parse<'cx>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     cx.global::<JsObject>("JSON")?.get(cx, "parse")
 }
 
 #[cfg(not(feature = "napi-6"))]
-fn json_parse<'cx, C>(cx: &mut C) -> JsResult<'cx, JsFunction>
-where
-    C: Context<'cx>,
-{
+fn json_parse<'cx>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     global_json_parse(cx)
 }
 
 #[cfg(feature = "napi-6")]
-fn json_parse<'cx, C>(cx: &mut C) -> JsResult<'cx, JsFunction>
-where
-    C: Context<'cx>,
-{
+fn json_parse<'cx>(cx: &mut Cx<'cx>) -> JsResult<'cx, JsFunction> {
     static PARSE: LocalKey<Root<JsFunction>> = LocalKey::new();
 
     PARSE
@@ -80,10 +59,7 @@ where
         .map(|f| f.to_inner(cx))
 }
 
-fn parse<'cx, C>(cx: &mut C, s: &str) -> JsResult<'cx, JsValue>
-where
-    C: Context<'cx>,
-{
+fn parse<'cx>(cx: &mut Cx<'cx>, s: &str) -> JsResult<'cx, JsValue> {
     let s = cx.string(s).upcast();
 
     json_parse(cx)?.call(cx, s, [s])
@@ -99,17 +75,14 @@ where
 {
     type Error = serde_json::Error;
 
-    fn try_from_js<C>(cx: &mut C, v: Handle<'cx, JsValue>) -> NeonResult<Result<Self, Self::Error>>
-    where
-        C: Context<'cx>,
-    {
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
         Ok(serde_json::from_str(&stringify(cx, v)?).map(Json))
     }
 
-    fn from_js<C>(cx: &mut C, v: Handle<'cx, JsValue>) -> NeonResult<Self>
-    where
-        C: Context<'cx>,
-    {
+    fn from_js(cx: &mut Cx<'cx>, v: Handle<'cx, JsValue>) -> NeonResult<Self> {
         Self::try_from_js(cx, v)?.or_else(|err| cx.throw_error(err.to_string()))
     }
 }
@@ -120,10 +93,7 @@ where
 {
     type Value = JsValue;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         let s = serde_json::to_string(&self.0).or_else(|err| cx.throw_error(err.to_string()))?;
 
         parse(cx, &s)

--- a/crates/neon/src/types_impl/extract/mod.rs
+++ b/crates/neon/src/types_impl/extract/mod.rs
@@ -102,7 +102,7 @@
 use std::{fmt, marker::PhantomData};
 
 use crate::{
-    context::{Context, FunctionContext},
+    context::{Context, Cx, FunctionContext},
     handle::Handle,
     result::{JsResult, NeonResult, ResultExt},
     types::{JsValue, Value},
@@ -133,14 +133,13 @@ where
     type Error;
 
     /// Extract this Rust type from a JavaScript value
-    fn try_from_js<C>(cx: &mut C, v: Handle<'cx, JsValue>) -> NeonResult<Result<Self, Self::Error>>
-    where
-        C: Context<'cx>;
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>>;
 
     /// Same as [`TryFromJs`], but all errors are converted to JavaScript exceptions
-    fn from_js<C>(cx: &mut C, v: Handle<'cx, JsValue>) -> NeonResult<Self>
-    where
-        C: Context<'cx>;
+    fn from_js(cx: &mut Cx<'cx>, v: Handle<'cx, JsValue>) -> NeonResult<Self>;
 }
 
 /// Convert Rust data into a JavaScript value
@@ -152,9 +151,7 @@ where
     type Value: Value;
 
     /// Convert `self` into a JavaScript value
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>;
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value>;
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "napi-5")))]

--- a/crates/neon/src/types_impl/extract/try_into_js.rs
+++ b/crates/neon/src/types_impl/extract/try_into_js.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::Context,
+    context::{Context, Cx},
     handle::Handle,
     result::{JsResult, ResultExt, Throw},
     types::{
@@ -16,10 +16,7 @@ where
 {
     type Value = T;
 
-    fn try_into_js<C>(self, _cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, _cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(self)
     }
 }
@@ -31,10 +28,7 @@ where
 {
     type Value = T::Value;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         match self {
             Ok(v) => v.try_into_js(cx),
             Err(err) => {
@@ -49,10 +43,7 @@ where
 impl<'cx> TryIntoJs<'cx> for Throw {
     type Value = JsValue;
 
-    fn try_into_js<C>(self, _cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, _cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Err(self)
     }
 }
@@ -63,10 +54,7 @@ where
 {
     type Value = JsValue;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         if let Some(val) = self {
             val.try_into_js(cx).map(|v| v.upcast())
         } else {
@@ -80,10 +68,7 @@ macro_rules! impl_number {
         impl<'cx> TryIntoJs<'cx> for $ty {
             type Value = JsNumber;
 
-            fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-            where
-                C: Context<'cx>,
-            {
+            fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
                 Ok(cx.number(self))
             }
         }
@@ -101,10 +86,7 @@ impl_number!(u8, u16, u32, i8, i16, i32, f32, f64);
 impl<'cx> TryIntoJs<'cx> for String {
     type Value = JsString;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(cx.string(self))
     }
 }
@@ -112,10 +94,7 @@ impl<'cx> TryIntoJs<'cx> for String {
 impl<'cx> TryIntoJs<'cx> for &'cx str {
     type Value = JsString;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(cx.string(self))
     }
 }
@@ -127,10 +106,7 @@ where
 {
     type Value = JsTypedArray<T>;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         JsTypedArray::from_slice(cx, &self)
     }
 }
@@ -142,10 +118,7 @@ where
 {
     type Value = JsTypedArray<T>;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         JsTypedArray::from_slice(cx, self)
     }
 }
@@ -153,10 +126,7 @@ where
 impl<'cx> TryIntoJs<'cx> for bool {
     type Value = JsBoolean;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(cx.boolean(self))
     }
 }
@@ -164,10 +134,7 @@ impl<'cx> TryIntoJs<'cx> for bool {
 impl<'cx> TryIntoJs<'cx> for () {
     type Value = JsUndefined;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(cx.undefined())
     }
 }
@@ -175,10 +142,7 @@ impl<'cx> TryIntoJs<'cx> for () {
 impl<'cx> TryIntoJs<'cx> for ArrayBuffer {
     type Value = JsArrayBuffer;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         JsArrayBuffer::from_slice(cx, &self.0)
     }
 }
@@ -186,10 +150,7 @@ impl<'cx> TryIntoJs<'cx> for ArrayBuffer {
 impl<'cx> TryIntoJs<'cx> for Buffer {
     type Value = JsBuffer;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         JsBuffer::from_slice(cx, &self.0)
     }
 }
@@ -197,10 +158,7 @@ impl<'cx> TryIntoJs<'cx> for Buffer {
 impl<'cx> TryIntoJs<'cx> for Date {
     type Value = JsDate;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         cx.date(self.0).or_throw(cx)
     }
 }

--- a/crates/neon/src/types_impl/extract/with.rs
+++ b/crates/neon/src/types_impl/extract/with.rs
@@ -1,8 +1,4 @@
-use crate::{
-    context::{Context, Cx},
-    result::JsResult,
-    types::extract::TryIntoJs,
-};
+use crate::{context::Cx, result::JsResult, types::extract::TryIntoJs};
 
 /// Wraps a closure that will be lazily evaluated when [`TryIntoJs::try_into_js`] is
 /// called.
@@ -47,11 +43,8 @@ where
 {
     type Value = O::Value;
 
-    fn try_into_js<C>(self, cx: &mut C) -> JsResult<'cx, Self::Value>
-    where
-        C: Context<'cx>,
-    {
-        (self.0)(cx.cx_mut()).try_into_js(cx)
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        (self.0)(cx).try_into_js(cx)
     }
 }
 

--- a/crates/neon/src/types_impl/promise.rs
+++ b/crates/neon/src/types_impl/promise.rs
@@ -453,7 +453,7 @@ impl Drop for Deferred {
 /// use tokio::runtime::Runtime;
 ///
 /// // Lazily allocate a Tokio runtime to use as the thread pool.
-/// fn runtime<'a, C: Context<'a>>(cx: &mut C) -> NeonResult<&'static Runtime> {
+/// fn runtime(cx: &mut Cx) -> NeonResult<&'static Runtime> {
 ///     static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 ///
 ///     RUNTIME


### PR DESCRIPTION
Being generic over `Context` offers no benefits over `Cx`. It is simpler to remove a generic argument.

* Every `Context` derefs to `Cx`
* `Cx` implements `Context`
* Reduces code bloat from monomorphization

We should double check that there's no other new APIs introduced in the pre-release that could benefit from this change. Unfortunately, we can't change existing APIs without a breaking change.