### PR TITLE
Return Results from native function wrappers

### DIFF
--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -336,17 +336,15 @@ impl CallbackInfo<'_> {
         // * Node-API fills empty slots with `undefined`
         // * `Handle` and `JsValue` are transparent wrappers around a raw pointer
         unsafe {
-            assert_eq!(
-                sys::get_cb_info(
-                    cx.env().to_raw(),
-                    self.info,
-                    &mut argc,
-                    argv.as_mut_ptr().cast(),
-                    ptr::null_mut(),
-                    ptr::null_mut(),
-                ),
-                Ok(())
-            );
+            sys::get_cb_info(
+                cx.env().to_raw(),
+                self.info,
+                &mut argc,
+                argv.as_mut_ptr().cast(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+            .unwrap();
         }
 
         // Empty values will be filled with `undefined`

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -345,7 +345,7 @@ impl CallbackInfo<'_> {
                     ptr::null_mut(),
                     ptr::null_mut(),
                 ),
-                sys::Status::Ok,
+                Ok(())
             );
         }
 

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -346,8 +346,8 @@ pub trait Object: Value {
         let obj = self.to_local();
         unsafe {
             match sys::object::freeze(env, obj) {
-                sys::Status::Ok => Ok(self),
-                sys::Status::PendingException => Err(Throw::new()),
+                Ok(()) => Ok(self),
+                Err(sys::Status::PendingException) => Err(Throw::new()),
                 _ => cx.throw_type_error("object cannot be frozen"),
             }
         }
@@ -359,8 +359,8 @@ pub trait Object: Value {
         let obj = self.to_local();
         unsafe {
             match sys::object::seal(env, obj) {
-                sys::Status::Ok => Ok(self),
-                sys::Status::PendingException => Err(Throw::new()),
+                Ok(()) => Ok(self),
+                Err(sys::Status::PendingException) => Err(Throw::new()),
                 _ => cx.throw_type_error("object cannot be sealed"),
             }
         }

--- a/crates/neon/src/sys/array.rs
+++ b/crates/neon/src/sys/array.rs
@@ -6,10 +6,7 @@ use super::{
 };
 
 pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
-    assert_eq!(
-        napi::create_array_with_length(env, length, out as *mut _),
-        Ok(())
-    );
+    let () = napi::create_array_with_length(env, length, out as *mut _).unwrap();
 }
 
 /// Gets the length of a `napi_value` containing a JavaScript Array.
@@ -19,9 +16,6 @@ pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
 /// exception.
 pub unsafe fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
-    assert_eq!(
-        napi::get_array_length(env, array, &mut len as *mut _),
-        Ok(())
-    );
+    let () = napi::get_array_length(env, array, &mut len as *mut _).unwrap();
     len
 }

--- a/crates/neon/src/sys/array.rs
+++ b/crates/neon/src/sys/array.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
-    let () = napi::create_array_with_length(env, length, out as *mut _).unwrap();
+    napi::create_array_with_length(env, length, out as *mut _).unwrap();
 }
 
 /// Gets the length of a `napi_value` containing a JavaScript Array.
@@ -16,6 +16,6 @@ pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
 /// exception.
 pub unsafe fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
-    let () = napi::get_array_length(env, array, &mut len as *mut _).unwrap();
+    napi::get_array_length(env, array, &mut len as *mut _).unwrap();
     len
 }

--- a/crates/neon/src/sys/array.rs
+++ b/crates/neon/src/sys/array.rs
@@ -8,7 +8,7 @@ use super::{
 pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
     assert_eq!(
         napi::create_array_with_length(env, length, out as *mut _),
-        napi::Status::Ok,
+        Ok(())
     );
 }
 
@@ -21,7 +21,7 @@ pub unsafe fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
     assert_eq!(
         napi::get_array_length(env, array, &mut len as *mut _),
-        napi::Status::Ok
+        Ok(())
     );
     len
 }

--- a/crates/neon/src/sys/arraybuffer.rs
+++ b/crates/neon/src/sys/arraybuffer.rs
@@ -11,7 +11,7 @@ pub unsafe fn new(env: Env, len: usize) -> Result<Local, napi::Status> {
     let mut buf = MaybeUninit::uninit();
     let status = napi::create_arraybuffer(env, len, null_mut(), buf.as_mut_ptr());
 
-    let () = match status {
+    match status {
         Err(err @ napi::Status::PendingException) => return Err(err),
         status => status.unwrap(),
     };
@@ -30,7 +30,7 @@ where
     let length = buf.len();
     let mut result = MaybeUninit::uninit();
 
-    let () = napi::create_external_arraybuffer(
+    napi::create_external_arraybuffer(
         env,
         buf.as_mut_ptr() as *mut _,
         length,
@@ -55,7 +55,7 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    let () = napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     if size == 0 {
         return &mut [];
@@ -70,7 +70,7 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    let () = napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     size
 }

--- a/crates/neon/src/sys/arraybuffer.rs
+++ b/crates/neon/src/sys/arraybuffer.rs
@@ -11,11 +11,10 @@ pub unsafe fn new(env: Env, len: usize) -> Result<Local, napi::Status> {
     let mut buf = MaybeUninit::uninit();
     let status = napi::create_arraybuffer(env, len, null_mut(), buf.as_mut_ptr());
 
-    if status == Err(napi::Status::PendingException) {
-        return Err(napi::Status::PendingException);
-    }
-
-    assert_eq!(status, Ok(()));
+    let () = match status {
+        Err(err @ napi::Status::PendingException) => return Err(err),
+        status => status.unwrap(),
+    };
 
     Ok(buf.assume_init())
 }
@@ -31,17 +30,15 @@ where
     let length = buf.len();
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::create_external_arraybuffer(
-            env,
-            buf.as_mut_ptr() as *mut _,
-            length,
-            Some(drop_external::<T>),
-            Box::into_raw(data) as *mut _,
-            result.as_mut_ptr(),
-        ),
-        Ok(())
-    );
+    let () = napi::create_external_arraybuffer(
+        env,
+        buf.as_mut_ptr() as *mut _,
+        length,
+        Some(drop_external::<T>),
+        Box::into_raw(data) as *mut _,
+        result.as_mut_ptr(),
+    )
+    .unwrap();
 
     result.assume_init()
 }
@@ -58,10 +55,7 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    assert_eq!(
-        napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        Ok(())
-    );
+    let () = napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     if size == 0 {
         return &mut [];
@@ -76,10 +70,7 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    assert_eq!(
-        napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        Ok(())
-    );
+    let () = napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     size
 }

--- a/crates/neon/src/sys/arraybuffer.rs
+++ b/crates/neon/src/sys/arraybuffer.rs
@@ -11,11 +11,11 @@ pub unsafe fn new(env: Env, len: usize) -> Result<Local, napi::Status> {
     let mut buf = MaybeUninit::uninit();
     let status = napi::create_arraybuffer(env, len, null_mut(), buf.as_mut_ptr());
 
-    if status == napi::Status::PendingException {
-        return Err(status);
+    if status == Err(napi::Status::PendingException) {
+        return Err(napi::Status::PendingException);
     }
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     Ok(buf.assume_init())
 }
@@ -40,7 +40,7 @@ where
             Box::into_raw(data) as *mut _,
             result.as_mut_ptr(),
         ),
-        napi::Status::Ok,
+        Ok(())
     );
 
     result.assume_init()
@@ -60,7 +60,7 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
 
     assert_eq!(
         napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        napi::Status::Ok,
+        Ok(())
     );
 
     if size == 0 {
@@ -78,7 +78,7 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
 
     assert_eq!(
         napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        napi::Status::Ok,
+        Ok(())
     );
 
     size

--- a/crates/neon/src/sys/async_work.rs
+++ b/crates/neon/src/sys/async_work.rs
@@ -68,13 +68,13 @@ pub unsafe fn schedule<I, O, D>(
             Box::into_raw(data).cast(),
             work,
         ),
-        napi::Status::Ok,
+        Ok(())
     );
 
     // Queue the work
     match napi::queue_async_work(env, *work) {
-        napi::Status::Ok => {}
-        status => {
+        Ok(()) => {}
+        Err(status) => {
             // If queueing failed, delete the work to prevent a leak
             napi::delete_async_work(env, *work);
             assert_eq!(status, napi::Status::Ok);

--- a/crates/neon/src/sys/async_work.rs
+++ b/crates/neon/src/sys/async_work.rs
@@ -58,7 +58,7 @@ pub unsafe fn schedule<I, O, D>(
     let work = &mut data.work as *mut _;
 
     // Create the `async_work`
-    let () = napi::create_async_work(
+    napi::create_async_work(
         env,
         ptr::null_mut(),
         super::string(env, "neon_async_work"),

--- a/crates/neon/src/sys/bindings/mod.rs
+++ b/crates/neon/src/sys/bindings/mod.rs
@@ -166,8 +166,13 @@ macro_rules! generate {
                 napi_name!($name),
                 ")",
             )]
-            pub unsafe fn $name($($param: $ptype,)*)$( -> $rtype)* {
-                (NAPI.$name)($($param,)*)
+            pub unsafe fn $name($($param: $ptype,)*)$( -> ::core::result::Result<(), $rtype>)* {
+                #[allow(unused)]
+                let r = (NAPI.$name)($($param,)*);
+                $(match r {
+                    <$rtype>::Ok => Ok(()),
+                    status => Err(status)
+                })*
             }
         )*
     };

--- a/crates/neon/src/sys/buffer.rs
+++ b/crates/neon/src/sys/buffer.rs
@@ -20,11 +20,11 @@ pub unsafe fn uninitialized(env: Env, len: usize) -> Result<(Local, *mut u8), na
     let mut bytes = MaybeUninit::uninit();
     let status = napi::create_buffer(env, len, bytes.as_mut_ptr(), buf.as_mut_ptr());
 
-    if status == napi::Status::PendingException {
-        return Err(status);
+    if status == Err(napi::Status::PendingException) {
+        return Err(napi::Status::PendingException);
     }
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     Ok((buf.assume_init(), bytes.assume_init().cast()))
 }
@@ -49,7 +49,7 @@ where
             Box::into_raw(data) as *mut _,
             result.as_mut_ptr(),
         ),
-        napi::Status::Ok,
+        Ok(())
     );
 
     result.assume_init()
@@ -69,7 +69,7 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
 
     assert_eq!(
         napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        napi::Status::Ok,
+        Ok(())
     );
 
     if size == 0 {
@@ -87,7 +87,7 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
 
     assert_eq!(
         napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        napi::Status::Ok,
+        Ok(())
     );
 
     size

--- a/crates/neon/src/sys/buffer.rs
+++ b/crates/neon/src/sys/buffer.rs
@@ -20,7 +20,7 @@ pub unsafe fn uninitialized(env: Env, len: usize) -> Result<(Local, *mut u8), na
     let mut bytes = MaybeUninit::uninit();
     let status = napi::create_buffer(env, len, bytes.as_mut_ptr(), buf.as_mut_ptr());
 
-    let () = match status {
+    match status {
         Err(err @ napi::Status::PendingException) => return Err(err),
         status => status.unwrap(),
     };
@@ -64,7 +64,7 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    let () = napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     if size == 0 {
         return &mut [];
@@ -79,7 +79,7 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    let () = napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     size
 }

--- a/crates/neon/src/sys/buffer.rs
+++ b/crates/neon/src/sys/buffer.rs
@@ -20,11 +20,10 @@ pub unsafe fn uninitialized(env: Env, len: usize) -> Result<(Local, *mut u8), na
     let mut bytes = MaybeUninit::uninit();
     let status = napi::create_buffer(env, len, bytes.as_mut_ptr(), buf.as_mut_ptr());
 
-    if status == Err(napi::Status::PendingException) {
-        return Err(napi::Status::PendingException);
-    }
-
-    assert_eq!(status, Ok(()));
+    let () = match status {
+        Err(err @ napi::Status::PendingException) => return Err(err),
+        status => status.unwrap(),
+    };
 
     Ok((buf.assume_init(), bytes.assume_init().cast()))
 }
@@ -40,17 +39,15 @@ where
     let length = buf.len();
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::create_external_buffer(
-            env,
-            length,
-            buf.as_mut_ptr() as *mut _,
-            Some(drop_external::<T>),
-            Box::into_raw(data) as *mut _,
-            result.as_mut_ptr(),
-        ),
-        Ok(())
-    );
+    napi::create_external_buffer(
+        env,
+        length,
+        buf.as_mut_ptr() as *mut _,
+        Some(drop_external::<T>),
+        Box::into_raw(data) as *mut _,
+        result.as_mut_ptr(),
+    )
+    .unwrap();
 
     result.assume_init()
 }
@@ -67,10 +64,7 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    assert_eq!(
-        napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        Ok(())
-    );
+    let () = napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     if size == 0 {
         return &mut [];
@@ -85,10 +79,7 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    assert_eq!(
-        napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _),
-        Ok(())
-    );
+    let () = napi::get_buffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
 
     size
 }

--- a/crates/neon/src/sys/call.rs
+++ b/crates/neon/src/sys/call.rs
@@ -33,9 +33,7 @@ impl Arguments {
 pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
     let mut target: MaybeUninit<Local> = MaybeUninit::zeroed();
 
-    let status = napi::get_new_target(env, info, target.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::get_new_target(env, info, target.as_mut_ptr()).unwrap();
 
     // get_new_target is guaranteed to assign to target, so it's initialized.
     let target: Local = target.assume_init();
@@ -47,23 +45,23 @@ pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
 }
 
 pub unsafe fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
-    let status = napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut());
-    assert_eq!(status, Ok(()));
+    let () =
+        napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut()).unwrap();
 }
 
 /// Gets the number of arguments passed to the function.
 // TODO: Remove this when `FunctionContext` is refactored to get call info upfront.
 pub unsafe fn len(env: Env, info: FunctionCallbackInfo) -> usize {
     let mut argc = 0usize;
-    let status = napi::get_cb_info(
+    let () = napi::get_cb_info(
         env,
         info,
         &mut argc as *mut _,
         null_mut(),
         null_mut(),
         null_mut(),
-    );
-    assert_eq!(status, Ok(()));
+    )
+    .unwrap();
     argc
 }
 
