### PR TITLE
Type extractors for common container types

### DIFF
--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -1,6 +1,6 @@
 use std::{
     any::{self, Any},
-    ops::Deref
+    ops::Deref,
 };
 
 use crate::{

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -1,5 +1,6 @@
 use std::{
-    any::{self, Any}, marker::PhantomData, ops::Deref
+    any::{self, Any},
+    ops::Deref
 };
 
 use crate::{

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -1,0 +1,42 @@
+use std::{any::Any, cell::RefCell};
+
+use crate::{
+    context::Cx, handle::Handle, result::{JsResult, NeonResult}, types::{extract::{TryFromJs, TryIntoJs}, JsBox, JsValue}
+};
+
+use super::error::RustTypeExpected;
+
+pub trait Container {
+    fn container_name() -> &'static str;
+}
+
+impl<T> Container for RefCell<T> {
+    fn container_name() -> &'static str {
+        "std::cell::RefCell"
+    }
+}
+
+impl<'cx, T: Container + 'static> TryFromJs<'cx> for &'cx RefCell<T> {
+    type Error = RustTypeExpected<RefCell<T>>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<RefCell<T>>, _>(cx) {
+            Ok(v) => Ok(Ok(JsBox::deref(&v))),
+            Err(_) => Ok(Err(RustTypeExpected::new())),
+        }
+    }
+}
+
+impl<'cx, T> TryIntoJs<'cx> for RefCell<T>
+where
+    T: Any + 'static,
+{
+    type Value = JsBox<RefCell<T>>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        Ok(JsBox::manually_finalize(cx, self))
+    }
+}

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -1,4 +1,8 @@
-use std::cell::RefCell;
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 use crate::{
     context::Cx,
@@ -10,7 +14,7 @@ use crate::{
     },
 };
 
-use super::error::RustTypeExpected;
+use super::error::{MutexError, RefCellError, RustTypeExpected};
 
 pub trait Container {
     fn container_name() -> &'static str;
@@ -19,6 +23,24 @@ pub trait Container {
 impl<T> Container for RefCell<T> {
     fn container_name() -> &'static str {
         "std::cell::RefCell"
+    }
+}
+
+impl<T> Container for Rc<T> {
+    fn container_name() -> &'static str {
+        "std::rc::Rc"
+    }
+}
+
+impl<T> Container for Arc<T> {
+    fn container_name() -> &'static str {
+        "std::sync::Arc"
+    }
+}
+
+impl<T> Container for Mutex<T> {
+    fn container_name() -> &'static str {
+        "std::sync::Mutex"
     }
 }
 
@@ -36,6 +58,42 @@ impl<'cx, T: 'static> TryFromJs<'cx> for &'cx RefCell<T> {
     }
 }
 
+impl<'cx, T: 'static> TryFromJs<'cx> for Ref<'cx, T> {
+    type Error = RefCellError;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<RefCell<T>>, _>(cx) {
+            Ok(v) => {
+                let cell = JsBox::deref(&v);
+                Ok(cell.try_borrow().map_err(|_| RefCellError::Borrowed))
+            }
+            Err(_) => Ok(Err(RefCellError::WrongType)),
+        }
+    }
+}
+
+impl<'cx, T: 'static> TryFromJs<'cx> for RefMut<'cx, T> {
+    type Error = RefCellError;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<RefCell<T>>, _>(cx) {
+            Ok(v) => {
+                let cell = JsBox::deref(&v);
+                Ok(cell
+                    .try_borrow_mut()
+                    .map_err(|_| RefCellError::MutablyBorrowed))
+            }
+            Err(_) => Ok(Err(RefCellError::WrongType)),
+        }
+    }
+}
+
 impl<'cx, T> TryIntoJs<'cx> for RefCell<T>
 where
     T: 'static,
@@ -44,5 +102,101 @@ where
 
     fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
         Ok(JsBox::manually_finalize(cx, self))
