### PR TITLE
feat(neon): Add extractor for TypedArray

### DIFF
--- a/crates/neon/src/types_impl/extract/buffer.rs
+++ b/crates/neon/src/types_impl/extract/buffer.rs
@@ -1,0 +1,221 @@
+use crate::{
+    context::Cx,
+    handle::Handle,
+    result::{JsResult, NeonResult},
+    types::{
+        buffer::{Binary, TypedArray},
+        extract::{private, TryFromJs, TryIntoJs, TypeExpected},
+        JsArrayBuffer, JsBigInt64Array, JsBigUint64Array, JsBuffer, JsFloat32Array, JsFloat64Array,
+        JsInt16Array, JsInt32Array, JsInt8Array, JsTypedArray, JsUint16Array, JsUint32Array,
+        JsUint8Array, JsValue, Value,
+    },
+};
+
+/// Wrapper for converting between bytes and [`JsArrayBuffer`](JsArrayBuffer)
+pub struct ArrayBuffer<B>(pub B);
+
+impl<'cx, B> TryFromJs<'cx> for ArrayBuffer<B>
+where
+    for<'b> B: From<&'b [u8]>,
+{
+    type Error = TypeExpected<JsBuffer>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        let v = match v.downcast::<JsArrayBuffer, _>(cx) {
+            Ok(v) => v,
+            Err(_) => return Ok(Err(Self::Error::new())),
+        };
+
+        Ok(Ok(ArrayBuffer(B::from(v.as_slice(cx)))))
+    }
+}
+
+impl<'cx, B> TryIntoJs<'cx> for ArrayBuffer<B>
+where
+    B: AsRef<[u8]>,
+{
+    type Value = JsArrayBuffer;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        JsArrayBuffer::from_slice(cx, self.0.as_ref())
+    }
+}
+
+impl<B> private::Sealed for ArrayBuffer<B> {}
+
+/// Wrapper for converting between bytes and [`JsBuffer`](JsBuffer)
+pub struct Buffer<B>(pub B);
+
+impl<'cx, B> TryFromJs<'cx> for Buffer<B>
+where
+    for<'b> B: From<&'b [u8]>,
+{
+    type Error = TypeExpected<JsBuffer>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        let v = match v.downcast::<JsBuffer, _>(cx) {
+            Ok(v) => v,
+            Err(_) => return Ok(Err(Self::Error::new())),
+        };
+
+        Ok(Ok(Buffer(B::from(v.as_slice(cx)))))
+    }
+}
+
+impl<'cx, B> TryIntoJs<'cx> for Buffer<B>
+where
+    B: AsRef<[u8]>,
+{
+    type Value = JsBuffer;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        JsBuffer::from_slice(cx, self.0.as_ref())
+    }
+}
+
+impl<B> private::Sealed for Buffer<B> {}
+
+impl<'cx, T> TryIntoJs<'cx> for Vec<T>
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+    type Value = JsTypedArray<T>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        JsTypedArray::from_slice(cx, self.as_slice())
+    }
+}
+
+impl<'cx, T> TryFromJs<'cx> for Vec<T>
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+    type Error = TypeExpected<JsTypedArray<T>>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        let v = match v.downcast::<JsTypedArray<T>, _>(cx) {
+            Ok(v) => v,
+            Err(_) => return Ok(Err(Self::Error::new())),
+        };
+
+        Ok(Ok(v.as_slice(cx).to_vec()))
+    }
+}
+
+impl<T> private::Sealed for Vec<T>
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+}
+
+impl<'cx, T, const N: usize> TryIntoJs<'cx> for [T; N]
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+    type Value = JsTypedArray<T>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        JsTypedArray::from_slice(cx, self.as_slice())
+    }
+}
+
+impl<T, const N: usize> private::Sealed for [T; N]
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+}
+
+impl<'cx, T> TryIntoJs<'cx> for &[T]
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+    type Value = JsTypedArray<T>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        JsTypedArray::from_slice(cx, self)
+    }
+}
+
+impl<T> private::Sealed for &[T]
+where
+    JsTypedArray<T>: Value,
+    T: Binary,
+{
+}
+
+macro_rules! typed_array {
+    ($js:ident, $name:ident, $type:ty) => {
+        #[doc = concat!(
+            "Wrapper for converting between a Rust `[",
+            stringify!($type),
+            "]` array type and a [`",
+            stringify!($js),
+            "`]",
+        )]
+        pub struct $name<T>(pub T);
+
+        impl<'cx, T> TryIntoJs<'cx> for $name<T>
+        where
+            T: AsRef<[$type]>,
+        {
+            type Value = $js;
+
+            fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+                $js::from_slice(cx, self.0.as_ref())
+            }
+        }
+
+        impl<'cx, T> TryFromJs<'cx> for $name<T>
+        where
+            for<'a> T: From<&'a [$type]>,
+        {
+            type Error = TypeExpected<$js>;
+
+            fn try_from_js(
+                cx: &mut Cx<'cx>,
+                v: Handle<'cx, JsValue>,
+            ) -> NeonResult<Result<Self, Self::Error>> {
+                let v = match v.downcast::<$js, _>(cx) {
+                    Ok(v) => v,
+                    Err(_) => return Ok(Err(TypeExpected::new())),
+                };
+
+                Ok(Ok(Self(T::from(v.as_slice(cx)))))
+            }
+        }
+
+        impl<T> private::Sealed for $name<T> {}
+    };
+
+    ($(($js:ident, $name:ident, $type:ty),)*) => {
+        $(typed_array!($js, $name, $type);)*
+    };
+}
+
+typed_array![
+    (JsInt8Array, Int8Array, i8),
+    (JsUint8Array, Uint8Array, u8),
+    (JsInt16Array, Int16Array, i16),
+    (JsUint16Array, Uint16Array, u16),
+    (JsInt32Array, Int32Array, i32),
+    (JsUint32Array, Uint32Array, u32),
+    (JsFloat32Array, Float32Array, f32),
+    (JsFloat64Array, Float64Array, f64),
+    (JsBigInt64Array, BigInt64Array, i64),
+    (JsBigUint64Array, BigUint64Array, u64),
+];

