### PR TITLE
feature(create-neon): namespaced libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@neon-rs/manifest": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@neon-rs/manifest/-/manifest-0.1.0.tgz",
-      "integrity": "sha512-CtmcJbqczgEjiU169n+ZdmWwKLDFz5PSybmD6JbzzzWIi9JaLh5Jpk67vipN5AnEwYUEtXVSUmmkJGwzRBu5Ug==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@neon-rs/manifest/-/manifest-0.2.1.tgz",
+      "integrity": "sha512-DDDROadZXorclce/M/pHTmgwllgSt6Dm7KFhiGPP+pThYgg6K4igspha93UQyxmq6Y12yvrQlcEjK6TPaamlZQ==",
       "dependencies": {
         "jscodeshift": "^0.15.1"
       }
@@ -6069,7 +6069,7 @@
       "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@neon-rs/manifest": "^0.1.0",
+        "@neon-rs/manifest": "^0.2.1",
         "chalk": "^5.3.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",

--- a/pkgs/create-neon/data/templates/manifest/base/default.json.hbs
+++ b/pkgs/create-neon/data/templates/manifest/base/default.json.hbs
@@ -1,6 +1,6 @@
 
 {
-  "name": "{{options.name}}",
+  "name": "{{options.fullName}}",
   "version": "{{options.version}}",
   "main": "index.node",
   "scripts": {},

--- a/pkgs/create-neon/data/templates/manifest/base/library.json.hbs
+++ b/pkgs/create-neon/data/templates/manifest/base/library.json.hbs
@@ -1,6 +1,6 @@
 
 {
-  "name": "{{options.name}}",
+  "name": "{{options.fullName}}",
   "version": "{{options.version}}",
 {{#eq options.library.module compare="esm"}}
   "exports": {

--- a/pkgs/create-neon/data/templates/manifest/base/library.json.hbs
+++ b/pkgs/create-neon/data/templates/manifest/base/library.json.hbs
@@ -28,6 +28,9 @@
 {{#if options.library.cache.org}}
     "org": "{{options.library.cache.org}}",
 {{/if}}
+{{#if options.library.cache.prefix}}
+    "prefix": "{{options.library.cache.prefix}}",
+{{/if}}
 {{/eq}}
     "platforms": {},
     "load": "./src/load.cts"

--- a/pkgs/create-neon/data/versions.json
+++ b/pkgs/create-neon/data/versions.json
@@ -1,7 +1,7 @@
 {
   "neon": "1",
-  "neonCLI": "0.1.73",
-  "neonLoad": "0.1.73",
+  "neonCLI": "0.1.82",
+  "neonLoad": "0.1.82",
   "typescript": "5.3.3",
   "typesNode": "20.11.16",
   "tsconfigNode": {

--- a/pkgs/create-neon/package.json
+++ b/pkgs/create-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-neon",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Create Neon projects with no build configuration.",
   "type": "module",
   "exports": "./dist/src/bin/create-neon.js",

--- a/pkgs/create-neon/package.json
+++ b/pkgs/create-neon/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@neon-rs/manifest": "^0.1.0",
+    "@neon-rs/manifest": "^0.2.1",
     "chalk": "^5.3.0",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^7.0.1",

--- a/pkgs/create-neon/src/bin/create-neon.ts
+++ b/pkgs/create-neon/src/bin/create-neon.ts
@@ -40,7 +40,8 @@ try {
   }
 
   const [pkg] = opts._unknown;
-  const { org, basename } = /^((?<org>@[^/]+)\/)?(?<basename>.*)/.exec(pkg)?.groups as {
+  const { org, basename } = /^((?<org>@[^/]+)\/)?(?<basename>.*)/.exec(pkg)
+    ?.groups as {
     org: string;
     basename: string;
   };
@@ -158,7 +159,7 @@ function parseCache(
   //   bin: @acme-libs/logo-generator-darwin-arm64
   if (bins.startsWith("npm:")) {
     const split = bins.substring(4).split("/", 2);
-    const org = split[0].replace(/^@?/, '@'); // don't care if they include the @ or not
+    const org = split[0].replace(/^@?/, "@"); // don't care if they include the @ or not
     const prefix = split.length > 1 ? split[1] : defaultPrefix;
     return new NPM(org, prefix);
   }

--- a/pkgs/create-neon/src/bin/create-neon.ts
+++ b/pkgs/create-neon/src/bin/create-neon.ts
@@ -40,8 +40,10 @@ try {
   }
 
   const [pkg] = opts._unknown;
+  const { org, name } =
+    /^(@(?<org>[^/]+)\/)?(?<name>.*)/.exec(pkg)?.groups as { org: string; name: string };
   const platforms = parsePlatforms(opts.platform);
-  const cache = parseCache(opts.lib, opts.bins, pkg);
+  const cache = parseCache(opts.lib, opts.bins, name, org);
   const ci = parseCI(opts.ci);
 
   if (opts.yes) {
@@ -49,7 +51,8 @@ try {
   }
 
   createNeon({
-    name: pkg,
+    org,
+    name,
     version: "0.1.0",
     library: opts.lib
       ? {
@@ -112,21 +115,50 @@ function parseCI(ci: string): CI | undefined {
 function parseCache(
   lib: boolean,
   bins: string,
-  pkg: string
+  pkg: string,
+  org: string | undefined
 ): Cache | undefined {
-  if (bins === "none") {
-    return lib ? new NPM(pkg) : undefined;
+  let prefix = org ? `${pkg}-` : "";
+  org ??= `@${pkg}`;
+
+  // CASE: npm create neon -- --app logos-r-us
+  // CASE: npm create neon -- --app @acme/logos-r-us
+  //   - <no binaries cache>
+  if (bins === "none" && !lib) {
+    return undefined;
   }
 
-  if (bins === "npm") {
-    return new NPM(pkg);
+  // CASE: npm create neon -- --lib logo-generator
+  // CASE: npm create neon -- --lib --bins npm logo-generator
+  //   - lib: `logo-generator`
+  //   - bin: `@logo-generator/darwin-arm64`
+
+  // CASE: npm create neon -- --lib @acme/logo-generator
+  // CASE: npm create neon -- --lib --bins npm @acme/logo-generator
+  //   - lib: `@acme/logo-generator`
+  //   - bin: `@acme/logo-generator-darwin-arm64`
+  if (bins === "none" || bins === "npm") {
+    return new NPM(org, prefix);
   }
 
+  // CASE: npm create neon -- --lib --bins=npm:acme logo-generator
+  //   lib: logo-generator
+  //   bin: @acme/logo-generator-darwin-arm64
+
+  // CASE: npm create neon -- --lib --bins=npm:acme/libs-logo-generator- logo-generator
+  //   lib: logo-generator
+  //   bin: @acme/libs-logo-generator-darwin-arm64
+
+  // CASE: npm create neon -- --lib --bins=npm:acme-libs @acme/logo-generator
+  //   lib: @acme-libs/logo-generator
+  //   bin: @acme-libs/logo-generator-darwin-arm64
   if (bins.startsWith("npm:")) {
-    return new NPM(pkg, bins.substring(4));
+    const split = bins.substring(4).split('/', 2);
+
+    return new NPM(split[0], split.length > 1 ? split[1] : prefix);
   }
 
   throw new Error(
-    `Unrecognized binaries cache ${bins}, expected 'npm[:org]' or 'none'`
+    `Unrecognized binaries cache ${bins}, expected 'npm[:org[/prefix]]' or 'none'`
   );
 }

--- a/pkgs/create-neon/src/bin/create-neon.ts
+++ b/pkgs/create-neon/src/bin/create-neon.ts
@@ -45,7 +45,7 @@ try {
     org?: string;
     basename: string;
   };
-  const fullName = org ? `${org}/${basename}` : basename;
+  const fullName = org ? pkg : basename;
   const platforms = parsePlatforms(opts.platform);
   const cache = parseCache(opts.lib, opts.bins, basename, org);
   const ci = parseCI(opts.ci);

--- a/pkgs/create-neon/src/bin/create-neon.ts
+++ b/pkgs/create-neon/src/bin/create-neon.ts
@@ -40,8 +40,10 @@ try {
   }
 
   const [pkg] = opts._unknown;
-  const { org, name } =
-    /^(@(?<org>[^/]+)\/)?(?<name>.*)/.exec(pkg)?.groups as { org: string; name: string };
+  const { org, name } = /^(@(?<org>[^/]+)\/)?(?<name>.*)/.exec(pkg)?.groups as {
+    org: string;
+    name: string;
+  };
   const platforms = parsePlatforms(opts.platform);
   const cache = parseCache(opts.lib, opts.bins, name, org);
   const ci = parseCI(opts.ci);
@@ -153,7 +155,7 @@ function parseCache(
   //   lib: @acme-libs/logo-generator
   //   bin: @acme-libs/logo-generator-darwin-arm64
   if (bins.startsWith("npm:")) {
-    const split = bins.substring(4).split('/', 2);
+    const split = bins.substring(4).split("/", 2);
 
     return new NPM(split[0], split.length > 1 ? split[1] : prefix);
   }

--- a/pkgs/create-neon/src/bin/create-neon.ts
+++ b/pkgs/create-neon/src/bin/create-neon.ts
@@ -42,7 +42,7 @@ try {
   const [pkg] = opts._unknown;
   const { org, basename } = /^((?<org>@[^/]+)\/)?(?<basename>.*)/.exec(pkg)
     ?.groups as {
-    org: string;
+    org?: string;
     basename: string;
   };
   const fullName = org ? `${org}/${basename}` : basename;

--- a/pkgs/create-neon/src/cache/npm.ts
+++ b/pkgs/create-neon/src/cache/npm.ts
@@ -2,15 +2,12 @@ import { Cache } from "../cache.js";
 
 export class NPM implements Cache {
   readonly org: string;
+  readonly prefix: string;
 
   readonly type: string = "npm";
 
-  constructor(pkg: string, org?: string) {
-    this.org = org || NPM.inferOrg(pkg);
-  }
-
-  static inferOrg(pkg: string): string {
-    const m = pkg.match(/^@([^/]+)\/(.*)/);
-    return `@${m?.[1] ?? pkg}`;
+  constructor(org: string, prefix: string) {
+    this.org = org;
+    this.prefix = prefix;
   }
 }

--- a/pkgs/create-neon/src/create/creator.ts
+++ b/pkgs/create-neon/src/create/creator.ts
@@ -29,6 +29,7 @@ export type LibraryOptions = {
 };
 
 export type ProjectOptions = {
+  org?: string | undefined;
   name: string;
   version: string;
   library: LibraryOptions | null;

--- a/pkgs/create-neon/src/create/creator.ts
+++ b/pkgs/create-neon/src/create/creator.ts
@@ -30,7 +30,8 @@ export type LibraryOptions = {
 
 export type ProjectOptions = {
   org?: string | undefined;
-  name: string;
+  basename: string;
+  fullName: string;
   version: string;
   library: LibraryOptions | null;
   app: boolean | null;
@@ -65,12 +66,12 @@ export abstract class Creator {
   async create(cx: Context): Promise<void> {
     try {
       this._temp = await mktemp();
-      this._tempPkg = path.join(this._temp, this._options.name);
+      this._tempPkg = path.join(this._temp, this._options.basename);
 
       await fs.mkdir(this._tempPkg);
     } catch (err: any) {
       await die(
-        `Could not create \`${this._options.name}\`: ${err.message}`,
+        `Could not create \`${this._options.basename}\`: ${err.message}`,
         this._temp
       );
     }
@@ -123,11 +124,11 @@ export abstract class Creator {
     await this.createNeonBoilerplate(cx);
 
     try {
-      await fs.rename(this._tempPkg, this._options.name);
+      await fs.rename(this._tempPkg, this._options.basename);
       await fs.rmdir(this._temp);
     } catch (err: any) {
       await die(
-        `Could not create \`${this._options.name}\`: ${err.message}`,
+        `Could not create \`${this._options.basename}\`: ${err.message}`,
         this._tempPkg
       );
     }

--- a/pkgs/create-neon/src/index.ts
+++ b/pkgs/create-neon/src/index.ts
@@ -61,9 +61,20 @@ async function askProjectType(options: ProjectOptions) {
         ? await dialog.ask({
             prompt: "cache org",
             parse: (v: string): string => v,
-            default: NPM.inferOrg(options.name),
+            default: `@${options.org ?? options.name}`,
           })
         : null;
+
+    const prefix =
+      cache === "npm" && org === `@${options.name}`
+      ? ""
+      : cache === "npm"
+      ? await dialog.ask({
+          prompt: "cache prefix",
+          parse: (v: string): string => v,
+          default: `${options.name}-`,
+      })
+      : null;
 
     const ci = await dialog.ask({
       prompt: "ci provider",
@@ -76,7 +87,7 @@ async function askProjectType(options: ProjectOptions) {
     options.library = {
       lang: Lang.TS,
       module: ModuleType.ESM,
-      cache: cache === "npm" ? new NPM(options.name, org!) : undefined,
+      cache: cache === "npm" ? new NPM(org!, prefix!) : undefined,
       ci: ci === "github" ? new GitHub() : undefined,
       platforms: platforms.length === 1 ? platforms[0] : platforms,
     };

--- a/pkgs/create-neon/src/index.ts
+++ b/pkgs/create-neon/src/index.ts
@@ -58,11 +58,13 @@ async function askProjectType(options: ProjectOptions) {
 
     const org =
       cache === "npm"
-        ? (await dialog.ask({
-            prompt: "cache org",
-            parse: (v: string): string => v,
-            default: `@${options.org ?? options.basename}`,
-          })).replace(/^@?/, "@") // don't care if they include the @ or not
+        ? (
+            await dialog.ask({
+              prompt: "cache org",
+              parse: (v: string): string => v,
+              default: `@${options.org ?? options.basename}`,
+            })
+          ).replace(/^@?/, "@") // don't care if they include the @ or not
         : null;
 
     const prefix =

--- a/pkgs/create-neon/src/index.ts
+++ b/pkgs/create-neon/src/index.ts
@@ -62,7 +62,7 @@ async function askProjectType(options: ProjectOptions) {
             await dialog.ask({
               prompt: "cache org",
               parse: (v: string): string => v,
-              default: `@${options.org ?? options.basename}`,
+              default: options.org ?? `@${options.basename}`,
             })
           ).replace(/^@?/, "@") // don't care if they include the @ or not
         : null;

--- a/pkgs/create-neon/src/index.ts
+++ b/pkgs/create-neon/src/index.ts
@@ -58,21 +58,21 @@ async function askProjectType(options: ProjectOptions) {
 
     const org =
       cache === "npm"
-        ? await dialog.ask({
+        ? (await dialog.ask({
             prompt: "cache org",
             parse: (v: string): string => v,
-            default: `@${options.org ?? options.name}`,
-          })
+            default: `@${options.org ?? options.basename}`,
+          })).replace(/^@?/, "@") // don't care if they include the @ or not
         : null;
 
     const prefix =
-      cache === "npm" && org === `@${options.name}`
+      cache === "npm" && org === `@${options.basename}`
         ? ""
         : cache === "npm"
         ? await dialog.ask({
             prompt: "cache prefix",
             parse: (v: string): string => v,
-            default: `${options.name}-`,
+            default: `${options.basename}-`,
           })
         : null;
 
@@ -99,9 +99,9 @@ async function askProjectType(options: ProjectOptions) {
 
 export async function createNeon(options: ProjectOptions): Promise<void> {
   try {
-    await assertCanMkdir(options.name);
+    await assertCanMkdir(options.basename);
   } catch (err: any) {
-    await die(`Could not create \`${options.name}\`: ${err.message}`);
+    await die(`Could not create \`${options.basename}\`: ${err.message}`);
   }
 
   const cx = new Context(options);
@@ -124,6 +124,6 @@ export async function createNeon(options: ProjectOptions): Promise<void> {
   await creator.create(cx);
 
   console.log(
-    `✨ Created Neon project \`${options.name}\`. Happy 🦀 hacking! ✨`
+    `✨ Created Neon project \`${options.fullName}\`. Happy 🦀 hacking! ✨`
   );
 }

--- a/pkgs/create-neon/src/index.ts
+++ b/pkgs/create-neon/src/index.ts
@@ -67,14 +67,14 @@ async function askProjectType(options: ProjectOptions) {
 
     const prefix =
       cache === "npm" && org === `@${options.name}`
-      ? ""
-      : cache === "npm"
-      ? await dialog.ask({
-          prompt: "cache prefix",
-          parse: (v: string): string => v,
-          default: `${options.name}-`,
-      })
-      : null;
+        ? ""
+        : cache === "npm"
+        ? await dialog.ask({
+            prompt: "cache prefix",
+            parse: (v: string): string => v,
+            default: `${options.name}-`,
+          })
+        : null;
 
     const ci = await dialog.ask({
       prompt: "ci provider",

--- a/pkgs/create-neon/test/create-neon.ts
+++ b/pkgs/create-neon/test/create-neon.ts
@@ -222,7 +222,7 @@ describe("Project creation", () => {
 
     assert.strictEqual(json.neon.type, "library");
     assert.strictEqual(json.neon.org, "@dherman");
-    assert.strictEqual(json.neon.prefix, "create-neon-test-project-")
+    assert.strictEqual(json.neon.prefix, "create-neon-test-project-");
     assert.strictEqual(json.neon.platforms, "common");
     assert.strictEqual(json.neon.load, "./src/load.cts");
 

--- a/pkgs/create-neon/test/create-neon.ts
+++ b/pkgs/create-neon/test/create-neon.ts
@@ -33,6 +33,7 @@ describe("Command-line argument validation", () => {
 });
 
 const PROJECT = "create-neon-test-project";
+const NAMESPACED_PROJECT = "@dherman/create-neon-test-project";
 
 describe("Project creation", () => {
   afterEach(async () => {
@@ -182,6 +183,46 @@ describe("Project creation", () => {
 
     assert.strictEqual(json.neon.type, "library");
     assert.strictEqual(json.neon.org, "@create-neon-test-project");
+    assert.notProperty(json.neon, "prefix");
+    assert.strictEqual(json.neon.platforms, "common");
+    assert.strictEqual(json.neon.load, "./src/load.cts");
+
+    TOML.parse(
+      await fs.readFile(path.join(PROJECT, "Cargo.toml"), { encoding: "utf8" })
+    );
+  });
+
+  it("asks for a prefix when Neon lib is namespaced", async () => {
+    try {
+      await expect(spawn(NODE, [CREATE_NEON, NAMESPACED_PROJECT]), {
+        "neon project type": "lib",
+        "neon target platforms": "",
+        "neon binary cache": "",
+        "neon cache org": "",
+        "neon cache prefix": "",
+        "neon ci provider": "",
+        "package name:": "",
+        "version:": "",
+        "description:": "",
+        "git repository:": "",
+        "keywords:": "",
+        "author:": "",
+        "license:": "",
+        "Is this OK?": "",
+      });
+    } catch (error: any) {
+      assert.fail("create-neon unexpectedly failed: " + error.message);
+    }
+
+    let json = JSON.parse(
+      await fs.readFile(path.join(PROJECT, "package.json"), {
+        encoding: "utf8",
+      })
+    );
+
+    assert.strictEqual(json.neon.type, "library");
+    assert.strictEqual(json.neon.org, "@dherman");
+    assert.strictEqual(json.neon.prefix, "create-neon-test-project-")
     assert.strictEqual(json.neon.platforms, "common");
     assert.strictEqual(json.neon.load, "./src/load.cts");
 


### PR DESCRIPTION
This PR adds support for namespaced libraries with optionally prefixed binary prebuild packages.

Details:
- optionally generate prefix field when generating package.json
- bump generated CLI dependency number to 0.1.82
- allow both `quux` and `@foobar/quux` style names in cmdline arg
- allow naming scheme to be given explicitly via `--bins npm[:org[/prefix]]`

Full case analysis of command-line options:

| Command-line args                                           | Main package         | Binaries org      | Binaries prefix          | Example binary                         |
|-------------------------------------------------------------|----------------------|-------------------|--------------------------|----------------------------------------|
| `--app logos-r-us`                                          | logos-r-us           | N/A               | N/A                    | N/A                                    |
| `--lib logo-generator`                                      | logo-generator       | `@logo-generator` | `""`                     | @logo-generator/darwin-arm64           |
| `--lib --bins=npm:acme logo-generator`                      | logo-generator       | `@acme`           | `"logo-generator-"`      | @acme/logo-generator-darwin-arm64      |
| `--lib --bins=npm:acme/libs-logo-generator- logo-generator` | logo-generator       | `@acme`           | `"libs-logo-generator-"` | @acme/libs-logo-generator-darwin-arm64 |
| `--lib @acme/logo-generator`                                | @acme/logo-generator | `@acme`           | `"logo-generator-"`      | @acme/logo-generator-darwin-arm64      |
| `--lib --bins=npm:acme-libs @acme/logo-generator`           | @acme/logo-generator | `@acme-libs`      | `"logo-generator-"`      | @acme-libs/logo-generator-darwin-arm64 |