+    }
+}
+
+impl<'cx, T: 'static> TryFromJs<'cx> for Rc<T> {
+    type Error = RustTypeExpected<Rc<T>>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<Rc<T>>, _>(cx) {
+            Ok(v) => Ok(Ok(JsBox::deref(&v).clone())),
+            Err(_) => Ok(Err(RustTypeExpected::new())),
+        }
+    }
+}
+
+impl<'cx, T> TryIntoJs<'cx> for Rc<T>
+where
+    T: 'static,
+{
+    type Value = JsBox<Rc<T>>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        Ok(JsBox::manually_finalize(cx, self))
+    }
+}
+
+impl<'cx, T: 'static> TryFromJs<'cx> for Arc<T> {
+    type Error = RustTypeExpected<Arc<T>>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<Arc<T>>, _>(cx) {
+            Ok(v) => Ok(Ok(JsBox::deref(&v).clone())),
+            Err(_) => Ok(Err(RustTypeExpected::new())),
+        }
+    }
+}
+
+impl<'cx, T> TryIntoJs<'cx> for Arc<T>
+where
+    T: 'static,
+{
+    type Value = JsBox<Arc<T>>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        Ok(JsBox::manually_finalize(cx, self))
+    }
+}
+
+impl<'cx, T: 'static> TryFromJs<'cx> for &'cx Mutex<T> {
+    type Error = RustTypeExpected<Mutex<T>>;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<Arc<Mutex<T>>>, _>(cx) {
+            Ok(v) => {
+                let arc = JsBox::deref(&v);
+                Ok(Ok(<Arc<Mutex<T>> as std::ops::Deref>::deref(arc)))
+            }
+            Err(_) => Ok(Err(RustTypeExpected::new())),
+        }
+    }
+}
+
+impl<'cx, T: 'static> TryFromJs<'cx> for MutexGuard<'cx, T> {
+    type Error = MutexError;
+
+    fn try_from_js(
+        cx: &mut Cx<'cx>,
+        v: Handle<'cx, JsValue>,
+    ) -> NeonResult<Result<Self, Self::Error>> {
+        match v.downcast::<JsBox<Arc<Mutex<T>>>, _>(cx) {
+            Ok(v) => {
+                let arc = JsBox::deref(&v);
+                let mutex = <Arc<Mutex<T>> as std::ops::Deref>::deref(arc);
+                Ok(mutex.lock().map_err(|_| MutexError::Poisoned))
+            }
+            Err(_) => Ok(Err(MutexError::WrongType)),
+        }
+    }
+}
+
+impl<'cx, T> TryIntoJs<'cx> for Mutex<T>
+where
+    T: 'static,
+{
+    type Value = JsBox<Arc<Mutex<T>>>;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        Ok(JsBox::manually_finalize(cx, Arc::new(self)))
     }
 }

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -79,9 +79,7 @@ impl<'cx, T: 'static> TryFromJs<'cx> for RefMut<'cx, T> {
         match v.downcast::<JsBox<RefCell<T>>, _>(cx) {
             Ok(v) => {
                 let cell = JsBox::deref(&v);
-                Ok(cell
-                    .try_borrow_mut()
-                    .map_err(|_| RefCellError::Borrowed))
+                Ok(cell.try_borrow_mut().map_err(|_| RefCellError::Borrowed))
             }
             Err(_) => Ok(Err(RefCellError::WrongType)),
         }

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -62,7 +62,7 @@ impl<'cx, T: 'static> TryFromJs<'cx> for Ref<'cx, T> {
         match v.downcast::<JsBox<RefCell<T>>, _>(cx) {
             Ok(v) => {
                 let cell = JsBox::deref(&v);
-                Ok(cell.try_borrow().map_err(|_| RefCellError::Borrowed))
+                Ok(cell.try_borrow().map_err(|_| RefCellError::MutablyBorrowed))
             }
             Err(_) => Ok(Err(RefCellError::WrongType)),
         }
@@ -81,7 +81,7 @@ impl<'cx, T: 'static> TryFromJs<'cx> for RefMut<'cx, T> {
                 let cell = JsBox::deref(&v);
                 Ok(cell
                     .try_borrow_mut()
-                    .map_err(|_| RefCellError::MutablyBorrowed))
+                    .map_err(|_| RefCellError::Borrowed))
             }
             Err(_) => Ok(Err(RefCellError::WrongType)),
         }

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -22,7 +22,7 @@ impl<T> Container for RefCell<T> {
     }
 }
 