@@ -75,34 +73,30 @@ pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> Arguments {
     // Starts as the size allocated; after `get_cb_info` it is the number of arguments
     let mut argc = ARGV_SIZE;
 
-    assert_eq!(
-        napi::get_cb_info(
-            env,
-            info,
-            &mut argc as *mut _,
-            argv.as_mut_ptr().cast(),
-            null_mut(),
-            null_mut(),
-        ),
-        Ok(()),
-    );
+    let () = napi::get_cb_info(
+        env,
+        info,
+        &mut argc as *mut _,
+        argv.as_mut_ptr().cast(),
+        null_mut(),
+        null_mut(),
+    )
+    .unwrap();
 
     // We did not allocate enough space; allocate on the heap and try again
     let argv = if argc > ARGV_SIZE {
         // We know exactly how much space to reserve
         let mut argv = Vec::with_capacity(argc);
 
-        assert_eq!(
-            napi::get_cb_info(
-                env,
-                info,
-                &mut argc as *mut _,
-                argv.as_mut_ptr(),
-                null_mut(),
-                null_mut(),
-            ),
-            Ok(()),
-        );
+        let () = napi::get_cb_info(
+            env,
+            info,
+            &mut argc as *mut _,
+            argv.as_mut_ptr(),
+            null_mut(),
+            null_mut(),
+        )
+        .unwrap();
 
         // Set the size of `argv` to the number of initialized elements
         argv.set_len(argc);

--- a/crates/neon/src/sys/call.rs
+++ b/crates/neon/src/sys/call.rs
@@ -33,7 +33,7 @@ impl Arguments {
 pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
     let mut target: MaybeUninit<Local> = MaybeUninit::zeroed();
 
-    let () = napi::get_new_target(env, info, target.as_mut_ptr()).unwrap();
+    napi::get_new_target(env, info, target.as_mut_ptr()).unwrap();
 
     // get_new_target is guaranteed to assign to target, so it's initialized.
     let target: Local = target.assume_init();
@@ -45,15 +45,14 @@ pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
 }
 
 pub unsafe fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
-    let () =
-        napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut()).unwrap();
+    napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut()).unwrap();
 }
 
 /// Gets the number of arguments passed to the function.
 // TODO: Remove this when `FunctionContext` is refactored to get call info upfront.
 pub unsafe fn len(env: Env, info: FunctionCallbackInfo) -> usize {
     let mut argc = 0usize;
-    let () = napi::get_cb_info(
+    napi::get_cb_info(
         env,
         info,
         &mut argc as *mut _,
@@ -73,7 +72,7 @@ pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> Arguments {
     // Starts as the size allocated; after `get_cb_info` it is the number of arguments
     let mut argc = ARGV_SIZE;
 
-    let () = napi::get_cb_info(
+    napi::get_cb_info(
         env,
         info,
         &mut argc as *mut _,
@@ -88,7 +87,7 @@ pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> Arguments {
         // We know exactly how much space to reserve
         let mut argv = Vec::with_capacity(argc);
 
-        let () = napi::get_cb_info(
+        napi::get_cb_info(
             env,
             info,
             &mut argc as *mut _,

--- a/crates/neon/src/sys/call.rs
+++ b/crates/neon/src/sys/call.rs
@@ -35,7 +35,7 @@ pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
 
     let status = napi::get_new_target(env, info, target.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     // get_new_target is guaranteed to assign to target, so it's initialized.
     let target: Local = target.assume_init();
@@ -48,7 +48,7 @@ pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
 
 pub unsafe fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
     let status = napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut());
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 }
 
 /// Gets the number of arguments passed to the function.
@@ -63,7 +63,7 @@ pub unsafe fn len(env: Env, info: FunctionCallbackInfo) -> usize {
         null_mut(),
         null_mut(),
     );
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
     argc
 }
 
@@ -84,7 +84,7 @@ pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> Arguments {
             null_mut(),
             null_mut(),
         ),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     // We did not allocate enough space; allocate on the heap and try again
@@ -101,7 +101,7 @@ pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> Arguments {
                 null_mut(),
                 null_mut(),
             ),
-            napi::Status::Ok,
+            Ok(()),
         );
 
         // Set the size of `argv` to the number of initialized elements

--- a/crates/neon/src/sys/convert.rs
+++ b/crates/neon/src/sys/convert.rs
@@ -6,5 +6,5 @@ use super::{
 pub unsafe fn to_string(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::coerce_to_string(env, value, out as *mut _);
 
-    status == napi::Status::Ok
+    status.is_ok()
 }

--- a/crates/neon/src/sys/date.rs
+++ b/crates/neon/src/sys/date.rs
@@ -12,7 +12,7 @@ use super::{
 /// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
 pub unsafe fn new_date(env: Env, value: f64) -> Local {
     let mut local = MaybeUninit::zeroed();
-    let () = napi::create_date(env, value, local.as_mut_ptr()).unwrap();
+    napi::create_date(env, value, local.as_mut_ptr()).unwrap();
     local.assume_init()
 }
 
@@ -24,6 +24,6 @@ pub unsafe fn new_date(env: Env, value: f64) -> Local {
 /// `Local` must be an NAPI value associated with the given `Env`
 pub unsafe fn value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    let () = napi::get_date_value(env, p, &mut value as *mut _).unwrap();
+    napi::get_date_value(env, p, &mut value as *mut _).unwrap();
     value
 }

--- a/crates/neon/src/sys/date.rs
+++ b/crates/neon/src/sys/date.rs
@@ -13,7 +13,7 @@ use super::{
 pub unsafe fn new_date(env: Env, value: f64) -> Local {
     let mut local = MaybeUninit::zeroed();
     let status = napi::create_date(env, value, local.as_mut_ptr());
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
     local.assume_init()
 }
 
@@ -26,6 +26,6 @@ pub unsafe fn new_date(env: Env, value: f64) -> Local {
 pub unsafe fn value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
     let status = napi::get_date_value(env, p, &mut value as *mut _);
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
     value
 }

--- a/crates/neon/src/sys/date.rs
+++ b/crates/neon/src/sys/date.rs
@@ -12,8 +12,7 @@ use super::{
 /// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
 pub unsafe fn new_date(env: Env, value: f64) -> Local {
     let mut local = MaybeUninit::zeroed();
-    let status = napi::create_date(env, value, local.as_mut_ptr());
-    assert_eq!(status, Ok(()));
+    let () = napi::create_date(env, value, local.as_mut_ptr()).unwrap();
     local.assume_init()
 }
 
@@ -25,7 +24,6 @@ pub unsafe fn new_date(env: Env, value: f64) -> Local {
 /// `Local` must be an NAPI value associated with the given `Env`
 pub unsafe fn value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    let status = napi::get_date_value(env, p, &mut value as *mut _);
-    assert_eq!(status, Ok(()));
+    let () = napi::get_date_value(env, p, &mut value as *mut _).unwrap();
     value
 }

--- a/crates/neon/src/sys/error.rs
+++ b/crates/neon/src/sys/error.rs
@@ -8,7 +8,7 @@ use super::{
 pub unsafe fn is_throwing(env: Env) -> bool {
     let mut b: MaybeUninit<bool> = MaybeUninit::zeroed();
 
-    let () = napi::is_exception_pending(env, b.as_mut_ptr()).unwrap();
+    napi::is_exception_pending(env, b.as_mut_ptr()).unwrap();
 
     b.assume_init()
 }
@@ -18,55 +18,55 @@ pub unsafe fn catch_error(env: Env, error: *mut Local) -> bool {
         return false;
     }
 
-    let () = napi::get_and_clear_last_exception(env, error).unwrap();
+    napi::get_and_clear_last_exception(env, error).unwrap();
 
     true
 }
 
 pub unsafe fn clear_exception(env: Env) {
     let mut result = MaybeUninit::uninit();
-    let () = napi::is_exception_pending(env, result.as_mut_ptr()).unwrap();
+    napi::is_exception_pending(env, result.as_mut_ptr()).unwrap();
 
     if !result.assume_init() {
         return;
     }
 
     let mut result = MaybeUninit::uninit();
-    let () = napi::get_and_clear_last_exception(env, result.as_mut_ptr()).unwrap();
+    napi::get_and_clear_last_exception(env, result.as_mut_ptr()).unwrap();
 }
 
 pub unsafe fn throw(env: Env, val: Local) {
-    let () = napi::throw(env, val).unwrap();
+    napi::throw(env, val).unwrap();
 }
 
 pub unsafe fn new_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    let () = napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
+    napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
 
     *out = result.assume_init();
 }
 
 pub unsafe fn new_type_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    let () = napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
+    napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
 
     *out = result.assume_init();
 }
 
 pub unsafe fn new_range_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    let () = napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
+    napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
 
     *out = result.assume_init();
 }
 
 pub unsafe fn throw_error_from_utf8(env: Env, msg: *const u8, len: i32) {
     let mut out = MaybeUninit::uninit();
-    let () =
-        napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr()).unwrap();
+
+    napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr()).unwrap();
 
     let mut err = MaybeUninit::uninit();
-    let () = napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr()).unwrap();
+    napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr()).unwrap();
 
     throw(env, err.assume_init());
 }

--- a/crates/neon/src/sys/error.rs
+++ b/crates/neon/src/sys/error.rs
@@ -8,9 +8,7 @@ use super::{
 pub unsafe fn is_throwing(env: Env) -> bool {
     let mut b: MaybeUninit<bool> = MaybeUninit::zeroed();
 
-    let status = napi::is_exception_pending(env, b.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::is_exception_pending(env, b.as_mut_ptr()).unwrap();
 
     b.assume_init()
 }
@@ -20,72 +18,55 @@ pub unsafe fn catch_error(env: Env, error: *mut Local) -> bool {
         return false;
     }
 
-    let status = napi::get_and_clear_last_exception(env, error);
-
-    assert_eq!(status, Ok(()));
+    let () = napi::get_and_clear_last_exception(env, error).unwrap();
 
     true
 }
 
 pub unsafe fn clear_exception(env: Env) {
     let mut result = MaybeUninit::uninit();
-    let status = napi::is_exception_pending(env, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::is_exception_pending(env, result.as_mut_ptr()).unwrap();
 
     if !result.assume_init() {
         return;
     }
 
     let mut result = MaybeUninit::uninit();
-    let status = napi::get_and_clear_last_exception(env, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::get_and_clear_last_exception(env, result.as_mut_ptr()).unwrap();
 }
 
 pub unsafe fn throw(env: Env, val: Local) {
-    let status = napi::throw(env, val);
-
-    assert_eq!(status, Ok(()));
+    let () = napi::throw(env, val).unwrap();
 }
 
 pub unsafe fn new_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    let status = napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
 
     *out = result.assume_init();
 }
 
 pub unsafe fn new_type_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    let status = napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
 
     *out = result.assume_init();
 }
 
 pub unsafe fn new_range_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    let status = napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
 
     *out = result.assume_init();
 }
 
 pub unsafe fn throw_error_from_utf8(env: Env, msg: *const u8, len: i32) {
     let mut out = MaybeUninit::uninit();
-    let status = napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () =
+        napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr()).unwrap();
 
     let mut err = MaybeUninit::uninit();
-    let status = napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr()).unwrap();
 
     throw(env, err.assume_init());
 }

--- a/crates/neon/src/sys/error.rs
+++ b/crates/neon/src/sys/error.rs
@@ -10,7 +10,7 @@ pub unsafe fn is_throwing(env: Env) -> bool {
 
     let status = napi::is_exception_pending(env, b.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     b.assume_init()
 }
@@ -22,7 +22,7 @@ pub unsafe fn catch_error(env: Env, error: *mut Local) -> bool {
 
     let status = napi::get_and_clear_last_exception(env, error);
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     true
 }
@@ -31,7 +31,7 @@ pub unsafe fn clear_exception(env: Env) {
     let mut result = MaybeUninit::uninit();
     let status = napi::is_exception_pending(env, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     if !result.assume_init() {
         return;
@@ -40,20 +40,20 @@ pub unsafe fn clear_exception(env: Env) {
     let mut result = MaybeUninit::uninit();
     let status = napi::get_and_clear_last_exception(env, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 }
 
 pub unsafe fn throw(env: Env, val: Local) {
     let status = napi::throw(env, val);
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 }
 
 pub unsafe fn new_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
     let status = napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     *out = result.assume_init();
 }
@@ -62,7 +62,7 @@ pub unsafe fn new_type_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
     let status = napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     *out = result.assume_init();
 }
@@ -71,7 +71,7 @@ pub unsafe fn new_range_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
     let status = napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     *out = result.assume_init();
 }
@@ -80,12 +80,12 @@ pub unsafe fn throw_error_from_utf8(env: Env, msg: *const u8, len: i32) {
     let mut out = MaybeUninit::uninit();
     let status = napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     let mut err = MaybeUninit::uninit();
     let status = napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     throw(env, err.assume_init());
 }

--- a/crates/neon/src/sys/external.rs
+++ b/crates/neon/src/sys/external.rs
@@ -32,7 +32,7 @@ pub unsafe fn deref<T: 'static>(env: Env, local: Local) -> Option<*const T> {
     let mut result = MaybeUninit::uninit();
     let status = napi::typeof_value(env, local, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     let result = result.assume_init();
 
@@ -52,7 +52,7 @@ pub unsafe fn deref<T: 'static>(env: Env, local: Local) -> Option<*const T> {
     let mut result = MaybeUninit::uninit();
     let status = napi::get_value_external(env, local, result.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     let v = result.assume_init();
     let v = &**v.cast_const().cast::<DebugSendWrapper<T>>() as *const T;
@@ -77,7 +77,7 @@ pub unsafe fn create<T: 'static>(env: Env, v: T, finalizer: fn(Env, T)) -> Local
 
     // `napi_create_external` will only fail if the VM is in a throwing state
     // or shutting down.
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     let external = result.assume_init();
 

--- a/crates/neon/src/sys/external.rs
+++ b/crates/neon/src/sys/external.rs
@@ -30,7 +30,7 @@ extern "C" fn finalize_external<T: 'static>(
 /// <https://github.com/neon-bindings/neon/issues/591>
 pub unsafe fn deref<T: 'static>(env: Env, local: Local) -> Option<*const T> {
     let mut result = MaybeUninit::uninit();
-    let () = napi::typeof_value(env, local, result.as_mut_ptr()).unwrap();
+    napi::typeof_value(env, local, result.as_mut_ptr()).unwrap();
 
     let result = result.assume_init();
 
@@ -48,7 +48,7 @@ pub unsafe fn deref<T: 'static>(env: Env, local: Local) -> Option<*const T> {
     }
 
     let mut result = MaybeUninit::uninit();
-    let () = napi::get_value_external(env, local, result.as_mut_ptr()).unwrap();
+    napi::get_value_external(env, local, result.as_mut_ptr()).unwrap();
 
     let v = result.assume_init();
     let v = &**v.cast_const().cast::<DebugSendWrapper<T>>() as *const T;
@@ -73,7 +73,7 @@ pub unsafe fn create<T: 'static>(env: Env, v: T, finalizer: fn(Env, T)) -> Local
 
     // `napi_create_external` will only fail if the VM is in a throwing state
     // or shutting down.
-    let () = status.unwrap();
+    status.unwrap();
 
     let external = result.assume_init();
 

--- a/crates/neon/src/sys/external.rs
+++ b/crates/neon/src/sys/external.rs
@@ -30,9 +30,7 @@ extern "C" fn finalize_external<T: 'static>(
 /// <https://github.com/neon-bindings/neon/issues/591>
 pub unsafe fn deref<T: 'static>(env: Env, local: Local) -> Option<*const T> {
     let mut result = MaybeUninit::uninit();
-    let status = napi::typeof_value(env, local, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::typeof_value(env, local, result.as_mut_ptr()).unwrap();
 
     let result = result.assume_init();
 
@@ -50,9 +48,7 @@ pub unsafe fn deref<T: 'static>(env: Env, local: Local) -> Option<*const T> {
     }
 
     let mut result = MaybeUninit::uninit();
-    let status = napi::get_value_external(env, local, result.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::get_value_external(env, local, result.as_mut_ptr()).unwrap();
 
     let v = result.assume_init();
     let v = &**v.cast_const().cast::<DebugSendWrapper<T>>() as *const T;
@@ -77,7 +73,7 @@ pub unsafe fn create<T: 'static>(env: Env, v: T, finalizer: fn(Env, T)) -> Local
 
     // `napi_create_external` will only fail if the VM is in a throwing state
     // or shutting down.
-    assert_eq!(status, Ok(()));
+    let () = status.unwrap();
 
     let external = result.assume_init();
 

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -22,13 +22,14 @@ where
         out.as_mut_ptr(),
     );
 
-    if status == Err(napi::Status::PendingException) {
-        drop(Box::from_raw(data));
+    let () = match status {
+        Err(err @ napi::Status::PendingException) => {
+            drop(Box::from_raw(data));
 
-        return Err(napi::Status::PendingException);
-    }
-
-    assert_eq!(status, Ok(()));
+            return Err(err);
+        }
+        status => status.unwrap(),
+    };
 
     let out = out.assume_init();
 
@@ -54,7 +55,7 @@ where
         // If adding the finalizer fails the closure will leak, but it would
         // be unsafe to drop it because there's no guarantee V8 won't use the
         // pointer.
-        assert_eq!(status, Ok(()));
+        let () = status.unwrap();
     }
 
     Ok(out)
@@ -67,16 +68,15 @@ where
     F: Fn(Env, napi::CallbackInfo) -> Local + 'static,
 {
     let mut data = MaybeUninit::uninit();
-    let status = napi::get_cb_info(
+    let () = napi::get_cb_info(
         env,
         info,
         ptr::null_mut(),
         ptr::null_mut(),
         ptr::null_mut(),
         data.as_mut_ptr(),
-    );
-
-    assert_eq!(status, Ok(()));
+    )
+    .unwrap();
 
     let callback = &*data.assume_init().cast::<F>();
 

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -22,7 +22,7 @@ where
         out.as_mut_ptr(),
     );
 
-    let () = match status {
+    match status {
         Err(err @ napi::Status::PendingException) => {
             drop(Box::from_raw(data));
 
@@ -55,7 +55,7 @@ where
         // If adding the finalizer fails the closure will leak, but it would
         // be unsafe to drop it because there's no guarantee V8 won't use the
         // pointer.
-        let () = status.unwrap();
+        status.unwrap();
     }
 
     Ok(out)
@@ -68,7 +68,7 @@ where
     F: Fn(Env, napi::CallbackInfo) -> Local + 'static,
 {
     let mut data = MaybeUninit::uninit();
-    let () = napi::get_cb_info(
+    napi::get_cb_info(
         env,
         info,
         ptr::null_mut(),

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -22,13 +22,13 @@ where
         out.as_mut_ptr(),
     );
 
-    if status == napi::Status::PendingException {
+    if status == Err(napi::Status::PendingException) {
         drop(Box::from_raw(data));
 
-        return Err(status);
+        return Err(napi::Status::PendingException);
     }
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     let out = out.assume_init();
 
@@ -54,7 +54,7 @@ where
         // If adding the finalizer fails the closure will leak, but it would
         // be unsafe to drop it because there's no guarantee V8 won't use the
         // pointer.
-        assert_eq!(status, napi::Status::Ok);
+        assert_eq!(status, Ok(()));
     }
 
     Ok(out)
@@ -76,7 +76,7 @@ where
         data.as_mut_ptr(),
     );
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     let callback = &*data.assume_init().cast::<F>();
 
@@ -92,5 +92,5 @@ pub unsafe fn construct(
 ) -> bool {
     let status = napi::new_instance(env, fun, argc, argv as *const _, out as *mut _);
 
-    status == napi::Status::Ok
+    status.is_ok()
 }

--- a/crates/neon/src/sys/lifecycle.rs
+++ b/crates/neon/src/sys/lifecycle.rs
@@ -17,10 +17,8 @@ use super::{bindings as napi, raw::Env};
 pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T {
     let data = Box::into_raw(Box::new(data));
 
-    assert_eq!(
-        napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut(),),
-        Ok(()),
-    );
+    let () =
+        napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut()).unwrap();
 
     data
 }
@@ -33,7 +31,7 @@ pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T 
 pub unsafe fn get_instance_data<T: Send + 'static>(env: Env) -> *mut T {
     let mut data = MaybeUninit::uninit();
 
-    assert_eq!(napi::get_instance_data(env, data.as_mut_ptr(),), Ok(()),);
+    let () = napi::get_instance_data(env, data.as_mut_ptr()).unwrap();
 
     data.assume_init().cast()
 }

--- a/crates/neon/src/sys/lifecycle.rs
+++ b/crates/neon/src/sys/lifecycle.rs
@@ -19,7 +19,7 @@ pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T 
 
     assert_eq!(
         napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut(),),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     data
@@ -33,10 +33,7 @@ pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T 
 pub unsafe fn get_instance_data<T: Send + 'static>(env: Env) -> *mut T {
     let mut data = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::get_instance_data(env, data.as_mut_ptr(),),
-        napi::Status::Ok,
-    );
+    assert_eq!(napi::get_instance_data(env, data.as_mut_ptr(),), Ok(()),);
 
     data.assume_init().cast()
 }

--- a/crates/neon/src/sys/lifecycle.rs
+++ b/crates/neon/src/sys/lifecycle.rs
@@ -17,8 +17,7 @@ use super::{bindings as napi, raw::Env};
 pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T {
     let data = Box::into_raw(Box::new(data));
 
-    let () =
-        napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut()).unwrap();
+    napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut()).unwrap();
 
     data
 }
