### PR TITLE
fix(create-neon): Render diagnostics to stderr in cargo build

### DIFF
--- a/pkgs/create-neon/package.json
+++ b/pkgs/create-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-neon",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Create Neon projects with no build configuration.",
   "type": "module",
   "exports": "./dist/src/bin/create-neon.js",

--- a/pkgs/create-neon/src/create/app.ts
+++ b/pkgs/create-neon/src/create/app.ts
@@ -8,8 +8,10 @@ export class AppCreator extends Creator {
   scripts(): Record<string, string> {
     return {
       test: "cargo test",
-      "cargo-build": "cargo build --message-format=json > cargo.log",
-      "cross-build": "cross build --message-format=json > cross.log",
+      "cargo-build":
+        "cargo build --message-format=json-render-diagnostics > cargo.log",
+      "cross-build":
+        "cross build --message-format=json-render-diagnostics > cross.log",
       "postcargo-build": "neon dist < cargo.log",
       "postcross-build": "neon dist -m /target < cross.log",
       debug: "npm run cargo-build --",

--- a/pkgs/create-neon/src/create/lib.ts
+++ b/pkgs/create-neon/src/create/lib.ts
@@ -95,8 +95,8 @@ export class LibCreator extends Creator {
 
     let scripts: Record<string, string> = {
       test: `${tscAnd}cargo test`,
-      "cargo-build": `${tscAnd}cargo build --message-format=json > cargo.log`,
-      "cross-build": `${tscAnd}cross build --message-format=json > cross.log`,
+      "cargo-build": `${tscAnd}cargo build --message-format=json-render-diagnostics > cargo.log`,
+      "cross-build": `${tscAnd}cross build --message-format=json-render-diagnostics > cross.log`,
       "postcargo-build": "neon dist < cargo.log",
       "postcross-build": "neon dist -m /target < cross.log",
       debug: "npm run cargo-build --",


### PR DESCRIPTION
Currently, `create-neon` uses `--message-format=json` which outputs diagnostics (e.g., compile errors) to `stdout` in JSON metadata. This makes it difficult to see compiler errors. For example, I have started with the out-of-the-box Neon app and changed the return type of `hello` to be `JsNumber`.

```sh
$ npm run build

> example@0.1.0 build
> npm run cargo-build -- --release


> example@0.1.0 cargo-build
> cargo build --message-format=json > cargo.log --release

   Compiling example v0.1.0 (/private/tmp/example)
error: could not compile `example` (lib) due to 2 previous errors
```

The error message does not show. If I change to `--message-format=json-render-diagnostics`, artifacts will still be sent to `stdout`, but compile errors will be rendered in human readable form on `stderr`.

```sh
$ npm run build

> example@0.1.0 build
> npm run cargo-build -- --release


> example@0.1.0 cargo-build
> cargo build --message-format=json-render-diagnostics > cargo.log --release

   Compiling example v0.1.0 (/private/tmp/example)
error[E0308]: mismatched types
   --> src/lib.rs:4:8
    |
4   |     Ok(cx.string("hello node"))
    |     -- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Handle<'_, JsNumber>`, found `Handle<'_, JsString>`
    |     |
    |     arguments to this enum variant are incorrect
    |
    = note: expected struct `Handle<'_, neon::prelude::JsNumber>`
               found struct `Handle<'_, JsString>`
```