-impl<'cx, T: Container + 'static> TryFromJs<'cx> for &'cx RefCell<T> {
+impl<'cx, T: 'static> TryFromJs<'cx> for &'cx RefCell<T> {
     type Error = RustTypeExpected<RefCell<T>>;
 
     fn try_from_js(

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, cell::RefCell};
+use std::cell::RefCell;
 
 use crate::{
     context::Cx, handle::Handle, result::{JsResult, NeonResult}, types::{extract::{TryFromJs, TryIntoJs}, JsBox, JsValue}
@@ -32,7 +32,7 @@ impl<'cx, T: Container + 'static> TryFromJs<'cx> for &'cx RefCell<T> {
 
 impl<'cx, T> TryIntoJs<'cx> for RefCell<T>
 where
-    T: Any + 'static,
+    T: 'static,
 {
     type Value = JsBox<RefCell<T>>;
 

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -83,7 +83,7 @@ impl<'cx, T: 'static> TryFromJs<'cx> for Rc<T> {
         v: Handle<'cx, JsValue>,
     ) -> NeonResult<Result<Self, Self::Error>> {
         match v.downcast::<JsBox<Rc<T>>, _>(cx) {
-            Ok(v) => Ok(Ok(JsBox::deref(&v).clone())),
+            Ok(v) => Ok(Ok(Rc::clone(&v))),
             Err(_) => Ok(Err(TypeExpected::new())),
         }
     }
@@ -108,7 +108,7 @@ impl<'cx, T: 'static> TryFromJs<'cx> for Arc<T> {
         v: Handle<'cx, JsValue>,
     ) -> NeonResult<Result<Self, Self::Error>> {
         match v.downcast::<JsBox<Arc<T>>, _>(cx) {
-            Ok(v) => Ok(Ok(JsBox::deref(&v).clone())),
+            Ok(v) => Ok(Ok(Arc::clone(&v))),
             Err(_) => Ok(Err(TypeExpected::new())),
         }
     }

--- a/crates/neon/src/types_impl/extract/container.rs
+++ b/crates/neon/src/types_impl/extract/container.rs
@@ -1,7 +1,13 @@
 use std::cell::RefCell;
 
 use crate::{
-    context::Cx, handle::Handle, result::{JsResult, NeonResult}, types::{extract::{TryFromJs, TryIntoJs}, JsBox, JsValue}
+    context::Cx,
+    handle::Handle,
+    result::{JsResult, NeonResult},
+    types::{
+        extract::{TryFromJs, TryIntoJs},
+        JsBox, JsValue,
+    },
 };
 
 use super::error::RustTypeExpected;

--- a/crates/neon/src/types_impl/extract/error.rs
+++ b/crates/neon/src/types_impl/extract/error.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, error, fmt, marker::PhantomData};
+use std::{any::{self, Any}, convert::Infallible, error, fmt, marker::PhantomData};
 
 use crate::{
     context::{Context, Cx},
@@ -8,6 +8,8 @@ use crate::{
         JsError, JsValue, Value,
     },
 };
+
+use super::container::Container;
 
 type BoxError = Box<dyn error::Error + Send + Sync + 'static>;
 
@@ -43,6 +45,39 @@ impl<'cx, T: Value> TryIntoJs<'cx> for TypeExpected<T> {
 }
 
 impl<T: Value> private::Sealed for TypeExpected<T> {}
+
+/// Error returned when an implicitly boxed Rust value is not the type expected
+pub struct RustTypeExpected<T: Container>(PhantomData<T>);
+
+impl<T: Container> RustTypeExpected<T> {
+    pub(super) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T: Container> fmt::Display for RustTypeExpected<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "expected {}", T::container_name())
+    }
+}
+
+impl<T: Container> fmt::Debug for RustTypeExpected<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("RustTypeExpected").field(&T::container_name()).finish()
+    }
+}
+
+impl<T: Container> error::Error for RustTypeExpected<T> {}
+
+impl<'cx, T: Container + 'static> TryIntoJs<'cx> for RustTypeExpected<T> {
+    type Value = JsError;
+
+    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
+        JsError::type_error(cx, self.to_string())
+    }
+}
+
+impl<T: Container> private::Sealed for RustTypeExpected<T> {}
 
 impl<'cx> TryIntoJs<'cx> for Infallible {
     type Value = JsValue;

--- a/crates/neon/src/types_impl/extract/error.rs
+++ b/crates/neon/src/types_impl/extract/error.rs
@@ -63,7 +63,9 @@ impl<T: Container> fmt::Display for RustTypeExpected<T> {
 
 impl<T: Container> fmt::Debug for RustTypeExpected<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("RustTypeExpected").field(&T::container_name()).finish()
+        f.debug_tuple("RustTypeExpected")
+            .field(&T::container_name())
+            .finish()
     }
 }
 

