### PR TITLE
fix(neon): Relax lifetime constraints on `With` and provide helper for forcing HRTB with JS values

### DIFF
--- a/crates/neon/src/macros.rs
+++ b/crates/neon/src/macros.rs
@@ -201,15 +201,15 @@ pub use neon_macros::main;
 /// ```
 /// # #[cfg(all(feature = "napi-6", feature = "futures"))]
 /// # {
-/// # use neon::types::extract::{TryIntoJs, With};
+/// # use neon::types::extract::{self, TryIntoJs};
 /// #[neon::export]
 /// async fn add(a: f64, b: f64) -> impl for<'cx> TryIntoJs<'cx> {
 ///     let sum = a + b;
 ///
-///     With(move |_cx| {
+///     extract::with(move |cx| {
 ///         println!("Hello from the JavaScript main thread!");
 ///
-///         sum
+///         sum.try_into_js(cx)
 ///     })
 /// }
 /// # }

--- a/crates/neon/src/types_impl/extract/mod.rs
+++ b/crates/neon/src/types_impl/extract/mod.rs
@@ -113,7 +113,7 @@ pub use self::{
         Int32Array, Int8Array, Uint16Array, Uint32Array, Uint8Array,
     },
     error::{Error, TypeExpected},
-    with::With,
+    with::with,
 };
 
 #[cfg(feature = "serde")]

--- a/crates/neon/src/types_impl/function/mod.rs
+++ b/crates/neon/src/types_impl/function/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     object::Object,
     result::{JsResult, NeonResult},
     types::{
-        extract::{TryFromJs, TryIntoJs, With},
+        extract::{TryFromJs, TryIntoJs},
         private::ValueInternal,
         JsFunction, JsObject, JsValue, Value,
     },
@@ -215,23 +215,6 @@ impl<'cx> private::TryIntoArgumentsInternal<'cx> for () {
     fn try_into_args_vec(self, _cx: &mut Cx<'cx>) -> NeonResult<private::ArgsVec<'cx>> {
         Ok(smallvec![])
     }
-}
-
-impl<'cx, F, O> private::TryIntoArgumentsInternal<'cx> for With<F, O>
-where
-    F: FnOnce(&mut Cx) -> O,
-    O: private::TryIntoArgumentsInternal<'cx>,
-{
-    fn try_into_args_vec(self, cx: &mut Cx<'cx>) -> NeonResult<private::ArgsVec<'cx>> {
-        (self.0)(cx).try_into_args_vec(cx)
-    }
-}
-
-impl<'cx, F, O> TryIntoArguments<'cx> for With<F, O>
-where
-    F: FnOnce(&mut Cx) -> O,
-    O: TryIntoArguments<'cx>,
-{
 }
 
 impl<'cx, T, E> private::TryIntoArgumentsInternal<'cx> for Result<T, E>

--- a/test/napi/lib/extract.js
+++ b/test/napi/lib/extract.js
@@ -90,4 +90,11 @@ describe("Extractors", () => {
       }
     );
   });
+
+  it("With", async () => {
+    assert.strictEqual(await addon.sleepWithJs(1.5), 1.5);
+    assert.strictEqual(await addon.sleepWithJsSync(1.5), 1.5);
+    assert.strictEqual(await addon.sleepWith(1.5), 1.5);
+    assert.strictEqual(await addon.sleepWithSync(1.5), 1.5);
+  });
 });

--- a/test/napi/src/js/extract.rs
+++ b/test/napi/src/js/extract.rs
@@ -158,3 +158,36 @@ pub fn buffer_concat(mut a: Vec<u8>, Uint8Array(b): Uint8Array<Vec<u8>>) -> Arra
 pub fn string_to_buf(s: String) -> Uint8Array<String> {
     Uint8Array(s)
 }