@@ -31,7 +30,7 @@ pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T 
 pub unsafe fn get_instance_data<T: Send + 'static>(env: Env) -> *mut T {
     let mut data = MaybeUninit::uninit();
 
-    let () = napi::get_instance_data(env, data.as_mut_ptr()).unwrap();
+    napi::get_instance_data(env, data.as_mut_ptr()).unwrap();
 
     data.assume_init().cast()
 }

--- a/crates/neon/src/sys/mem.rs
+++ b/crates/neon/src/sys/mem.rs
@@ -7,7 +7,7 @@ pub unsafe fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
     let mut result = false;
     assert_eq!(
         napi::strict_equals(env, lhs, rhs, &mut result as *mut _),
-        napi::Status::Ok
+        Ok(())
     );
     result
 }

--- a/crates/neon/src/sys/mem.rs
+++ b/crates/neon/src/sys/mem.rs
@@ -5,9 +5,6 @@ use super::{
 
 pub unsafe fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::strict_equals(env, lhs, rhs, &mut result as *mut _),
-        Ok(())
-    );
+    let () = napi::strict_equals(env, lhs, rhs, &mut result as *mut _).unwrap();
     result
 }

--- a/crates/neon/src/sys/mem.rs
+++ b/crates/neon/src/sys/mem.rs
@@ -5,6 +5,6 @@ use super::{
 
 pub unsafe fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
     let mut result = false;
-    let () = napi::strict_equals(env, lhs, rhs, &mut result as *mut _).unwrap();
+    napi::strict_equals(env, lhs, rhs, &mut result as *mut _).unwrap();
     result
 }

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -120,7 +120,7 @@ unsafe fn string(env: Env, s: impl AsRef<str>) -> raw::Local {
             s.len(),
             result.as_mut_ptr(),
         ),