--- a/crates/neon/src/types_impl/extract/error.rs
+++ b/crates/neon/src/types_impl/extract/error.rs
@@ -123,42 +123,6 @@ impl<'cx> TryIntoJs<'cx> for RefCellError {
 
 impl private::Sealed for RefCellError {}
 
-pub enum MutexError {
-    WrongType,
-    Poisoned,
-}
-
-impl fmt::Display for MutexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            MutexError::WrongType => write!(f, "expected {}", RefCell::<()>::container_name()),
-            MutexError::Poisoned => write!(f, "std::sync::Mutex is poisoned"),
-        }
-    }
-}
-
-impl fmt::Debug for MutexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            MutexError::WrongType => f.debug_tuple("MutexError::WrongType").finish(),
-            MutexError::Poisoned => f.debug_tuple("MutexError::Poisoned").finish(),
-        }
-    }
-}
-
-impl<'cx> TryIntoJs<'cx> for MutexError {
-    type Value = JsError;
-
-    fn try_into_js(self, cx: &mut Cx<'cx>) -> JsResult<'cx, Self::Value> {
-        match self {
-            MutexError::WrongType => JsError::type_error(cx, self.to_string()),
-            MutexError::Poisoned => JsError::error(cx, self.to_string()),
-        }
-    }
-}
-
-impl private::Sealed for MutexError {}
-
 impl<'cx> TryIntoJs<'cx> for Infallible {
     type Value = JsValue;
 

--- a/crates/neon/src/types_impl/extract/error.rs
+++ b/crates/neon/src/types_impl/extract/error.rs
@@ -91,8 +91,8 @@ impl fmt::Display for RefCellError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RefCellError::WrongType => write!(f, "expected {}", RefCell::<()>::container_name()),
-            RefCellError::MutablyBorrowed => write!(f, "std::cell::RefCell is mutably borrowed"),
-            RefCellError::Borrowed => write!(f, "std::cell::RefCell is borrowed"),
+            RefCellError::MutablyBorrowed => write!(f, "RefCell is mutably borrowed"),
+            RefCellError::Borrowed => write!(f, "RefCell is borrowed"),
         }
     }
 }