--- a/crates/neon/src/types_impl/extract/mod.rs
+++ b/crates/neon/src/types_impl/extract/mod.rs
@@ -108,6 +108,10 @@ use crate::{
 
 pub use self::{
     boxed::Boxed,
+    buffer::{
+        ArrayBuffer, BigInt64Array, BigUint64Array, Buffer, Float32Array, Float64Array, Int16Array,
+        Int32Array, Int8Array, Uint16Array, Uint32Array, Uint8Array,
+    },
     error::{Error, TypeExpected},
     with::With,
 };
@@ -121,6 +125,7 @@ pub use self::json::Json;
 pub mod json;
 
 mod boxed;
+mod buffer;
 mod either;
 mod error;
 mod private;
@@ -170,12 +175,6 @@ where
 #[cfg(feature = "napi-5")]
 /// Wrapper for converting between [`f64`] and [`JsDate`](super::JsDate)
 pub struct Date(pub f64);
-
-/// Wrapper for converting between [`Vec<u8>`] and [`JsArrayBuffer`](super::JsArrayBuffer)
-pub struct ArrayBuffer(pub Vec<u8>);
-
-/// Wrapper for converting between [`Vec<u8>`] and [`JsBuffer`](super::JsBuffer)
-pub struct Buffer(pub Vec<u8>);
 
 /// Trait specifying values that may be extracted from function arguments.
 ///

--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -1,14 +1,11 @@
-use std::sync::Arc;
-
 use crate::{
     context::FunctionContext,
     handle::{Handle, Root},
     object::Object,
     result::{NeonResult, Throw},
     types::{
-        buffer::Binary,
-        extract::{ArrayBuffer, Buffer, Date, Error, TryIntoJs},
-        JsTypedArray, Value,
+        extract::{Date, Error, TryIntoJs},
+        Value,
     },
 };
 
@@ -46,59 +43,6 @@ impl<T> Sealed for Option<T> {}
 
 impl<T, E> Sealed for Result<T, E> {}
 
-impl<T> Sealed for Vec<T>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-}
-
-impl<T> Sealed for Box<[T]>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-}
-
-impl<T, const N: usize> Sealed for [T; N]
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-}
-
-impl<T> Sealed for &Vec<T>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-}
-
-impl<T> Sealed for &[T]
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-}
-
-impl<'cx, T> Sealed for Arc<T> where for<'a> &'a T: TryIntoJs<'cx> {}
-
 impl<'cx, T> Sealed for Box<T> where T: TryIntoJs<'cx> {}
 
-impl_sealed!(
-    u8,
-    u16,
-    u32,
-    i8,
-    i16,
-    i32,
-    f32,
-    f64,
-    bool,
-    String,
-    Date,
-    Buffer,
-    ArrayBuffer,
-    Throw,
-    Error,
-);
+impl_sealed!(u8, u16, u32, i8, i16, i32, f32, f64, bool, String, Date, Throw, Error,);