-        Status::Ok,
+        Ok(())
     );
 
     result.assume_init()

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -113,7 +113,7 @@ unsafe fn string(env: Env, s: impl AsRef<str>) -> raw::Local {
     let s = s.as_ref();
     let mut result = MaybeUninit::uninit();
 
-    let () = create_string_utf8(
+    create_string_utf8(
         env,
         s.as_bytes().as_ptr() as *const _,
         s.len(),

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -113,15 +113,13 @@ unsafe fn string(env: Env, s: impl AsRef<str>) -> raw::Local {
     let s = s.as_ref();
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        create_string_utf8(
-            env,
-            s.as_bytes().as_ptr() as *const _,
-            s.len(),
-            result.as_mut_ptr(),
-        ),
-        Ok(())
-    );
+    let () = create_string_utf8(
+        env,
+        s.as_bytes().as_ptr() as *const _,
+        s.len(),
+        result.as_mut_ptr(),
+    )
+    .unwrap();
 
     result.assume_init()
 }

--- a/crates/neon/src/sys/primitive.rs
+++ b/crates/neon/src/sys/primitive.rs
@@ -24,7 +24,7 @@ pub unsafe fn boolean_value(env: Env, p: Local) -> bool {
     let mut value = false;
     assert_eq!(
         napi::get_value_bool(env, p, &mut value as *mut bool),
-        napi::Status::Ok
+        Ok(())
     );
     value
 }
@@ -41,7 +41,7 @@ pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
     assert_eq!(
         napi::get_value_double(env, p, &mut value as *mut f64),
-        napi::Status::Ok
+        Ok(())
     );
     value
 }

--- a/crates/neon/src/sys/primitive.rs
+++ b/crates/neon/src/sys/primitive.rs
@@ -5,17 +5,17 @@ use super::{
 
 /// Mutates the `out` argument provided to refer to the global `undefined` object.
 pub unsafe fn undefined(out: &mut Local, env: Env) {
-    napi::get_undefined(env, out as *mut Local);
+    let () = napi::get_undefined(env, out as *mut Local).unwrap();
 }
 
 /// Mutates the `out` argument provided to refer to the global `null` object.
 pub unsafe fn null(out: &mut Local, env: Env) {
-    napi::get_null(env, out as *mut Local);
+    let () = napi::get_null(env, out as *mut Local).unwrap();
 }
 
 /// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
 pub unsafe fn boolean(out: &mut Local, env: Env, b: bool) {
-    napi::get_boolean(env, b, out as *mut Local);
+    let () = napi::get_boolean(env, b, out as *mut Local).unwrap();
 }
 
 /// Get the boolean value out of a `Local` object. If the `Local` object does not contain a
@@ -32,16 +32,13 @@ pub unsafe fn boolean_value(env: Env, p: Local) -> bool {
 /// Mutates the `out` argument provided to refer to a newly created `Local` containing a
 /// JavaScript number.
 pub unsafe fn number(out: &mut Local, env: Env, v: f64) {
-    napi::create_double(env, v, out as *mut Local);
+    let () = napi::create_double(env, v, out as *mut Local).unwrap();
 }
 
 /// Gets the underlying value of an `Local` object containing a JavaScript number. Panics if
 /// the given `Local` is not a number.
 pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    assert_eq!(
-        napi::get_value_double(env, p, &mut value as *mut f64),
-        Ok(())
-    );
+    let () = napi::get_value_double(env, p, &mut value as *mut f64).unwrap();
     value
 }

--- a/crates/neon/src/sys/primitive.rs
+++ b/crates/neon/src/sys/primitive.rs
@@ -5,17 +5,17 @@ use super::{
 
 /// Mutates the `out` argument provided to refer to the global `undefined` object.
 pub unsafe fn undefined(out: &mut Local, env: Env) {
-    let () = napi::get_undefined(env, out as *mut Local).unwrap();
+    napi::get_undefined(env, out as *mut Local).unwrap();
 }
 
 /// Mutates the `out` argument provided to refer to the global `null` object.
 pub unsafe fn null(out: &mut Local, env: Env) {
-    let () = napi::get_null(env, out as *mut Local).unwrap();
+    napi::get_null(env, out as *mut Local).unwrap();
 }
 
 /// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
 pub unsafe fn boolean(out: &mut Local, env: Env, b: bool) {
-    let () = napi::get_boolean(env, b, out as *mut Local).unwrap();
+    napi::get_boolean(env, b, out as *mut Local).unwrap();
 }
 
 /// Get the boolean value out of a `Local` object. If the `Local` object does not contain a
@@ -32,13 +32,13 @@ pub unsafe fn boolean_value(env: Env, p: Local) -> bool {
 /// Mutates the `out` argument provided to refer to a newly created `Local` containing a
 /// JavaScript number.
 pub unsafe fn number(out: &mut Local, env: Env, v: f64) {
-    let () = napi::create_double(env, v, out as *mut Local).unwrap();
+    napi::create_double(env, v, out as *mut Local).unwrap();
 }
 
 /// Gets the underlying value of an `Local` object containing a JavaScript number. Panics if
 /// the given `Local` is not a number.
 pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    let () = napi::get_value_double(env, p, &mut value as *mut f64).unwrap();
+    napi::get_value_double(env, p, &mut value as *mut f64).unwrap();
     value
 }

--- a/crates/neon/src/sys/promise.rs
+++ b/crates/neon/src/sys/promise.rs
@@ -15,7 +15,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
     let mut deferred = MaybeUninit::uninit();
     let mut promise = MaybeUninit::uninit();
 
-    let () = napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()).unwrap();
+    napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()).unwrap();
 
     (deferred.assume_init(), promise.assume_init())
 }
@@ -26,7 +26,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
 /// * `env` is a valid `napi_env` for the current thread
 /// * `resolution` is a valid `napi::Value`
 pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Value) {
-    let () = napi::resolve_deferred(env, deferred, resolution).unwrap();
+    napi::resolve_deferred(env, deferred, resolution).unwrap();
 }
 
 /// Rejects a promise from a `napi::Deferred` handle
@@ -35,7 +35,7 @@ pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Valu
 /// * `env` is a valid `napi_env` for the current thread
 /// * `rejection` is a valid `napi::Value`
 pub unsafe fn reject(env: Env, deferred: napi::Deferred, rejection: napi::Value) {
-    let () = napi::reject_deferred(env, deferred, rejection).unwrap();
+    napi::reject_deferred(env, deferred, rejection).unwrap();
 }
 
 #[cfg(feature = "napi-6")]
@@ -47,7 +47,7 @@ pub unsafe fn reject_err_message(env: Env, deferred: napi::Deferred, msg: impl A
     let msg = super::string(env, msg);
     let mut err = MaybeUninit::uninit();
 
-    let () = napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()).unwrap();
+    napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()).unwrap();
 
     reject(env, deferred, err.assume_init());
 }

