### PR TITLE
feat(neon): Add more TryIntoJs and TryFromJs implementations

### DIFF
--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -1,6 +1,7 @@
 use crate::{
     context::FunctionContext,
-    handle::Handle,
+    handle::{Handle, Root},
+    object::Object,
     result::{NeonResult, Throw},
     types::{
         buffer::Binary,
@@ -34,6 +35,8 @@ impl Sealed for () {}
 impl Sealed for &str {}
 
 impl<'cx, V: Value> Sealed for Handle<'cx, V> {}
+
+impl<O: Object> Sealed for Root<O> {}
 
 impl<T> Sealed for Option<T> {}
 

--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     context::FunctionContext,
     handle::{Handle, Root},
@@ -5,7 +7,7 @@ use crate::{
     result::{NeonResult, Throw},
     types::{
         buffer::Binary,
-        extract::{ArrayBuffer, Buffer, Date, Error},
+        extract::{ArrayBuffer, Buffer, Date, Error, TryIntoJs},
         JsTypedArray, Value,
     },
 };
@@ -34,6 +36,8 @@ impl Sealed for () {}
 
 impl Sealed for &str {}
 
+impl Sealed for &String {}
+
 impl<'cx, V: Value> Sealed for Handle<'cx, V> {}
 
 impl<O: Object> Sealed for Root<O> {}
@@ -49,12 +53,37 @@ where
 {
 }
 
+impl<T> Sealed for Box<[T]>
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+}
+
+impl<T, const N: usize> Sealed for [T; N]
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+}
+
+impl<T> Sealed for &Vec<T>
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+}
+
 impl<T> Sealed for &[T]
 where
     JsTypedArray<T>: Value,
     T: Binary,
 {
 }
+
+impl<'cx, T> Sealed for Arc<T> where for<'a> &'a T: TryIntoJs<'cx> {}
+
+impl<'cx, T> Sealed for Box<T> where T: TryIntoJs<'cx> {}
 
 impl_sealed!(
     u8,

--- a/crates/neon/src/types_impl/extract/try_from_js.rs
+++ b/crates/neon/src/types_impl/extract/try_from_js.rs
@@ -7,7 +7,8 @@ use std::{convert::Infallible, ptr};
 
 use crate::{
     context::{internal::ContextInternal, Cx},
-    handle::Handle,
+    handle::{Handle, Root},
+    object::Object,
     result::{NeonResult, ResultExt, Throw},
     sys,
     types::{
@@ -40,6 +41,25 @@ where
         v: Handle<'cx, JsValue>,
     ) -> NeonResult<Result<Self, Self::Error>> {
         Ok(v.downcast(cx).map_err(|_| TypeExpected::new()))
+    }
+
+    from_js!();
+}
+
+impl<'cx, O> TryFromJs<'cx> for Root<O>
+where
+    O: Object,
+{
+    type Error = TypeExpected<O>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        Ok(match v.downcast::<O, _>(cx) {
+            Ok(v) => Ok(v.root(cx)),
+            Err(_) => Err(TypeExpected::new()),
+        })
     }
 
     from_js!();


### PR DESCRIPTION
While trying `#[neon::export]` out in another project, I found some trivial `TryFromJs` and `TryIntoJs` implementations that simplified code.

* `TryFromJs` for `Root<T>`. We can call `.root(cx)` when extracting
* `TryIntoJs` for `Box<T>` and `Arc<T>` smart pointers. This is especially useful if you want to return an `Arc<Vec<T>>` and convert it into a typed array.
* `TryIntoJs` for `&Vec<T>` and `&String`. We already had the slice versions, but it's nice to have these as well when combined with the smart pointers above.

I wanted to implement for `T` where `T: AsRef<U>` and `for<'a> &'a U: TryIntoJs<'cx>`, but this isn't possible since `U` wouldn't be bound by the implementation. It also conflicts with some specialized versions.

There's a bunch more that we _could_ add (e.g., `Box<str>`), but I'm trying to be a little conservative and not implement for a bunch of strange types that users don't need. These are all convenience implementations anyway. Users have `With` as an escape hatch.