--- a/crates/neon/src/types_impl/extract/error.rs
+++ b/crates/neon/src/types_impl/extract/error.rs
@@ -1,4 +1,4 @@
-use std::{any::{self, Any}, convert::Infallible, error, fmt, marker::PhantomData};
+use std::{convert::Infallible, error, fmt, marker::PhantomData};
 
 use crate::{
     context::{Context, Cx},

--- a/crates/neon/src/types_impl/extract/mod.rs
+++ b/crates/neon/src/types_impl/extract/mod.rs
@@ -126,6 +126,7 @@ pub mod json;
 
 mod boxed;
 mod buffer;
+mod container;
 mod either;
 mod error;
 mod private;

--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use crate::{
     context::FunctionContext,
     handle::{Handle, Root},
@@ -44,5 +46,9 @@ impl<T> Sealed for Option<T> {}
 impl<T, E> Sealed for Result<T, E> {}
 
 impl<'cx, T> Sealed for Box<T> where T: TryIntoJs<'cx> {}
+
+impl<T> Sealed for RefCell<T> {}
+
+impl<T> Sealed for &RefCell<T> {}
 
 impl_sealed!(u8, u16, u32, i8, i16, i32, f32, f64, bool, String, Date, Throw, Error,);

--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -59,8 +59,8 @@ impl<T> Sealed for Arc<T> {}
 
 impl<T> Sealed for Rc<T> {}
 
-impl<'a, T> Sealed for Ref<'a, T> {}
+impl<T> Sealed for Ref<'_, T> {}
 
-impl<'a, T> Sealed for RefMut<'a, T> {}
+impl<T> Sealed for RefMut<'_, T> {}
 
 impl_sealed!(u8, u16, u32, i8, i16, i32, f32, f64, bool, String, Date, Throw, Error,);

--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::{Ref, RefCell, RefMut},
     rc::Rc,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::Arc,
 };
 
 use crate::{
@@ -59,14 +59,8 @@ impl<T> Sealed for Arc<T> {}
 
 impl<T> Sealed for Rc<T> {}
 
-impl<T> Sealed for Mutex<T> {}
-
-impl<T> Sealed for &Mutex<T> {}
-
 impl<'a, T> Sealed for Ref<'a, T> {}
 
 impl<'a, T> Sealed for RefMut<'a, T> {}
-
-impl<'a, T> Sealed for MutexGuard<'a, T> {}
 
 impl_sealed!(u8, u16, u32, i8, i16, i32, f32, f64, bool, String, Date, Throw, Error,);

--- a/crates/neon/src/types_impl/extract/private.rs
+++ b/crates/neon/src/types_impl/extract/private.rs
@@ -1,4 +1,8 @@
-use std::cell::RefCell;
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 use crate::{
     context::FunctionContext,
@@ -50,5 +54,19 @@ impl<'cx, T> Sealed for Box<T> where T: TryIntoJs<'cx> {}
 impl<T> Sealed for RefCell<T> {}
 
 impl<T> Sealed for &RefCell<T> {}
+
+impl<T> Sealed for Arc<T> {}
+
+impl<T> Sealed for Rc<T> {}
+
+impl<T> Sealed for Mutex<T> {}
+
+impl<T> Sealed for &Mutex<T> {}
+
+impl<'a, T> Sealed for Ref<'a, T> {}
+
+impl<'a, T> Sealed for RefMut<'a, T> {}
+
+impl<'a, T> Sealed for MutexGuard<'a, T> {}
 
 impl_sealed!(u8, u16, u32, i8, i16, i32, f32, f64, bool, String, Date, Throw, Error,);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6066,7 +6066,7 @@
       }
     },
     "pkgs/create-neon": {
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@neon-rs/manifest": "^0.2.1",

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -27,7 +27,10 @@ describe("Container type extractors", function () {
       assert.fail("should have thrown");
     } catch (err) {
       assert.instanceOf(err, TypeError);
-      assert.strictEqual(err.message, "expected std::cell::RefCell");
+      assert.strictEqual(
+        err.message,
+        "expected neon::types_impl::boxed::JsBox<core::cell::RefCell<alloc::string::String>>"
+      );
     }
   });
 
@@ -40,7 +43,7 @@ describe("Container type extractors", function () {
       assert.fail("should have thrown");
     } catch (err) {
       assert.instanceOf(err, Error);
-      assert.strictEqual(err.message, "RefCell is mutably borrowed");
+      assert.include(err.message, "already mutably borrowed");
     }
   });
 