--- a/crates/neon/src/sys/promise.rs
+++ b/crates/neon/src/sys/promise.rs
@@ -15,10 +15,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
     let mut deferred = MaybeUninit::uninit();
     let mut promise = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()),
-        Ok(()),
-    );
+    let () = napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()).unwrap();
 
     (deferred.assume_init(), promise.assume_init())
 }
@@ -29,7 +26,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
 /// * `env` is a valid `napi_env` for the current thread
 /// * `resolution` is a valid `napi::Value`
 pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Value) {
-    assert_eq!(napi::resolve_deferred(env, deferred, resolution), Ok(()),);
+    let () = napi::resolve_deferred(env, deferred, resolution).unwrap();
 }
 
 /// Rejects a promise from a `napi::Deferred` handle
@@ -38,7 +35,7 @@ pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Valu
 /// * `env` is a valid `napi_env` for the current thread
 /// * `rejection` is a valid `napi::Value`
 pub unsafe fn reject(env: Env, deferred: napi::Deferred, rejection: napi::Value) {
-    assert_eq!(napi::reject_deferred(env, deferred, rejection), Ok(()),);
+    let () = napi::reject_deferred(env, deferred, rejection).unwrap();
 }
 
 #[cfg(feature = "napi-6")]
@@ -50,10 +47,7 @@ pub unsafe fn reject_err_message(env: Env, deferred: napi::Deferred, msg: impl A
     let msg = super::string(env, msg);
     let mut err = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()),
-        Ok(()),
-    );
+    let () = napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()).unwrap();
 
     reject(env, deferred, err.assume_init());
 }

--- a/crates/neon/src/sys/promise.rs
+++ b/crates/neon/src/sys/promise.rs
@@ -17,7 +17,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
 
     assert_eq!(
         napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     (deferred.assume_init(), promise.assume_init())
@@ -29,10 +29,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
 /// * `env` is a valid `napi_env` for the current thread
 /// * `resolution` is a valid `napi::Value`
 pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Value) {
-    assert_eq!(
-        napi::resolve_deferred(env, deferred, resolution),
-        napi::Status::Ok,
-    );
+    assert_eq!(napi::resolve_deferred(env, deferred, resolution), Ok(()),);
 }
 
 /// Rejects a promise from a `napi::Deferred` handle
@@ -41,10 +38,7 @@ pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Valu
 /// * `env` is a valid `napi_env` for the current thread
 /// * `rejection` is a valid `napi::Value`
 pub unsafe fn reject(env: Env, deferred: napi::Deferred, rejection: napi::Value) {
-    assert_eq!(
-        napi::reject_deferred(env, deferred, rejection),
-        napi::Status::Ok,
-    );
+    assert_eq!(napi::reject_deferred(env, deferred, rejection), Ok(()),);
 }
 
 #[cfg(feature = "napi-6")]
@@ -58,7 +52,7 @@ pub unsafe fn reject_err_message(env: Env, deferred: napi::Deferred, msg: impl A
 
     assert_eq!(
         napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     reject(env, deferred, err.assume_init());

--- a/crates/neon/src/sys/reference.rs
+++ b/crates/neon/src/sys/reference.rs
@@ -8,7 +8,7 @@ use super::{
 pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
     let mut result = MaybeUninit::uninit();
 
-    let () = napi::create_reference(env, value, 1, result.as_mut_ptr()).unwrap();
+    napi::create_reference(env, value, 1, result.as_mut_ptr()).unwrap();
 
     result.assume_init()
 }
@@ -18,7 +18,7 @@ pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
 pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     let mut result = MaybeUninit::uninit();
 
-    let () = napi::reference_ref(env, value, result.as_mut_ptr()).unwrap();
+    napi::reference_ref(env, value, result.as_mut_ptr()).unwrap();
 
     result.assume_init() as usize
 }
@@ -28,7 +28,7 @@ pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
 pub unsafe fn unreference(env: Env, value: napi::Ref) {
     let mut result = MaybeUninit::uninit();
 
-    let () = napi::reference_unref(env, value, result.as_mut_ptr()).unwrap();
+    napi::reference_unref(env, value, result.as_mut_ptr()).unwrap();
 
     if result.assume_init() == 0 {
         assert_eq!(napi::delete_reference(env, value), Ok(()));
@@ -40,7 +40,7 @@ pub unsafe fn unreference(env: Env, value: napi::Ref) {
 pub unsafe fn get(env: Env, value: napi::Ref) -> Local {
     let mut result = MaybeUninit::uninit();
 
-    let () = napi::get_reference_value(env, value, result.as_mut_ptr()).unwrap();
+    napi::get_reference_value(env, value, result.as_mut_ptr()).unwrap();
 
     result.assume_init()
 }

--- a/crates/neon/src/sys/reference.rs
+++ b/crates/neon/src/sys/reference.rs
@@ -10,7 +10,7 @@ pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
 
     assert_eq!(
         napi::create_reference(env, value, 1, result.as_mut_ptr()),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     result.assume_init()
@@ -21,10 +21,7 @@ pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
 pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::reference_ref(env, value, result.as_mut_ptr()),
-        napi::Status::Ok,
-    );
+    assert_eq!(napi::reference_ref(env, value, result.as_mut_ptr()), Ok(()),);
 
     result.assume_init() as usize
 }
@@ -36,11 +33,11 @@ pub unsafe fn unreference(env: Env, value: napi::Ref) {
 
     assert_eq!(
         napi::reference_unref(env, value, result.as_mut_ptr()),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     if result.assume_init() == 0 {
-        assert_eq!(napi::delete_reference(env, value), napi::Status::Ok);
+        assert_eq!(napi::delete_reference(env, value), Ok(()));
     }
 }
 
@@ -51,7 +48,7 @@ pub unsafe fn get(env: Env, value: napi::Ref) -> Local {
 
     assert_eq!(
         napi::get_reference_value(env, value, result.as_mut_ptr()),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     result.assume_init()

--- a/crates/neon/src/sys/reference.rs
+++ b/crates/neon/src/sys/reference.rs
@@ -8,10 +8,7 @@ use super::{
 pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::create_reference(env, value, 1, result.as_mut_ptr()),
-        Ok(()),
-    );
+    let () = napi::create_reference(env, value, 1, result.as_mut_ptr()).unwrap();
 
     result.assume_init()
 }
@@ -21,7 +18,7 @@ pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
 pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(napi::reference_ref(env, value, result.as_mut_ptr()), Ok(()),);
+    let () = napi::reference_ref(env, value, result.as_mut_ptr()).unwrap();
 
     result.assume_init() as usize
 }
@@ -31,10 +28,7 @@ pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
 pub unsafe fn unreference(env: Env, value: napi::Ref) {
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::reference_unref(env, value, result.as_mut_ptr()),
-        Ok(()),
-    );
+    let () = napi::reference_unref(env, value, result.as_mut_ptr()).unwrap();
 
     if result.assume_init() == 0 {
         assert_eq!(napi::delete_reference(env, value), Ok(()));
@@ -46,10 +40,7 @@ pub unsafe fn unreference(env: Env, value: napi::Ref) {
 pub unsafe fn get(env: Env, value: napi::Ref) -> Local {
     let mut result = MaybeUninit::uninit();
 
-    assert_eq!(
-        napi::get_reference_value(env, value, result.as_mut_ptr()),
-        Ok(()),
-    );
+    let () = napi::get_reference_value(env, value, result.as_mut_ptr()).unwrap();
 
     result.assume_init()
 }

--- a/crates/neon/src/sys/scope.rs
+++ b/crates/neon/src/sys/scope.rs
@@ -14,10 +14,7 @@ impl HandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        assert_eq!(
-            napi::open_handle_scope(env, scope.as_mut_ptr()),
-            napi::Status::Ok,
-        );
+        assert_eq!(napi::open_handle_scope(env, scope.as_mut_ptr()), Ok(()),);
 
         Self {
             env,
@@ -31,7 +28,7 @@ impl Drop for HandleScope {
         unsafe {
             let _status = napi::close_handle_scope(self.env, self.scope);
 
-            debug_assert_eq!(_status, napi::Status::Ok,);
+            debug_assert_eq!(_status, Ok(()),);
         }
     }
 }
@@ -47,7 +44,7 @@ impl EscapableHandleScope {
 
         assert_eq!(
             napi::open_escapable_handle_scope(env, scope.as_mut_ptr()),
-            napi::Status::Ok,
+            Ok(()),
         );
 
         Self {
@@ -61,7 +58,7 @@ impl EscapableHandleScope {
 
         assert_eq!(
             napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()),
-            napi::Status::Ok,
+            Ok(()),
         );
 
         escapee.assume_init()
@@ -73,11 +70,11 @@ impl Drop for EscapableHandleScope {
         unsafe {
             let _status = napi::close_escapable_handle_scope(self.env, self.scope);
 
-            debug_assert_eq!(_status, napi::Status::Ok,);
+            debug_assert_eq!(_status, Ok(()),);
         }
     }
 }
 
 pub unsafe fn get_global(env: Env, out: &mut Local) {
-    assert_eq!(super::get_global(env, out as *mut _), napi::Status::Ok);
+    assert_eq!(super::get_global(env, out as *mut _), Ok(()));
 }

--- a/crates/neon/src/sys/scope.rs
+++ b/crates/neon/src/sys/scope.rs
@@ -14,7 +14,7 @@ impl HandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        let () = napi::open_handle_scope(env, scope.as_mut_ptr()).unwrap();
+        napi::open_handle_scope(env, scope.as_mut_ptr()).unwrap();
 
         Self {
             env,
@@ -42,7 +42,7 @@ impl EscapableHandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        let () = napi::open_escapable_handle_scope(env, scope.as_mut_ptr()).unwrap();
+        napi::open_escapable_handle_scope(env, scope.as_mut_ptr()).unwrap();
 
         Self {
             env,
@@ -53,7 +53,7 @@ impl EscapableHandleScope {
     pub(crate) unsafe fn escape(&self, value: napi::Value) -> napi::Value {
         let mut escapee = MaybeUninit::uninit();
 
-        let () = napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()).unwrap();
+        napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()).unwrap();
 
         escapee.assume_init()
     }
@@ -70,5 +70,5 @@ impl Drop for EscapableHandleScope {
 }
 
 pub unsafe fn get_global(env: Env, out: &mut Local) {
-    let () = super::get_global(env, out as *mut _).unwrap();
+    super::get_global(env, out as *mut _).unwrap();
 }

--- a/crates/neon/src/sys/scope.rs
+++ b/crates/neon/src/sys/scope.rs
@@ -14,7 +14,7 @@ impl HandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        assert_eq!(napi::open_handle_scope(env, scope.as_mut_ptr()), Ok(()),);
+        let () = napi::open_handle_scope(env, scope.as_mut_ptr()).unwrap();
 
         Self {
             env,
@@ -42,10 +42,7 @@ impl EscapableHandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        assert_eq!(
-            napi::open_escapable_handle_scope(env, scope.as_mut_ptr()),
-            Ok(()),
-        );
+        let () = napi::open_escapable_handle_scope(env, scope.as_mut_ptr()).unwrap();
 
         Self {
             env,
@@ -56,10 +53,7 @@ impl EscapableHandleScope {
     pub(crate) unsafe fn escape(&self, value: napi::Value) -> napi::Value {
         let mut escapee = MaybeUninit::uninit();
 
-        assert_eq!(
-            napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()),
-            Ok(()),
-        );
+        let () = napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()).unwrap();
 
         escapee.assume_init()
     }
@@ -76,5 +70,5 @@ impl Drop for EscapableHandleScope {
 }
 
 pub unsafe fn get_global(env: Env, out: &mut Local) {
-    assert_eq!(super::get_global(env, out as *mut _), Ok(()));
+    let () = super::get_global(env, out as *mut _).unwrap();
 }

--- a/crates/neon/src/sys/string.rs
+++ b/crates/neon/src/sys/string.rs
@@ -13,30 +13,30 @@ pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool 
 
 pub unsafe fn utf8_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
-    let () = napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
+    napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
 
     len.assume_init()
 }
 
 pub unsafe fn data(env: Env, out: *mut u8, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
-    let () =
-        napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr()).unwrap();
+
+    napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr()).unwrap();
 
     read.assume_init()
 }
 
 pub unsafe fn utf16_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
-    let () =
-        napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
+
+    napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
 
     len.assume_init()
 }
 
 pub unsafe fn data_utf16(env: Env, out: *mut u16, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
-    let () = napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr()).unwrap();
+    napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr()).unwrap();
 
     read.assume_init()
 }

--- a/crates/neon/src/sys/string.rs
+++ b/crates/neon/src/sys/string.rs
@@ -13,36 +13,30 @@ pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool 
 
 pub unsafe fn utf8_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
-    let status = napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
 
     len.assume_init()
 }
 
 pub unsafe fn data(env: Env, out: *mut u8, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
-    let status = napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () =
+        napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr()).unwrap();
 
     read.assume_init()
 }
 
 pub unsafe fn utf16_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
-    let status = napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () =
+        napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
 
     len.assume_init()
 }
 
 pub unsafe fn data_utf16(env: Env, out: *mut u16, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
-    let status = napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr());
-
-    assert_eq!(status, Ok(()));
+    let () = napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr()).unwrap();
 
     read.assume_init()
 }

