### PR TITLE
Make build() fn's closure return a Result

### DIFF
--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -37,9 +37,7 @@ use crate::{
     handle::{Handle, Root},
     result::{NeonResult, Throw},
     sys::{self, raw},
-    types::{
-        build_result, function::CallOptions, utf8::Utf8, JsFunction, JsUndefined, JsValue, Value,
-    },
+    types::{build, function::CallOptions, utf8::Utf8, JsFunction, JsUndefined, JsValue, Value},
 };
 
 #[cfg(feature = "napi-6")]
@@ -163,8 +161,7 @@ pub trait Object: Value {
         cx: &mut C,
         key: K,
     ) -> NeonResult<Handle<'a, JsValue>> {
-        let env = cx.env();
-        build_result(env, move || unsafe {
+        build(cx.env(), move || unsafe {
             let mut out: raw::Local = std::ptr::null_mut();
             key.get_from(cx, &mut out, self.to_local())
                 .then_some(out)
@@ -189,7 +186,7 @@ pub trait Object: Value {
     fn get_own_property_names<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsArray> {
         let env = cx.env();
 
-        build_result(env, move || unsafe {
+        build(env, move || unsafe {
             let mut out: raw::Local = std::ptr::null_mut();
             sys::object::get_own_property_names(&mut out, env.to_raw(), self.to_local())
                 .then_some(out)

--- a/crates/neon/src/reflect.rs
+++ b/crates/neon/src/reflect.rs
@@ -5,7 +5,7 @@ use crate::{
     handle::Handle,
     result::{JsResult, Throw},
     sys::raw,
-    types::{build_result, private::ValueInternal, JsString, JsValue},
+    types::{build, private::ValueInternal, JsString, JsValue},
 };
 
 pub fn eval<'a, 'b, C: Context<'a>>(
@@ -13,7 +13,7 @@ pub fn eval<'a, 'b, C: Context<'a>>(
     script: Handle<'b, JsString>,
 ) -> JsResult<'a, JsValue> {
     let env = cx.env();
-    build_result(env, move || unsafe {
+    build(env, move || unsafe {
         let mut out: raw::Local = std::ptr::null_mut();
         crate::sys::string::run_script(&mut out, env.to_raw(), script.to_local())
             .then_some(out)

--- a/crates/neon/src/reflect.rs
+++ b/crates/neon/src/reflect.rs
@@ -3,16 +3,20 @@
 use crate::{
     context::Context,
     handle::Handle,
-    result::JsResult,
-    types::{build, private::ValueInternal, JsString, JsValue},
+    result::{JsResult, Throw},
+    sys::raw,
+    types::{build_result, private::ValueInternal, JsString, JsValue},
 };
 
 pub fn eval<'a, 'b, C: Context<'a>>(
     cx: &mut C,
     script: Handle<'b, JsString>,
 ) -> JsResult<'a, JsValue> {
-    let env = cx.env().to_raw();
-    build(cx.env(), |out| unsafe {
-        crate::sys::string::run_script(out, env, script.to_local())
+    let env = cx.env();
+    build_result(env, move || unsafe {
+        let mut out: raw::Local = std::ptr::null_mut();
+        crate::sys::string::run_script(&mut out, env.to_raw(), script.to_local())
+            .then_some(out)
+            .ok_or(Throw::new())
     })
 }

--- a/crates/neon/src/types_impl/error.rs
+++ b/crates/neon/src/types_impl/error.rs
@@ -8,7 +8,7 @@ use crate::{
     object::Object,
     result::{NeonResult, Throw},
     sys::{self, raw},
-    types::{build, private::ValueInternal, utf8::Utf8, Value},
+    types::{build_result, private::ValueInternal, utf8::Utf8, Value},
 };
 
 /// The type of JavaScript
@@ -77,10 +77,12 @@ impl JsError {
         cx: &mut C,
         msg: S,
     ) -> NeonResult<Handle<'a, JsError>> {
+        let env = cx.env();
         let msg = cx.string(msg.as_ref());
-        build(cx.env(), |out| unsafe {
-            sys::error::new_error(cx.env().to_raw(), out, msg.to_local());
-            true
+        build_result(env, || unsafe {
+            let mut out = std::ptr::null_mut();
+            sys::error::new_error(env.to_raw(), &mut out, msg.to_local());
+            Ok(out)
         })
     }
 
@@ -91,10 +93,12 @@ impl JsError {
         cx: &mut C,
         msg: S,
     ) -> NeonResult<Handle<'a, JsError>> {
+        let env = cx.env();
         let msg = cx.string(msg.as_ref());
-        build(cx.env(), |out| unsafe {
-            sys::error::new_type_error(cx.env().to_raw(), out, msg.to_local());
-            true
+        build_result(env, || unsafe {
+            let mut out = std::ptr::null_mut();
+            sys::error::new_type_error(env.to_raw(), &mut out, msg.to_local());
+            Ok(out)
         })
     }
 
@@ -105,10 +109,12 @@ impl JsError {
         cx: &mut C,
         msg: S,
     ) -> NeonResult<Handle<'a, JsError>> {
+        let env = cx.env();
         let msg = cx.string(msg.as_ref());
-        build(cx.env(), |out| unsafe {
-            sys::error::new_range_error(cx.env().to_raw(), out, msg.to_local());
-            true
+        build_result(env, move || unsafe {
+            let mut out: raw::Local = std::ptr::null_mut();
+            sys::error::new_range_error(env.to_raw(), &mut out, msg.to_local());
+            Ok(out)
         })
     }
 }

--- a/crates/neon/src/types_impl/error.rs
+++ b/crates/neon/src/types_impl/error.rs
@@ -8,7 +8,7 @@ use crate::{
     object::Object,
     result::{NeonResult, Throw},
     sys::{self, raw},
-    types::{build_result, private::ValueInternal, utf8::Utf8, Value},
+    types::{build, private::ValueInternal, utf8::Utf8, Value},
 };
 
 /// The type of JavaScript
@@ -79,11 +79,13 @@ impl JsError {
     ) -> NeonResult<Handle<'a, JsError>> {
         let env = cx.env();
         let msg = cx.string(msg.as_ref());
-        build_result(env, || unsafe {
-            let mut out = std::ptr::null_mut();
+
+        let mut out = std::ptr::null_mut();
+        let value = unsafe {
             sys::error::new_error(env.to_raw(), &mut out, msg.to_local());
-            Ok(out)
-        })
+            Self::from_local(env, out)
+        };
+        Ok(Handle::new_internal(value))
     }
 
     /// Creates an instance of the [`TypeError`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError) class.
@@ -95,7 +97,7 @@ impl JsError {
     ) -> NeonResult<Handle<'a, JsError>> {
         let env = cx.env();
         let msg = cx.string(msg.as_ref());
-        build_result(env, || unsafe {
+        build(env, || unsafe {
             let mut out = std::ptr::null_mut();
             sys::error::new_type_error(env.to_raw(), &mut out, msg.to_local());
             Ok(out)
@@ -111,7 +113,7 @@ impl JsError {
     ) -> NeonResult<Handle<'a, JsError>> {
         let env = cx.env();
         let msg = cx.string(msg.as_ref());
-        build_result(env, move || unsafe {
+        build(env, move || unsafe {
             let mut out: raw::Local = std::ptr::null_mut();
             sys::error::new_range_error(env.to_raw(), &mut out, msg.to_local());
             Ok(out)

--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -59,7 +59,7 @@ pub use self::promise::JsFuture;
 
 // This should be considered deprecated and will be removed:
 // https://github.com/neon-bindings/neon/issues/983
-pub(crate) fn build_result<'a, T: Value, E, F: FnOnce() -> Result<raw::Local, E>>(
+pub(crate) fn build<'a, T: Value, E, F: FnOnce() -> Result<raw::Local, E>>(
     env: Env,
     init: F,
 ) -> Result<Handle<'a, T>, E> {
@@ -84,7 +84,7 @@ impl<T: Object> SuperType<T> for JsObject {
 pub trait Value: ValueInternal {
     fn to_string<'cx, C: Context<'cx>>(&self, cx: &mut C) -> JsResult<'cx, JsString> {
         let env = cx.env();
-        build_result(env, || unsafe {
+        build(env, || unsafe {
             let mut out = std::ptr::null_mut();
             sys::convert::to_string(&mut out, env.to_raw(), self.to_local())
                 .then_some(out)
@@ -1168,7 +1168,7 @@ impl JsFunction {
     {
         let (argc, argv) = unsafe { prepare_call(cx, args.as_ref()) }?;
         let env = cx.env();
-        build_result(env, move || unsafe {
+        build(env, move || unsafe {
             let mut out: raw::Local = std::ptr::null_mut();
 
             sys::fun::call(
@@ -1215,7 +1215,7 @@ impl JsFunction {
         let (argc, argv) = unsafe { prepare_call(cx, args.as_ref()) }?;
         let env = cx.env();
         {
-            build_result(env, move || unsafe {
+            build(env, move || unsafe {
                 let mut out: raw::Local = std::ptr::null_mut();
                 sys::fun::construct(&mut out, env.to_raw(), self.to_local(), argc, argv)
                     .then_some(out)


### PR DESCRIPTION
This is a pure refactor that makes the `build` function more idiomatic; no externally-facing types or functions are changed. The big benefit here is that it makes it possible to, in a future change, make the return type of some functions infallible, like `JsError::error`.