--- a/crates/neon/src/types_impl/extract/try_from_js.rs
+++ b/crates/neon/src/types_impl/extract/try_from_js.rs
@@ -12,10 +12,9 @@ use crate::{
     result::{NeonResult, Throw},
     sys,
     types::{
-        buffer::{Binary, TypedArray},
-        extract::{ArrayBuffer, Buffer, Date, TryFromJs, TypeExpected},
+        extract::{Date, TryFromJs, TypeExpected},
         private::ValueInternal,
-        JsArrayBuffer, JsBoolean, JsBuffer, JsNumber, JsString, JsTypedArray, JsValue, Value,
+        JsBoolean, JsNumber, JsString, JsValue, Value,
     },
 };
 
@@ -197,58 +196,6 @@ impl<'cx> TryFromJs<'cx> for () {
         _v: Handle<'cx, JsValue>,
     ) -> NeonResult<Result<Self, Self::Error>> {
         Ok(Ok(()))
-    }
-}
-
-impl<'cx, T> TryFromJs<'cx> for Vec<T>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-    type Error = TypeExpected<JsTypedArray<T>>;
-
-    fn try_from_js(
-        cx: &mut Cx<'cx>,
-        v: Handle<'cx, JsValue>,
-    ) -> NeonResult<Result<Self, Self::Error>> {
-        let v = match v.downcast::<JsTypedArray<T>, _>(cx) {
-            Ok(v) => v,
-            Err(_) => return Ok(Err(Self::Error::new())),
-        };
-
-        Ok(Ok(v.as_slice(cx).to_vec()))
-    }
-}
-
-impl<'cx> TryFromJs<'cx> for Buffer {
-    type Error = TypeExpected<JsBuffer>;
-
-    fn try_from_js(
-        cx: &mut Cx<'cx>,
-        v: Handle<'cx, JsValue>,
-    ) -> NeonResult<Result<Self, Self::Error>> {
-        let v = match v.downcast::<JsBuffer, _>(cx) {
-            Ok(v) => v,
-            Err(_) => return Ok(Err(Self::Error::new())),
-        };
-
-        Ok(Ok(Buffer(v.as_slice(cx).to_vec())))
-    }
-}
-
-impl<'cx> TryFromJs<'cx> for ArrayBuffer {
-    type Error = TypeExpected<JsBuffer>;
-
-    fn try_from_js(
-        cx: &mut Cx<'cx>,
-        v: Handle<'cx, JsValue>,
-    ) -> NeonResult<Result<Self, Self::Error>> {
-        let v = match v.downcast::<JsArrayBuffer, _>(cx) {
-            Ok(v) => v,
-            Err(_) => return Ok(Err(Self::Error::new())),
-        };
-
-        Ok(Ok(ArrayBuffer(v.as_slice(cx).to_vec())))
     }
 }
 

--- a/crates/neon/src/types_impl/extract/try_into_js.rs
+++ b/crates/neon/src/types_impl/extract/try_into_js.rs
@@ -1,15 +1,11 @@
-use std::sync::Arc;
-
-use crate::prelude::Object;
 use crate::{
     context::{Context, Cx},
     handle::{Handle, Root},
+    object::Object,
     result::{JsResult, ResultExt, Throw},
     types::{
-        buffer::Binary,
-        extract::{ArrayBuffer, Buffer, Date, TryIntoJs},
-        JsArrayBuffer, JsBoolean, JsBuffer, JsDate, JsNumber, JsString, JsTypedArray, JsUndefined,
-        JsValue, Value,
+        extract::{Date, TryIntoJs},
+        JsBoolean, JsDate, JsNumber, JsString, JsUndefined, JsValue, Value,
     },
 };
 
@@ -88,18 +84,6 @@ where
     }
 }
 