--- a/crates/neon/src/sys/string.rs
+++ b/crates/neon/src/sys/string.rs
@@ -8,14 +8,14 @@ use super::{
 pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool {
     let status = napi::create_string_utf8(env, data as *const _, len as usize, out);
 
-    status == napi::Status::Ok
+    status.is_ok()
 }
 
 pub unsafe fn utf8_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
     let status = napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     len.assume_init()
 }
@@ -24,7 +24,7 @@ pub unsafe fn data(env: Env, out: *mut u8, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
     let status = napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     read.assume_init()
 }
@@ -33,7 +33,7 @@ pub unsafe fn utf16_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
     let status = napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     len.assume_init()
 }
@@ -42,7 +42,7 @@ pub unsafe fn data_utf16(env: Env, out: *mut u16, len: usize, value: Local) -> u
     let mut read = MaybeUninit::uninit();
     let status = napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr());
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     read.assume_init()
 }
@@ -50,5 +50,5 @@ pub unsafe fn data_utf16(env: Env, out: *mut u16, len: usize, value: Local) -> u
 pub unsafe fn run_script(out: &mut Local, env: Env, value: Local) -> bool {
     let status = napi::run_script(env, value, out as *mut _);
 
-    status == napi::Status::Ok
+    status == Ok(())
 }