@@ -53,7 +56,7 @@ describe("Container type extractors", function () {
       assert.fail("should have thrown");
     } catch (err) {
       assert.instanceOf(err, Error);
-      assert.strictEqual(err.message, "RefCell is borrowed");
+      assert.include(err.message, "already borrowed");
     }
   });
 

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -1,0 +1,17 @@
+const addon = require("..");
+const { expect } = require("chai");
+const assert = require("chai").assert;
+
+describe("container", function () {
+  it("can produce and consume a RefCell", function () {
+    const cell = addon.createStringRefCell("my sekret mesij");
+    const s = addon.readStringRefCell(cell);
+    assert.strictEqual("my sekret mesij", s);
+  });
+
+  it("concatenates a RefCell<String> with a String", function () {
+    const cell = addon.createStringRefCell("hello");
+    const s = addon.stringRefCellConcat(cell, " world");
+    assert.strictEqual("hello world", s);
+  });
+});

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -6,12 +6,21 @@ describe("container", function () {
   it("can produce and consume a RefCell", function () {
     const cell = addon.createStringRefCell("my sekret mesij");
     const s = addon.readStringRefCell(cell);
-    assert.strictEqual("my sekret mesij", s);
+    assert.strictEqual(s, "my sekret mesij");
   });
 
   it("concatenates a RefCell<String> with a String", function () {
     const cell = addon.createStringRefCell("hello");
     const s = addon.stringRefCellConcat(cell, " world");
-    assert.strictEqual("hello world", s);
+    assert.strictEqual(s, "hello world");
+  });
+
+  it("fails with a type error when not given a RefCell", function () {
+    try {
+      addon.stringRefCellConcat("hello", " world");
+    } catch (err) {
+      assert.instanceOf(err, TypeError);
+      assert.strictEqual(err.message, "expected std::cell::RefCell");
+    }
   });
 });

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -2,26 +2,58 @@ const addon = require("..");
 const { expect } = require("chai");
 const assert = require("chai").assert;
 