-impl<'cx, T, V> TryIntoJs<'cx> for Arc<T>
-where
-    for<'a> &'a T: TryIntoJs<'cx, Value = V>,
-    V: Value,
-{
-    type Value = V;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        self.as_ref().try_into_js(cx)
-    }
-}
-
 macro_rules! impl_number {
     ($ty:ident) => {
         impl<'cx> TryIntoJs<'cx> for $ty {
@@ -144,66 +128,6 @@ impl<'a, 'cx> TryIntoJs<'cx> for &'a String {
     }
 }
 
-impl<'cx, T> TryIntoJs<'cx> for Vec<T>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-    type Value = JsTypedArray<T>;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsTypedArray::from_slice(cx, &self)
-    }
-}
-
-impl<'cx, T> TryIntoJs<'cx> for Box<[T]>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-    type Value = JsTypedArray<T>;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsTypedArray::from_slice(cx, &self)
-    }
-}
-
-impl<'cx, T, const N: usize> TryIntoJs<'cx> for [T; N]
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-    type Value = JsTypedArray<T>;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsTypedArray::from_slice(cx, self.as_slice())
-    }
-}
-
-impl<'a, 'cx, T> TryIntoJs<'cx> for &'a Vec<T>
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-    type Value = JsTypedArray<T>;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsTypedArray::from_slice(cx, self)
-    }
-}
-
-impl<'a, 'cx, T> TryIntoJs<'cx> for &'a [T]
-where
-    JsTypedArray<T>: Value,
-    T: Binary,
-{
-    type Value = JsTypedArray<T>;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsTypedArray::from_slice(cx, self)
-    }
-}
-
 impl<'cx> TryIntoJs<'cx> for bool {
     type Value = JsBoolean;
 
@@ -217,22 +141,6 @@ impl<'cx> TryIntoJs<'cx> for () {
 
     fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(cx.undefined())
-    }
-}
-
-impl<'cx> TryIntoJs<'cx> for ArrayBuffer {
-    type Value = JsArrayBuffer;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsArrayBuffer::from_slice(cx, &self.0)
-    }
-}
-
-impl<'cx> TryIntoJs<'cx> for Buffer {
-    type Value = JsBuffer;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        JsBuffer::from_slice(cx, &self.0)
     }
 }
 

--- a/test/napi/lib/extract.js
+++ b/test/napi/lib/extract.js
@@ -58,6 +58,18 @@ describe("Extractors", () => {
     test(Float64Array);
   });
 
+  it("TypedArray", () => {
+    assert.deepStrictEqual(
+      Buffer.from(addon.bufferConcat(Buffer.from("abc"), Buffer.from("def"))),
+      Buffer.from("abcdef")
+    );
+
+    assert.deepStrictEqual(
+      Buffer.from(addon.stringToBuf("Hello, World!")),
+      Buffer.from("Hello, World!")
+    );
+  });
+
   it("JSON", () => {
     assert.strictEqual(addon.extract_json_sum([1, 2, 3, 4]), 10);
     assert.strictEqual(addon.extract_json_sum([8, 16, 18]), 42);

--- a/test/napi/src/js/extract.rs
+++ b/test/napi/src/js/extract.rs
@@ -22,9 +22,9 @@ pub fn extract_values(mut cx: FunctionContext) -> JsResult<JsArray> {
         String,
         Date,
         Handle<JsValue>,
-        ArrayBuffer,
+        ArrayBuffer<Vec<u8>>,
         Vec<u8>,
-        Buffer,
+        Buffer<Vec<u8>>,
         Option<f64>,
         Option<String>,
     ) = cx.args()?;
@@ -144,4 +144,17 @@ pub fn extract_either(either: Either<String, f64>) -> String {
         Either::Left(s) => format!("String: {s}"),
         Either::Right(n) => format!("Number: {n}"),
     }
+}
+
+#[neon::export]
+// TypedArrays can be extracted and returned
+pub fn buffer_concat(mut a: Vec<u8>, Uint8Array(b): Uint8Array<Vec<u8>>) -> ArrayBuffer<Vec<u8>> {
+    a.extend(b);
+    ArrayBuffer(a)
+}
+
+#[neon::export]
+// Extractors work with anything that can be used as slice of the correct type
+pub fn string_to_buf(s: String) -> Uint8Array<String> {
+    Uint8Array(s)
 }


### PR DESCRIPTION
This removes the `TryIntoJs` implementations for `Arc` and `Box` to free them up for implicitly `Boxed` implementations.

In order to maintain the ability to return borrowed buffers (e.g., `Arc<Vec<u8>>`), I've added extractors for typed arrays. It requires slightly more type noise (e.g., `Uint8Array<Arc<Vec<u8>>` instead of `Arc<Vec<u8>>`), but it is more powerful because it will work across all types that are `AsRef<[T]>`.

The implementation in this PR opts for bespoke `struct` extractors for each of the typed array types (e.g., `Uint8Array`, `Int8Array`). The benefits of this approach are the simplicity of implementation and the ability to directly use them as destructor patterns and constructors. The most significant downside is that there's no trait to unify them for generic buffer functions.

If we wanted to include a trait for handling these in the future, we could introduce a `TypedArray` extractor and accept that this implementation is distinct from the one in this PR. No breaking change would be necessary.

## Example Usage

```rust
use bytes::BytesMut;
use neon::types::extract::Uint8Array;

#[neon::export]
pub fn concat_bytes(
    Uint8Array(mut buf): Uint8Array<BytesMut>,
    data: Vec<u8>,
) -> Uint8Array<BytesMut> {
    buf.put_slice(&data);

    Uint8Array(buf)
}
```