### PR TITLE
breaking: Remove the `FromArgs` impl on `T: TryFromJs` and add `cx.arg()` and `cx.arg_opt()`.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,6 +13,7 @@ jobs:
     name: regression
     permissions:
       checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "test/*",
     "bench",
 ]
+
+[profile.release]
+lto = true

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -182,7 +182,7 @@ use crate::{
     types::{
         boxed::{Finalize, JsBox},
         error::JsError,
-        extract::FromArgs,
+        extract::{FromArgs, TryFromJs},
         private::ValueInternal,
         Deferred, JsArray, JsArrayBuffer, JsBoolean, JsBuffer, JsFunction, JsNull, JsNumber,
         JsObject, JsPromise, JsString, JsUndefined, JsValue, StringResult, Value,
@@ -844,6 +844,14 @@ impl<'cx> FunctionContext<'cx> {
         T::from_args(self)
     }
 
+    /// Extract a single argument from a unary function. See [`Context::args`] for more details.
+    pub fn arg<T>(&mut self) -> NeonResult<T>
+    where
+        T: TryFromJs<'cx>,
+    {
+        self.args::<(T,)>().map(|(v,)| v)
+    }
+
     /// Extract Rust data from the JavaScript arguments.
     ///
     /// Similar to [`FunctionContext::args`], but does not throw a JavaScript exception on errors. Useful
@@ -866,6 +874,14 @@ impl<'cx> FunctionContext<'cx> {
         T: FromArgs<'cx>,
     {
         T::from_args_opt(self)
+    }
+
+    /// Extract a single optional argument from a unary function. See [`Context::args_opt`] for more details.
+    pub fn arg_opt<T>(&mut self) -> NeonResult<Option<T>>
+    where
+        T: TryFromJs<'cx>,
+    {
+        self.args_opt::<(T,)>().map(|v| v.map(|(v,)| v))
     }
 
     pub(crate) fn argv<const N: usize>(&mut self) -> [Handle<'cx, JsValue>; N] {

--- a/crates/neon/src/types_impl/extract/mod.rs
+++ b/crates/neon/src/types_impl/extract/mod.rs
@@ -183,27 +183,19 @@ pub struct Date(pub f64);
 /// the sake of brevity, only tuples up to size 8 are shown in this documentation.
 pub trait FromArgs<'cx>: private::FromArgsInternal<'cx> {}
 
-// Convenience implementation for single arguments instead of needing a single element tuple
-impl<'cx, T> private::FromArgsInternal<'cx> for T
-where
-    T: TryFromJs<'cx>,
-{
-    fn from_args(cx: &mut FunctionContext<'cx>) -> NeonResult<Self> {
-        let (v,) = private::FromArgsInternal::from_args(cx)?;
-
-        Ok(v)
+// Functions as a noop zero-argument base case of [`from_args_impl`]
+impl<'cx> private::FromArgsInternal<'cx> for () {
+    fn from_args(_cx: &mut FunctionContext<'cx>) -> NeonResult<Self> {
+        Ok(())
     }
 
-    fn from_args_opt(cx: &mut FunctionContext<'cx>) -> NeonResult<Option<Self>> {
-        if let Some((v,)) = private::FromArgsInternal::from_args_opt(cx)? {
-            Ok(Some(v))
-        } else {
-            Ok(None)
-        }
+    fn from_args_opt(_cx: &mut FunctionContext<'cx>) -> NeonResult<Option<Self>> {
+        Ok(Some(()))
     }
 }
 
-impl<'cx, T> FromArgs<'cx> for T where T: TryFromJs<'cx> {}
+// Functions as a zero-argument base case of [`from_args_impl`]
+impl<'cx> FromArgs<'cx> for () {}
 
 // N.B.: `FromArgs` _could_ have a blanket impl for `T` where `T: FromArgsInternal`.
 // However, it is explicitly implemented in the macro in order for it to be included in docs.

--- a/test/napi/src/js/extract.rs
+++ b/test/napi/src/js/extract.rs
@@ -66,74 +66,74 @@ pub fn extract_buffer_sum(mut cx: FunctionContext) -> JsResult<JsNumber> {
     }
 
     // `Float32Array`
-    if let Some(buf) = cx.args_opt::<Vec<f32>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<f32>>()? {
         return sum(&mut cx, buf, |n| n.into());
     }
 
     // `Float32Array`
-    if let Some(buf) = cx.args_opt::<Vec<f64>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<f64>>()? {
         return sum(&mut cx, buf, |n| n);
     }
 
     // `Buffer`
-    if let Some(Buffer(buf)) = cx.args_opt()? {
+    if let Some(Buffer(buf)) = cx.arg_opt()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `ArrayBuffer`
-    if let Some(ArrayBuffer(buf)) = cx.args_opt()? {
+    if let Some(ArrayBuffer(buf)) = cx.arg_opt()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Uint8Array`
-    if let Some(buf) = cx.args_opt::<Vec<u8>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<u8>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Uint16Array`
-    if let Some(buf) = cx.args_opt::<Vec<u16>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<u16>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Uint32Array`
-    if let Some(buf) = cx.args_opt::<Vec<u32>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<u32>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Uint64Array`
-    if let Some(buf) = cx.args_opt::<Vec<u64>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<u64>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Int8Array`
-    if let Some(buf) = cx.args_opt::<Vec<i8>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<i8>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Int16Array`
-    if let Some(buf) = cx.args_opt::<Vec<i16>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<i16>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Int32Array`
-    if let Some(buf) = cx.args_opt::<Vec<i32>>()? {
+    if let Some(buf) = cx.arg_opt::<Vec<i32>>()? {
         return sum(&mut cx, buf, |n| n as f64);
     }
 
     // `Int64Array`
-    let buf: Vec<i64> = cx.args()?;
+    let buf: Vec<i64> = cx.arg()?;
 
     sum(&mut cx, buf, |n| n as f64)
 }
 
 pub fn extract_json_sum(mut cx: FunctionContext) -> JsResult<JsNumber> {
-    let Json::<Vec<f64>>(nums) = cx.args()?;
+    let Json::<Vec<f64>>(nums) = cx.arg()?;
 
     Ok(cx.number(nums.into_iter().sum::<f64>()))
 }
 
 pub fn extract_single_add_one(mut cx: FunctionContext) -> JsResult<JsNumber> {
-    let n: f64 = cx.args()?;
+    let n: f64 = cx.arg()?;
 
     Ok(cx.number(n + 1.0))
 }


### PR DESCRIPTION
A blanket impl was added to avoid duplicate methods or a confusing `let (n,) = cx.args()?;` syntax for unary functions. However, this does not work well with the `#[neon::export]` macro where functions with zero arguments end up unnecessarily deserializing `undefined`.

Removing the blanket `impl` and replacing it with a specialized version for `()` allows the proc macros to be more efficient without unneeded complexity.

In order to make these changes more ergonomic, I added `Context::arg` and `Context::arg_opt` for unary functions.

**Attention**: This is a _breaking_ change, but the API has not landed in a stable version yet.

In the future, we could unify these APIs if Rust ships specialization.