-describe("container", function () {
+describe("Container type extractors", function () {
   it("can produce and consume a RefCell", function () {
     const cell = addon.createStringRefCell("my sekret mesij");
     const s = addon.readStringRefCell(cell);
     assert.strictEqual(s, "my sekret mesij");
   });
 
-  it("concatenates a RefCell<String> with a String", function () {
+  it("can produce and modify a RefCell", function () {
+    const cell = addon.createStringRefCell("new");
+    addon.writeStringRefCell(cell, "modified");
+    assert.strictEqual(addon.readStringRefCell(cell), "modified");
+  })
+
+  it("can concatenate a RefCell<String> with a String", function () {
     const cell = addon.createStringRefCell("hello");
     const s = addon.stringRefCellConcat(cell, " world");
     assert.strictEqual(s, "hello world");
   });
 
-  it("fails with a type error when not given a RefCell", function () {
+  it("fail with a type error when not given a RefCell", function () {
     try {
       addon.stringRefCellConcat("hello", " world");
       assert.fail("should have thrown");
     } catch (err) {
       assert.instanceOf(err, TypeError);
       assert.strictEqual(err.message, "expected std::cell::RefCell");
+    }
+  });
+
+  it("dynamically fail when borrowing a mutably borrowed RefCell", function () {
+    const cell = addon.createStringRefCell("hello");
+    try {
+      addon.borrowMutAndThen(cell, () => {
+        addon.stringRefConcat(cell, " world");
+      });
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.message, "RefCell is mutably borrowed");
+    }
+  });
+
+  it("dynamically fail when modifying a borrowed RefCell", function () {
+    const cell = addon.createStringRefCell("hello");
+    try {
+      addon.borrowAndThen(cell, () => {
+        addon.writeStringRef(cell, "world");
+      });
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.message, "RefCell is borrowed");
     }
   });
 });

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -56,4 +56,16 @@ describe("Container type extractors", function () {
       assert.strictEqual(err.message, "RefCell is borrowed");
     }
   });
+
+  it("can produce and consume an Rc", function () {
+    const cell = addon.createStringRc("my sekret mesij");
+    const s = addon.readStringRc(cell);
+    assert.strictEqual(s, "my sekret mesij");
+  });
+
+  it("can produce and consume an Arc", function () {
+    const cell = addon.createStringArc("my sekret mesij");
+    const s = addon.readStringArc(cell);
+    assert.strictEqual(s, "my sekret mesij");
+  });
 });

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -18,6 +18,7 @@ describe("container", function () {
   it("fails with a type error when not given a RefCell", function () {
     try {
       addon.stringRefCellConcat("hello", " world");
+      assert.fail("should have thrown");
     } catch (err) {
       assert.instanceOf(err, TypeError);
       assert.strictEqual(err.message, "expected std::cell::RefCell");

--- a/test/napi/lib/container.js
+++ b/test/napi/lib/container.js
@@ -13,7 +13,7 @@ describe("Container type extractors", function () {
     const cell = addon.createStringRefCell("new");
     addon.writeStringRefCell(cell, "modified");
     assert.strictEqual(addon.readStringRefCell(cell), "modified");
-  })
+  });
 
   it("can concatenate a RefCell<String> with a String", function () {
     const cell = addon.createStringRefCell("hello");

--- a/test/napi/src/js/container.rs
+++ b/test/napi/src/js/container.rs
@@ -1,4 +1,6 @@
-use std::cell::RefCell;
+use neon::{prelude::*, types::extract::Error};
+
+use std::cell::{Ref, RefCell, RefMut};
 
 #[neon::export]
 fn create_string_ref_cell(s: String) -> RefCell<String> {
@@ -11,6 +13,38 @@ fn read_string_ref_cell(s: &RefCell<String>) -> String {
 }
 
 #[neon::export]
+fn write_string_ref_cell(s: &RefCell<String>, value: String) {
+    *s.borrow_mut() = value;
+}
+
+#[neon::export]
 fn string_ref_cell_concat(lhs: &RefCell<String>, rhs: String) -> String {
     lhs.borrow().clone() + &rhs
+}
+
+#[neon::export]
+fn string_ref_concat(lhs: Ref<String>, rhs: String) -> String {
+    lhs.clone() + &rhs
+}
+
+#[neon::export]
+fn write_string_ref(mut s: RefMut<String>, value: String) {
+    *s = value;
+}
+
+#[neon::export]
+fn borrow_and_then<'cx>(cx: &mut Cx<'cx>, cell: &RefCell<String>, f: Handle<JsFunction>)
+-> JsResult<'cx, JsString> {
+    let s = cell.borrow();
+    f.bind(cx).exec()?;
+    Ok(cx.string(s.clone()))
+}
+
+#[neon::export]
+fn borrow_mut_and_then<'cx>(cx: &mut Cx<'cx>, cell: &RefCell<String>, f: Handle<JsFunction>)
+-> JsResult<'cx, JsString> {
+    let mut s = cell.borrow_mut();
+    f.bind(cx).exec()?;
+    *s = "overwritten".to_string();
+    Ok(cx.string(s.clone()))
 }

--- a/test/napi/src/js/container.rs
+++ b/test/napi/src/js/container.rs
@@ -1,0 +1,16 @@
+use std::cell::RefCell;
+
+#[neon::export]
+fn create_string_ref_cell(s: String) -> RefCell<String> {
+    RefCell::new(s)
+}
+
+#[neon::export]
+fn read_string_ref_cell(s: &RefCell<String>) -> String {
+    s.borrow().clone()
+}
+
+#[neon::export]
+fn string_ref_cell_concat(lhs: &RefCell<String>, rhs: String) -> String {
+    lhs.borrow().clone() + &rhs
+}

--- a/test/napi/src/js/container.rs
+++ b/test/napi/src/js/container.rs
@@ -1,6 +1,10 @@
 use neon::prelude::*;
 
-use std::cell::{Ref, RefCell, RefMut};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+    sync::Arc,
+};
 
 #[neon::export]
 fn create_string_ref_cell(s: String) -> RefCell<String> {
@@ -53,4 +57,24 @@ fn borrow_mut_and_then<'cx>(
     f.bind(cx).exec()?;
     *s = "overwritten".to_string();
     Ok(cx.string(s.clone()))
+}
+
+#[neon::export]
+fn create_string_rc(s: String) -> Rc<String> {
+    Rc::new(s)
+}
+
+#[neon::export]
+fn read_string_rc(s: Rc<String>) -> String {
+    (*s).clone()
+}
+
+#[neon::export]
+fn create_string_arc(s: String) -> Arc<String> {
+    Arc::new(s)
+}
+
+#[neon::export]
+fn read_string_arc(s: Arc<String>) -> String {
+    (*s).clone()
 }

--- a/test/napi/src/js/container.rs
+++ b/test/napi/src/js/container.rs
@@ -1,4 +1,4 @@
-use neon::{prelude::*, types::extract::Error};
+use neon::prelude::*;
 
 use std::cell::{Ref, RefCell, RefMut};
 
@@ -33,16 +33,22 @@ fn write_string_ref(mut s: RefMut<String>, value: String) {
 }
 
 #[neon::export]
-fn borrow_and_then<'cx>(cx: &mut Cx<'cx>, cell: &RefCell<String>, f: Handle<JsFunction>)
--> JsResult<'cx, JsString> {
+fn borrow_and_then<'cx>(
+    cx: &mut Cx<'cx>,
+    cell: &RefCell<String>,
+    f: Handle<JsFunction>,
+) -> JsResult<'cx, JsString> {
     let s = cell.borrow();
     f.bind(cx).exec()?;
     Ok(cx.string(s.clone()))
 }
 
 #[neon::export]