--- a/crates/neon/src/sys/tag.rs
+++ b/crates/neon/src/sys/tag.rs
@@ -6,7 +6,7 @@ use super::{
 /// Return true if an `napi_value` `val` has the expected value type.
 unsafe fn is_type(env: Env, val: Local, expect: napi::ValueType) -> bool {
     let mut actual = napi::ValueType::Undefined;
-    let () = napi::typeof_value(env, val, &mut actual as *mut _).unwrap();
+    napi::typeof_value(env, val, &mut actual as *mut _).unwrap();
     actual == expect
 }
 
@@ -49,35 +49,35 @@ pub unsafe fn is_function(env: Env, val: Local) -> bool {
 
 pub unsafe fn is_error(env: Env, val: Local) -> bool {
     let mut result = false;
-    let () = napi::is_error(env, val, &mut result as *mut _).unwrap();
+    napi::is_error(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 /// Is `val` a Node.js Buffer instance?
 pub unsafe fn is_buffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    let () = napi::is_buffer(env, val, &mut result as *mut _).unwrap();
+    napi::is_buffer(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 /// Is `val` an ArrayBuffer instance?
 pub unsafe fn is_arraybuffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    let () = napi::is_arraybuffer(env, val, &mut result as *mut _).unwrap();
+    napi::is_arraybuffer(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 /// Is `val` a TypedArray instance?
 pub unsafe fn is_typedarray(env: Env, val: Local) -> bool {
     let mut result = false;
-    let () = napi::is_typedarray(env, val, &mut result as *mut _).unwrap();
+    napi::is_typedarray(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 #[cfg(feature = "napi-5")]
 pub unsafe fn is_date(env: Env, val: Local) -> bool {
     let mut result = false;
-    let () = napi::is_date(env, val, &mut result as *mut _).unwrap();
+    napi::is_date(env, val, &mut result as *mut _).unwrap();
     result
 }
 
@@ -87,20 +87,20 @@ pub unsafe fn is_date(env: Env, val: Local) -> bool {
 /// * `env` is a valid `napi_env` for the current thread
 pub unsafe fn is_promise(env: Env, val: Local) -> bool {
     let mut result = false;
-    let () = napi::is_promise(env, val, &mut result as *mut _).unwrap();
+    napi::is_promise(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn type_tag_object(env: Env, object: Local, tag: &super::TypeTag) {
-    let () = napi::type_tag_object(env, object, tag as *const _).unwrap();
+    napi::type_tag_object(env, object, tag as *const _).unwrap();
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn check_object_type_tag(env: Env, object: Local, tag: &super::TypeTag) -> bool {
     let mut result = false;
-    let () =
-        napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _).unwrap();
+
+    napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _).unwrap();
     result
 }
 

--- a/crates/neon/src/sys/tag.rs
+++ b/crates/neon/src/sys/tag.rs
@@ -6,7 +6,7 @@ use super::{
 /// Return true if an `napi_value` `val` has the expected value type.
 unsafe fn is_type(env: Env, val: Local, expect: napi::ValueType) -> bool {
     let mut actual = napi::ValueType::Undefined;
-    assert_eq!(napi::typeof_value(env, val, &mut actual as *mut _), Ok(()));
+    let () = napi::typeof_value(env, val, &mut actual as *mut _).unwrap();
     actual == expect
 }
 
@@ -49,38 +49,35 @@ pub unsafe fn is_function(env: Env, val: Local) -> bool {
 
 pub unsafe fn is_error(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(napi::is_error(env, val, &mut result as *mut _), Ok(()));
+    let () = napi::is_error(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 /// Is `val` a Node.js Buffer instance?
 pub unsafe fn is_buffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(napi::is_buffer(env, val, &mut result as *mut _), Ok(()));
+    let () = napi::is_buffer(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 /// Is `val` an ArrayBuffer instance?
 pub unsafe fn is_arraybuffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_arraybuffer(env, val, &mut result as *mut _),
-        Ok(())
-    );
+    let () = napi::is_arraybuffer(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 /// Is `val` a TypedArray instance?
 pub unsafe fn is_typedarray(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(napi::is_typedarray(env, val, &mut result as *mut _), Ok(()));
+    let () = napi::is_typedarray(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 #[cfg(feature = "napi-5")]
 pub unsafe fn is_date(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(napi::is_date(env, val, &mut result as *mut _), Ok(()));
+    let () = napi::is_date(env, val, &mut result as *mut _).unwrap();
     result
 }
 
@@ -90,22 +87,20 @@ pub unsafe fn is_date(env: Env, val: Local) -> bool {
 /// * `env` is a valid `napi_env` for the current thread
 pub unsafe fn is_promise(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(napi::is_promise(env, val, &mut result as *mut _), Ok(()));
+    let () = napi::is_promise(env, val, &mut result as *mut _).unwrap();
     result
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn type_tag_object(env: Env, object: Local, tag: &super::TypeTag) {
-    assert_eq!(napi::type_tag_object(env, object, tag as *const _), Ok(()));
+    let () = napi::type_tag_object(env, object, tag as *const _).unwrap();
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn check_object_type_tag(env: Env, object: Local, tag: &super::TypeTag) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _),
-        Ok(())
-    );
+    let () =
+        napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _).unwrap();
     result
 }
 

--- a/crates/neon/src/sys/tag.rs
+++ b/crates/neon/src/sys/tag.rs
@@ -6,10 +6,7 @@ use super::{
 /// Return true if an `napi_value` `val` has the expected value type.
 unsafe fn is_type(env: Env, val: Local, expect: napi::ValueType) -> bool {
     let mut actual = napi::ValueType::Undefined;
-    assert_eq!(
-        napi::typeof_value(env, val, &mut actual as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::typeof_value(env, val, &mut actual as *mut _), Ok(()));
     actual == expect
 }
 
@@ -42,10 +39,7 @@ pub unsafe fn is_object(env: Env, val: Local) -> bool {
 
 pub unsafe fn is_array(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_array(env, val, &mut result as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::is_array(env, val, &mut result as *mut _), Ok(()));
     result
 }
 
@@ -55,20 +49,14 @@ pub unsafe fn is_function(env: Env, val: Local) -> bool {
 
 pub unsafe fn is_error(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_error(env, val, &mut result as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::is_error(env, val, &mut result as *mut _), Ok(()));
     result
 }
 
 /// Is `val` a Node.js Buffer instance?
 pub unsafe fn is_buffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_buffer(env, val, &mut result as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::is_buffer(env, val, &mut result as *mut _), Ok(()));
     result
 }
 
@@ -77,7 +65,7 @@ pub unsafe fn is_arraybuffer(env: Env, val: Local) -> bool {
     let mut result = false;
     assert_eq!(
         napi::is_arraybuffer(env, val, &mut result as *mut _),
-        napi::Status::Ok
+        Ok(())
     );
     result
 }
@@ -85,20 +73,14 @@ pub unsafe fn is_arraybuffer(env: Env, val: Local) -> bool {
 /// Is `val` a TypedArray instance?
 pub unsafe fn is_typedarray(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_typedarray(env, val, &mut result as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::is_typedarray(env, val, &mut result as *mut _), Ok(()));
     result
 }
 
 #[cfg(feature = "napi-5")]
 pub unsafe fn is_date(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_date(env, val, &mut result as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::is_date(env, val, &mut result as *mut _), Ok(()));
     result
 }
 
@@ -108,19 +90,13 @@ pub unsafe fn is_date(env: Env, val: Local) -> bool {
 /// * `env` is a valid `napi_env` for the current thread
 pub unsafe fn is_promise(env: Env, val: Local) -> bool {
     let mut result = false;
-    assert_eq!(
-        napi::is_promise(env, val, &mut result as *mut _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::is_promise(env, val, &mut result as *mut _), Ok(()));
     result
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn type_tag_object(env: Env, object: Local, tag: &super::TypeTag) {
-    assert_eq!(
-        napi::type_tag_object(env, object, tag as *const _),
-        napi::Status::Ok
-    );
+    assert_eq!(napi::type_tag_object(env, object, tag as *const _), Ok(()));
 }
 
 #[cfg(feature = "napi-8")]
@@ -128,7 +104,7 @@ pub unsafe fn check_object_type_tag(env: Env, object: Local, tag: &super::TypeTa
     let mut result = false;
     assert_eq!(
         napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _),
-        napi::Status::Ok
+        Ok(())
     );
     result
 }

--- a/crates/neon/src/sys/tsfn.rs
+++ b/crates/neon/src/sys/tsfn.rs
@@ -129,13 +129,13 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     /// References a threadsafe function to prevent exiting the event loop until it has been dropped. (Default)
     /// Safety: `Env` must be valid for the current thread
     pub unsafe fn reference(&self, env: Env) {
-        let () = napi::ref_threadsafe_function(env, self.tsfn.0).unwrap();
+        napi::ref_threadsafe_function(env, self.tsfn.0).unwrap();
     }
 
     /// Unreferences a threadsafe function to allow exiting the event loop before it has been dropped.
     /// Safety: `Env` must be valid for the current thread
     pub unsafe fn unref(&self, env: Env) {
-        let () = napi::unref_threadsafe_function(env, self.tsfn.0).unwrap();
+        napi::unref_threadsafe_function(env, self.tsfn.0).unwrap();
     }
 
     // Provides a C ABI wrapper for a napi callback notifying us about tsfn

--- a/crates/neon/src/sys/tsfn.rs
+++ b/crates/neon/src/sys/tsfn.rs
@@ -129,13 +129,13 @@ impl<T: Send + 'static> ThreadsafeFunction<T> {
     /// References a threadsafe function to prevent exiting the event loop until it has been dropped. (Default)
     /// Safety: `Env` must be valid for the current thread
     pub unsafe fn reference(&self, env: Env) {
-        assert_eq!(napi::ref_threadsafe_function(env, self.tsfn.0), Ok(()),);
+        let () = napi::ref_threadsafe_function(env, self.tsfn.0).unwrap();
     }
 
     /// Unreferences a threadsafe function to allow exiting the event loop before it has been dropped.
     /// Safety: `Env` must be valid for the current thread
     pub unsafe fn unref(&self, env: Env) {
-        assert_eq!(napi::unref_threadsafe_function(env, self.tsfn.0), Ok(()),);
+        let () = napi::unref_threadsafe_function(env, self.tsfn.0).unwrap();
     }
 
     // Provides a C ABI wrapper for a napi callback notifying us about tsfn

--- a/crates/neon/src/sys/typedarray.rs
+++ b/crates/neon/src/sys/typedarray.rs
@@ -34,7 +34,7 @@ pub unsafe fn info(env: Env, value: Local) -> TypedArrayInfo {
             &mut (*ptr).buf,
             &mut (*ptr).offset,
         ),
-        napi::Status::Ok,
+        Ok(()),
     );
 
     info.assume_init()
@@ -50,11 +50,11 @@ pub unsafe fn new(
     let mut array = MaybeUninit::uninit();
     let status = napi::create_typedarray(env, typ, len, buffer, offset, array.as_mut_ptr());
 
-    if status == napi::Status::PendingException {
-        return Err(status);
+    if status == Err(napi::Status::PendingException) {
+        return Err(napi::Status::PendingException);
     }
 
-    assert_eq!(status, napi::Status::Ok);
+    assert_eq!(status, Ok(()));
 
     Ok(array.assume_init())
 }

--- a/crates/neon/src/sys/typedarray.rs
+++ b/crates/neon/src/sys/typedarray.rs
@@ -50,11 +50,10 @@ pub unsafe fn new(
     let mut array = MaybeUninit::uninit();
     let status = napi::create_typedarray(env, typ, len, buffer, offset, array.as_mut_ptr());
 
-    if status == Err(napi::Status::PendingException) {
-        return Err(napi::Status::PendingException);
-    }
-
-    assert_eq!(status, Ok(()));
+    let () = match status {
+        Err(err @ napi::Status::PendingException) => return Err(err),
+        status => status.unwrap(),
+    };
 
     Ok(array.assume_init())
 }

--- a/crates/neon/src/sys/typedarray.rs
+++ b/crates/neon/src/sys/typedarray.rs
@@ -50,7 +50,7 @@ pub unsafe fn new(
     let mut array = MaybeUninit::uninit();
     let status = napi::create_typedarray(env, typ, len, buffer, offset, array.as_mut_ptr());
 
-    let () = match status {
+    match status {
         Err(err @ napi::Status::PendingException) => return Err(err),
         status => status.unwrap(),
     };

--- a/crates/neon/src/types_impl/bigint.rs
+++ b/crates/neon/src/types_impl/bigint.rs
@@ -78,7 +78,7 @@ impl JsBigInt {
         let v = unsafe {
             assert_eq!(
                 sys::create_bigint_int64(cx.env().to_raw(), n, v.as_mut_ptr(),),
-                sys::Status::Ok,
+                Ok(()),
             );
 
             v.assume_init()
@@ -106,7 +106,7 @@ impl JsBigInt {
         let v = unsafe {
             assert_eq!(
                 sys::create_bigint_uint64(cx.env().to_raw(), n, v.as_mut_ptr(),),
-                sys::Status::Ok,
+                Ok(())
             );
 
             v.assume_init()
@@ -210,7 +210,7 @@ impl JsBigInt {
                     digits.as_ptr(),
                     v.as_mut_ptr(),
                 ),
-                sys::Status::Ok,
+                Ok(())
             );
 
             v.assume_init()
@@ -236,7 +236,7 @@ impl JsBigInt {
         unsafe {
             assert_eq!(
                 sys::get_value_bigint_int64(cx.env().to_raw(), self.0, &mut n, &mut lossless),
-                sys::Status::Ok,
+                Ok(())
             );
         }
 
@@ -260,7 +260,7 @@ impl JsBigInt {
         unsafe {
             assert_eq!(
                 sys::get_value_bigint_uint64(cx.env().to_raw(), self.0, &mut n, &mut lossless),
-                sys::Status::Ok,
+                Ok(())
             );
         }
 
@@ -394,7 +394,7 @@ impl JsBigInt {
                     &mut word_count,
                     digits.as_mut_ptr(),
                 ),
-                sys::Status::Ok,
+                Ok(())
             );
         }
 

--- a/crates/neon/src/types_impl/bigint.rs
+++ b/crates/neon/src/types_impl/bigint.rs
@@ -76,7 +76,7 @@ impl JsBigInt {
     {
         let mut v = MaybeUninit::uninit();
         let v = unsafe {
-            let () = sys::create_bigint_int64(cx.env().to_raw(), n, v.as_mut_ptr()).unwrap();
+            sys::create_bigint_int64(cx.env().to_raw(), n, v.as_mut_ptr()).unwrap();
 
             v.assume_init()
         };
@@ -101,7 +101,7 @@ impl JsBigInt {
     {
         let mut v = MaybeUninit::uninit();
         let v = unsafe {
-            let () = sys::create_bigint_uint64(cx.env().to_raw(), n, v.as_mut_ptr()).unwrap();
+            sys::create_bigint_uint64(cx.env().to_raw(), n, v.as_mut_ptr()).unwrap();
 
             v.assume_init()
         };
@@ -196,7 +196,7 @@ impl JsBigInt {
 
         let mut v = MaybeUninit::uninit();
         let v = unsafe {
-            let () = sys::create_bigint_words(
+            sys::create_bigint_words(
                 cx.env().to_raw(),
                 sign_bit,
                 digits.len(),
@@ -226,8 +226,7 @@ impl JsBigInt {
         let mut lossless = false;
 
         unsafe {
-            let () = sys::get_value_bigint_int64(cx.env().to_raw(), self.0, &mut n, &mut lossless)
-                .unwrap();
+            sys::get_value_bigint_int64(cx.env().to_raw(), self.0, &mut n, &mut lossless).unwrap();
         }
 
         if lossless {
@@ -248,8 +247,7 @@ impl JsBigInt {
         let mut lossless = false;
 
         unsafe {
-            let () = sys::get_value_bigint_uint64(cx.env().to_raw(), self.0, &mut n, &mut lossless)
-                .unwrap();
+            sys::get_value_bigint_uint64(cx.env().to_raw(), self.0, &mut n, &mut lossless).unwrap();
         }
 
         if lossless {
@@ -374,7 +372,7 @@ impl JsBigInt {
         let mut word_count = digits.len();
 
         unsafe {
-            let () = sys::get_value_bigint_words(
+            sys::get_value_bigint_words(
                 cx.env().to_raw(),
                 self.0,
                 &mut sign_bit,

--- a/crates/neon/src/types_impl/bigint.rs
+++ b/crates/neon/src/types_impl/bigint.rs
@@ -76,10 +76,7 @@ impl JsBigInt {
     {
         let mut v = MaybeUninit::uninit();
         let v = unsafe {
-            assert_eq!(
-                sys::create_bigint_int64(cx.env().to_raw(), n, v.as_mut_ptr(),),
-                Ok(()),
-            );
+            let () = sys::create_bigint_int64(cx.env().to_raw(), n, v.as_mut_ptr()).unwrap();
 
             v.assume_init()
         };
@@ -104,10 +101,7 @@ impl JsBigInt {
     {
         let mut v = MaybeUninit::uninit();
         let v = unsafe {
-            assert_eq!(
-                sys::create_bigint_uint64(cx.env().to_raw(), n, v.as_mut_ptr(),),
-                Ok(())
-            );
+            let () = sys::create_bigint_uint64(cx.env().to_raw(), n, v.as_mut_ptr()).unwrap();
 
             v.assume_init()
         };
@@ -202,16 +196,14 @@ impl JsBigInt {
 
         let mut v = MaybeUninit::uninit();
         let v = unsafe {
-            assert_eq!(
-                sys::create_bigint_words(
-                    cx.env().to_raw(),
-                    sign_bit,
-                    digits.len(),
-                    digits.as_ptr(),
-                    v.as_mut_ptr(),
-                ),
-                Ok(())
-            );
+            let () = sys::create_bigint_words(
+                cx.env().to_raw(),
+                sign_bit,
+                digits.len(),
+                digits.as_ptr(),
+                v.as_mut_ptr(),
+            )
+            .unwrap();
 
             v.assume_init()
         };
@@ -234,10 +226,8 @@ impl JsBigInt {
         let mut lossless = false;
 
         unsafe {
-            assert_eq!(
-                sys::get_value_bigint_int64(cx.env().to_raw(), self.0, &mut n, &mut lossless),
-                Ok(())
-            );
+            let () = sys::get_value_bigint_int64(cx.env().to_raw(), self.0, &mut n, &mut lossless)
+                .unwrap();
         }
 
         if lossless {
@@ -258,10 +248,8 @@ impl JsBigInt {
         let mut lossless = false;
 
         unsafe {
-            assert_eq!(
-                sys::get_value_bigint_uint64(cx.env().to_raw(), self.0, &mut n, &mut lossless),
-                Ok(())
-            );
+            let () = sys::get_value_bigint_uint64(cx.env().to_raw(), self.0, &mut n, &mut lossless)
+                .unwrap();
         }
 
         if lossless {
@@ -386,16 +374,14 @@ impl JsBigInt {
         let mut word_count = digits.len();
 
         unsafe {
-            assert_eq!(
-                sys::get_value_bigint_words(
-                    cx.env().to_raw(),
-                    self.0,
-                    &mut sign_bit,
-                    &mut word_count,
-                    digits.as_mut_ptr(),
-                ),
-                Ok(())
-            );
+            let () = sys::get_value_bigint_words(
+                cx.env().to_raw(),
+                self.0,
+                &mut sign_bit,
+                &mut word_count,
+                digits.as_mut_ptr(),
+            )
+            .unwrap();
         }
 
         let sign = if sign_bit == 0 {

--- a/crates/neon/src/types_impl/extract/try_from_js.rs
+++ b/crates/neon/src/types_impl/extract/try_from_js.rs
@@ -81,7 +81,7 @@ impl<'cx> TryFromJs<'cx> for f64 {
         let mut n = 0f64;
 
         unsafe {
-            let () = match sys::get_value_double(cx.env().to_raw(), v.to_local(), &mut n) {
+            match sys::get_value_double(cx.env().to_raw(), v.to_local(), &mut n) {
                 Err(sys::Status::NumberExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
                 status => status.unwrap(),
@@ -102,7 +102,7 @@ impl<'cx> TryFromJs<'cx> for bool {
         let mut b = false;
 
         unsafe {
-            let () = match sys::get_value_bool(cx.env().to_raw(), v.to_local(), &mut b) {
+            match sys::get_value_bool(cx.env().to_raw(), v.to_local(), &mut b) {
                 Err(sys::Status::BooleanExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
                 status => status.unwrap(),
@@ -125,7 +125,7 @@ impl<'cx> TryFromJs<'cx> for String {
         let mut len = 0usize;
 
         unsafe {
-            let () = match sys::get_value_string_utf8(env, v, ptr::null_mut(), 0, &mut len) {
+            match sys::get_value_string_utf8(env, v, ptr::null_mut(), 0, &mut len) {
                 Err(sys::Status::StringExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
                 status => status.unwrap(),
@@ -168,7 +168,7 @@ impl<'cx> TryFromJs<'cx> for Date {
         let mut d = 0f64;
 
         unsafe {
-            let () = match sys::get_date_value(cx.env().to_raw(), v.to_local(), &mut d) {
+            match sys::get_date_value(cx.env().to_raw(), v.to_local(), &mut d) {
                 Err(sys::Status::DateExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
                 status => status.unwrap(),
@@ -259,7 +259,7 @@ where
     let mut ty = sys::ValueType::Object;
 
     unsafe {
-        let () = match sys::typeof_value(cx.env().to_raw(), v.to_local(), &mut ty) {
+        match sys::typeof_value(cx.env().to_raw(), v.to_local(), &mut ty) {
             Err(sys::Status::PendingException) => return Err(Throw::new()),
             status => status.unwrap(),
         };

--- a/crates/neon/src/types_impl/extract/try_from_js.rs
+++ b/crates/neon/src/types_impl/extract/try_from_js.rs
@@ -82,9 +82,9 @@ impl<'cx> TryFromJs<'cx> for f64 {
 
         unsafe {
             match sys::get_value_double(cx.env().to_raw(), v.to_local(), &mut n) {
-                sys::Status::NumberExpected => return Ok(Err(TypeExpected::new())),
-                sys::Status::PendingException => return Err(Throw::new()),
-                status => assert_eq!(status, sys::Status::Ok),
+                Err(sys::Status::NumberExpected) => return Ok(Err(TypeExpected::new())),
+                Err(sys::Status::PendingException) => return Err(Throw::new()),
+                status => assert_eq!(status, Ok(())),
             }
         }
 
@@ -103,9 +103,9 @@ impl<'cx> TryFromJs<'cx> for bool {
 
         unsafe {
             match sys::get_value_bool(cx.env().to_raw(), v.to_local(), &mut b) {
-                sys::Status::BooleanExpected => return Ok(Err(TypeExpected::new())),
-                sys::Status::PendingException => return Err(Throw::new()),
-                status => assert_eq!(status, sys::Status::Ok),
+                Err(sys::Status::BooleanExpected) => return Ok(Err(TypeExpected::new())),
+                Err(sys::Status::PendingException) => return Err(Throw::new()),
+                status => assert_eq!(status, Ok(())),
             }
         }
 
@@ -126,9 +126,9 @@ impl<'cx> TryFromJs<'cx> for String {
 
         unsafe {
             match sys::get_value_string_utf8(env, v, ptr::null_mut(), 0, &mut len) {
-                sys::Status::StringExpected => return Ok(Err(TypeExpected::new())),
-                sys::Status::PendingException => return Err(Throw::new()),
-                status => assert_eq!(status, sys::Status::Ok),
+                Err(sys::Status::StringExpected) => return Ok(Err(TypeExpected::new())),
+                Err(sys::Status::PendingException) => return Err(Throw::new()),
+                status => assert_eq!(status, Ok(())),
             }
         }
 
@@ -145,7 +145,7 @@ impl<'cx> TryFromJs<'cx> for String {
                     buf.capacity(),
                     &mut written,
                 ),
-                sys::Status::Ok,
+                Ok(())
             );
 
             debug_assert_eq!(len, written);
@@ -169,9 +169,9 @@ impl<'cx> TryFromJs<'cx> for Date {
 
         unsafe {
             match sys::get_date_value(cx.env().to_raw(), v.to_local(), &mut d) {
-                sys::Status::DateExpected => return Ok(Err(TypeExpected::new())),
-                sys::Status::PendingException => return Err(Throw::new()),
-                status => assert_eq!(status, sys::Status::Ok),
+                Err(sys::Status::DateExpected) => return Ok(Err(TypeExpected::new())),
+                Err(sys::Status::PendingException) => return Err(Throw::new()),
+                status => assert_eq!(status, Ok(())),
             }
         }
 
@@ -260,8 +260,8 @@ where
 
     unsafe {
         match sys::typeof_value(cx.env().to_raw(), v.to_local(), &mut ty) {
-            sys::Status::PendingException => return Err(Throw::new()),
-            status => assert_eq!(status, sys::Status::Ok),
+            Err(sys::Status::PendingException) => return Err(Throw::new()),
+            status => assert_eq!(status, Ok(())),
         }
     }
 

--- a/crates/neon/src/types_impl/extract/try_from_js.rs
+++ b/crates/neon/src/types_impl/extract/try_from_js.rs
@@ -81,11 +81,11 @@ impl<'cx> TryFromJs<'cx> for f64 {
         let mut n = 0f64;
 
         unsafe {
-            match sys::get_value_double(cx.env().to_raw(), v.to_local(), &mut n) {
+            let () = match sys::get_value_double(cx.env().to_raw(), v.to_local(), &mut n) {
                 Err(sys::Status::NumberExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
-                status => assert_eq!(status, Ok(())),
-            }
+                status => status.unwrap(),
+            };
         }
 
         Ok(Ok(n))
@@ -102,11 +102,11 @@ impl<'cx> TryFromJs<'cx> for bool {
         let mut b = false;
 
         unsafe {
-            match sys::get_value_bool(cx.env().to_raw(), v.to_local(), &mut b) {
+            let () = match sys::get_value_bool(cx.env().to_raw(), v.to_local(), &mut b) {
                 Err(sys::Status::BooleanExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
-                status => assert_eq!(status, Ok(())),
-            }
+                status => status.unwrap(),
+            };
         }
 
         Ok(Ok(b))
@@ -125,11 +125,11 @@ impl<'cx> TryFromJs<'cx> for String {
         let mut len = 0usize;
 
         unsafe {
-            match sys::get_value_string_utf8(env, v, ptr::null_mut(), 0, &mut len) {
+            let () = match sys::get_value_string_utf8(env, v, ptr::null_mut(), 0, &mut len) {
                 Err(sys::Status::StringExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
-                status => assert_eq!(status, Ok(())),
-            }
+                status => status.unwrap(),
+            };
         }
 
         // Make room for null terminator to avoid losing a character
@@ -168,11 +168,11 @@ impl<'cx> TryFromJs<'cx> for Date {
         let mut d = 0f64;
 
         unsafe {
-            match sys::get_date_value(cx.env().to_raw(), v.to_local(), &mut d) {
+            let () = match sys::get_date_value(cx.env().to_raw(), v.to_local(), &mut d) {
                 Err(sys::Status::DateExpected) => return Ok(Err(TypeExpected::new())),
                 Err(sys::Status::PendingException) => return Err(Throw::new()),
-                status => assert_eq!(status, Ok(())),
-            }
+                status => status.unwrap(),
+            };
         }
 
         Ok(Ok(Date(d)))
@@ -259,10 +259,10 @@ where
     let mut ty = sys::ValueType::Object;
 
     unsafe {
-        match sys::typeof_value(cx.env().to_raw(), v.to_local(), &mut ty) {
+        let () = match sys::typeof_value(cx.env().to_raw(), v.to_local(), &mut ty) {
             Err(sys::Status::PendingException) => return Err(Throw::new()),
-            status => assert_eq!(status, Ok(())),
-        }
+            status => status.unwrap(),
+        };
     }
 
     Ok(matches!(

--- a/crates/neon/src/types_impl/private.rs
+++ b/crates/neon/src/types_impl/private.rs
@@ -112,17 +112,17 @@ pub trait ValueInternal: TransparentNoCopyWrapper + 'static {
 unsafe fn check_call_status<'a, C: Context<'a>>(
     cx: &mut C,
     callee: raw::Local,
-    status: sys::Status,
+    status: Result<(), sys::Status>,
 ) -> NeonResult<()> {
     match status {
-        sys::Status::InvalidArg if !sys::tag::is_function(cx.env().to_raw(), callee) => {
+        Err(sys::Status::InvalidArg) if !sys::tag::is_function(cx.env().to_raw(), callee) => {
             return cx.throw_error("not a function");
         }
-        sys::Status::PendingException => {
+        Err(sys::Status::PendingException) => {
             return Err(Throw::new());
         }
         status => {
-            assert_eq!(status, sys::Status::Ok);
+            assert_eq!(status, Ok(()));
         }
     }
 

--- a/crates/neon/src/types_impl/private.rs
+++ b/crates/neon/src/types_impl/private.rs
@@ -121,9 +121,7 @@ unsafe fn check_call_status<'a, C: Context<'a>>(
         Err(sys::Status::PendingException) => {
             return Err(Throw::new());
         }
-        status => {
-            assert_eq!(status, Ok(()));
-        }
+        status => status.unwrap(),
     }
 
     Ok(())


### PR DESCRIPTION
This doesn't bubble the `Result` return type all the way to the top, and it uses the existing status code as the error type instead of defining a new type as suggested in https://github.com/neon-bindings/neon/issues/802#issuecomment-2341793293.

Progress on #802