### PR TITLE
feat(neon): Allow getting a `&'cx T` from a `Handle<'cx, JsBox<T>>`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
       - name: npm install
         run: npm ci --prefer-offline --no-audit --no-fund
 
+      - name: Allow unprivileged X server
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Test (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run --auto-servernum npm test -- --nocapture


### PR DESCRIPTION
Resolves https://github.com/neon-bindings/neon/issues/678

I added `Handle<JsBox>::as_inner` and `JsBox::deref`. Let me know if you have preferred names. I was trying to pick reasonable names that didn't conflict with built-in incompatible traits (e.g., `AsRef`).

This feature is needed for `impl<'cx, T> TryFromJs<'cx> for &'cx RefCell<T>` which will allow low boilerplate extractors.