-fn borrow_mut_and_then<'cx>(cx: &mut Cx<'cx>, cell: &RefCell<String>, f: Handle<JsFunction>)
--> JsResult<'cx, JsString> {
+fn borrow_mut_and_then<'cx>(
+    cx: &mut Cx<'cx>,
+    cell: &RefCell<String>,
+    f: Handle<JsFunction>,
+) -> JsResult<'cx, JsString> {
     let mut s = cell.borrow_mut();
     f.bind(cx).exec()?;
     *s = "overwritten".to_string();

--- a/test/napi/src/lib.rs
+++ b/test/napi/src/lib.rs
@@ -12,6 +12,7 @@ mod js {
     pub mod bigint;
     pub mod boxed;
     pub mod coercions;
+    pub mod container;
     pub mod date;
     pub mod errors;
     pub mod export;


### PR DESCRIPTION
Implement type extractors for common container types in the standard library, so that they don't required explicit `Boxed` wrapping with `JsBox` in userland.

Implemented so far:
- `RefCell`
  - `impl TryIntoJs for RefCell`
  - `impl TryFromJs for &RefCell`
  - `impl TryFromJs for Ref`
  - `impl TryFromJs for RefMut`
- `Rc`
  - `impl TryIntoJs for Rc`
  - `impl TryFromJs for Rc`
- `Arc`
  - `impl TryIntoJs for Arc`
  - `impl TryFromJs for Arc`