+
+#[neon::export(task)]
+// Ensure that `with` produces a closure that can be moved across thread boundaries
+// and can return a JavaScript value.
+fn sleep_with_js(n: f64) -> impl for<'cx> TryIntoJs<'cx> {
+    use std::{thread, time::Duration};
+
+    thread::sleep(Duration::from_millis(n as u64));
+
+    with(move |cx| Ok(cx.number(n)))
+}
+
+#[neon::export]
+// Ensure that `with` can be used synchronously
+fn sleep_with_js_sync(n: f64) -> impl for<'cx> TryIntoJs<'cx> {
+    sleep_with_js(n)
+}
+
+#[neon::export(task)]
+// Ensure that `With` can be used Rust data
+fn sleep_with(n: f64) -> impl for<'cx> TryIntoJs<'cx> {
+    use std::{thread, time::Duration};
+
+    thread::sleep(Duration::from_millis(n as u64));
+
+    with(move |cx| n.try_into_js(cx))
+}
+
+#[neon::export]
+// Ensure that `With` can be used Rust data synchronously
+fn sleep_with_sync(n: f64) -> impl for<'cx> TryIntoJs<'cx> {
+    sleep_with(n)
+}

--- a/test/napi/src/js/functions.rs
+++ b/test/napi/src/js/functions.rs
@@ -1,4 +1,4 @@
-use neon::{prelude::*, types::extract::With};
+use neon::{prelude::*, types::extract};
 
 fn add1(mut cx: FunctionContext) -> JsResult<JsNumber> {
     let x = cx.argument::<JsNumber>(0)?.value(&mut cx);
@@ -50,7 +50,9 @@ pub fn call_js_function_with_bind_and_args_and_with(mut cx: FunctionContext) -> 
     let n: f64 = cx
         .argument::<JsFunction>(0)?
         .bind(&mut cx)
-        .args(With(|_| (1, 2, 3)))?
+        .arg(extract::with(|cx| Ok(cx.number(1))))?
+        .arg(2)?
+        .arg(3)?
         .call()?;
     Ok(cx.number(n))
 }

--- a/test/napi/src/js/futures.rs
+++ b/test/napi/src/js/futures.rs
@@ -4,7 +4,7 @@ use neon::{
     prelude::*,
     types::{
         buffer::TypedArray,
-        extract::{Error, Json, TryIntoJs, With},
+        extract::{self, Error, Json, TryIntoJs},
     },
 };
 
@@ -129,9 +129,9 @@ fn async_with_events(
     Ok(async move {
         let res = data.into_iter().map(|(a, b)| a * b).collect::<Vec<_>>();
 
-        With(move |cx| -> NeonResult<_> {
+        extract::with(move |cx| -> NeonResult<_> {
             emit(cx, "end")?;
-            Ok(res)
+            res.try_into_js(cx)
         })
     })
 }


### PR DESCRIPTION
`With` is primarily intended as a helper for providing a **thunk** executed on the main thread after an asynchronous operation. However, it's not currently possible to return JavaScript values due to unnecessarily restrictive lifetimes.

```rust
// DOES NOT COMPILE
use neon::types::extract::{TryIntoJs, With};

#[neon::export(task)]
fn example() -> impl for<'cx> TryIntoJs<'cx> {
    With(|cx| cx.number(42.0))
}
```

These changes relax thoe bounds, but unfortunately causes Rust to no longer correctly infer the correct HRTB. As a workaround, an `extract::with` helper is provided.

```rust
use neon::types::extract::{self, TryIntoJs};

// Compiles :)
#[neon::export(task)]
fn example() -> impl for<'cx> TryIntoJs<'cx> {
    extract::with(|cx| Ok(cx.number(42.0)))
}
```

I could not find a way to make a helper that works with *both* `JsResult` and Rust data *without* a lifetime. Since someone returning Rust data always has the option to call `.try_into_js(cx)`, I chose to keep the API simple by *only* providing the one helper.

## Open Questions

* [ ] Is it possible to implement a helper that supports generic return types of `O: TryIntoJs<'cx>` that aren't `'static`?
* [ ] Should we make `With` private? The `with` type would return an opaque `impl for<'cx> TryIntoJs<'cx>`. This _could_ simplify the API.