### PR TITLE
Un-deprecate `JsFunction::{call, exec, construct}`

### DIFF
--- a/crates/neon/src/types_impl/mod.rs
+++ b/crates/neon/src/types_impl/mod.rs
@@ -1119,8 +1119,7 @@ impl JsFunction {
 impl JsFunction {
     /// Calls this function.
     ///
-    /// **See also:** [`JsFunction::call_with`].
-    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
+    /// **See also:** [`JsFunction::bind`].
     pub fn call<'a, 'b, C: Context<'a>, T, AS>(
         &self,
         cx: &mut C,
@@ -1136,8 +1135,7 @@ impl JsFunction {
 
     /// Calls this function for side effect, discarding its result.
     ///
-    /// **See also:** [`JsFunction::call_with`].
-    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
+    /// **See also:** [`JsFunction::bind`].
     pub fn exec<'a, 'b, C: Context<'a>, T, AS>(
         &self,
         cx: &mut C,
@@ -1154,8 +1152,7 @@ impl JsFunction {
 
     /// Calls this function as a constructor.
     ///
-    /// **See also:** [`JsFunction::construct_with`].
-    #[deprecated(since = "TBD", note = "use `JsFunction::bind` instead")]
+    /// **See also:** [`JsFunction::bind`].
     pub fn construct<'a, 'b, C: Context<'a>, AS>(
         &self,
         cx: &mut C,


### PR DESCRIPTION
This PR un-deprecates `JsFunction::{call, exec, construct}` as lower-level primitives (which have also existed for a while, so it's a more invasive change for existing users than deprecating `call_with` and `construct_with`).