### PR TITLE
feat(neon): Add neon::types::extract::Boxed for JsBox conversions

### DIFF
--- a/crates/neon/src/types_impl/extract/boxed.rs
+++ b/crates/neon/src/types_impl/extract/boxed.rs
@@ -1,0 +1,79 @@
+use crate::{
+    context::{Context, Cx},
+    handle::Handle,
+    result::{JsResult, NeonResult, ResultExt},
+    types::{
+        extract::{private, TryFromJs, TryIntoJs, TypeExpected},
+        Finalize, JsBox, JsValue,
+    },
+};
+
+/// Wrapper to extract `T` from a [`JsBox<T>`](JsBox) or create a [`JsBox`]
+/// from a `T`.
+///
+/// [`Boxed`] is especially useful for exporting async functions and tasks.
+///
+/// ```
+/// # use std::sync::Arc;
+/// # use neon::{prelude::*, types::extract::Boxed};
+/// struct Greeter {
+///     greeting: String,
+/// }
+///
+/// impl Finalize for Greeter {}
+///
+/// impl Greeter {
+///     fn new(greeting: String) -> Self {
+///         Self { greeting }
+///     }
+///
+///     fn greet(&self, name: &str) -> String {
+///         format!("{}, {name}!", self.greeting)
+///     }
+/// }
+///
+/// #[neon::export]
+/// fn create_greeter(greeting: String) -> Boxed<Arc<Greeter>> {
+///     Boxed(Arc::new(Greeter::new(greeting)))
+/// }
+///
+/// #[neon::export(task)]
+/// fn greet(Boxed(greeter): Boxed<Arc<Greeter>>, name: String) -> String {
+///     greeter.greet(&name)
+/// }
+/// ```
+pub struct Boxed<T>(pub T);
+
+impl<'cx, T> TryFromJs<'cx> for Boxed<T>
+where
+    T: Clone + 'static,
+{
+    type Error = TypeExpected<JsBox<T>>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<T>, _>(cx) {
+            Ok(v) => Ok(Ok(Self(T::clone(&v)))),
+            Err(_) => Ok(Err(TypeExpected::new())),
+        }
+    }
+
+    fn from_js(cx: &mut Cx<'cx>, v: Handle<'cx, JsValue>) -> NeonResult<Self> {
+        Self::try_from_js(cx, v)?.or_throw(cx)
+    }
+}
+
+impl<'cx, T> TryIntoJs<'cx> for Boxed<T>
+where
+    T: Finalize + 'static,
+{
+    type Value = JsBox<T>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        Ok(cx.boxed(self.0))
+    }
+}
+
+impl<T> private::Sealed for Boxed<T> {}

--- a/crates/neon/src/types_impl/extract/mod.rs
+++ b/crates/neon/src/types_impl/extract/mod.rs
@@ -108,12 +108,13 @@ use crate::{
     types::{JsValue, Value},
 };
 
-pub use self::{error::Error, with::With};
+pub use self::{boxed::Boxed, error::Error, with::With};
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub use self::json::Json;
 
+mod boxed;
 mod error;
 #[cfg(feature = "serde")]
 mod json;


### PR DESCRIPTION
`JsBox<T>` can be extract in an exported function.

```rust
#[neon::export]
fn example(boxed: Handle<JsBox<String>>) {}
```

However, this only works for synchronous functions. If you need boxed data in an async function or task, it requires first cloning it in a sync function, which can be verbose.

```rust
#[neon::export]
fn example<'cx>(cx: &mut FunctionContext<'cx>, s: Handle<'cx, JsBox<String>>) -> Handle<'cx, JsPromise> {
    let s = String::clone(&s);
    
    cx.task(move || s).promise(|mut cx, s| cx.string(s))
}
```

However, we can trivially implement `TryFromJs` where `T: Clone`. It *must* be clone because `JsBox` only allows immutable references. This allows a much more ergonomic version.

```rust
#[neon::export(task)]
fn example(Boxed(s): Boxed<String>) -> String {
    s
}
```

Similarly, we can implement `TryIntoJs` for `Boxed` by calling `cx.boxed(..)`. The `TryIntoJs` implementation does not require `Clone` because we already have an owned copy.