### PR TITLE
Migrate to Rust 2024 Edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,39 +4,39 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "aquamarine"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df752953c49ce90719c7bf1fc587bc8227aed04732ea0c0f85e5397d7fdbd1a1"
+checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
 dependencies = [
  "include_dir",
  "itertools",
@@ -48,23 +48,23 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.57",
+ "syn 2.0.101",
  "which",
 ]
 
@@ -105,24 +105,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cexpr"
@@ -141,13 +132,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -158,15 +149,15 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "easy-cast"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6"
+checksum = "72852736692ec862655eca398c9bb1b476161b563c9f80f45f4808b9629750d6"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "electron-tests"
@@ -177,25 +168,25 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -204,51 +195,45 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "include_dir"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
  "include_dir_macros",
 ]
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -275,15 +260,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
@@ -296,35 +281,25 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
 
 [[package]]
 name = "linkify"
@@ -337,41 +312,41 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.25"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cfee0de9bd869589fb9a015e155946d1be5ff415cb844c2caccc6cc4b5db9"
+checksum = "22d227772b5999ddc0690e733f734f95ca05387e329c4084fe65678c51198ffe"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.25"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf157a4dc5a29b7b464aa8fe7edeff30076e07e13646a1c3874f58477dc99f8"
+checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -381,11 +356,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -410,7 +385,7 @@ dependencies = [
  "either",
  "getrandom",
  "itertools",
- "libloading 0.8.1",
+ "libloading",
  "linkify",
  "linkme",
  "neon-macros",
@@ -432,7 +407,7 @@ version = "1.1.0-alpha.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -473,19 +448,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -494,37 +468,27 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.32.1"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "peeking_take_while"
@@ -534,24 +498,27 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.57",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -580,27 +547,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psd"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1316f4ee59cdc95fc98e4e892a7edacaf1575620ca9e96abd421a2766fe45984"
+checksum = "9a25f9b8cfffd65d911baf31a033239f7a0facb755faa2481575b70db5dc9195"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -637,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -649,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -660,15 +627,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -678,34 +645,34 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "send_wrapper"
@@ -715,31 +682,32 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -761,15 +729,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
@@ -784,14 +752,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "termcolor"
@@ -804,40 +778,39 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
- "num_cpus",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -847,36 +820,44 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "trybuild"
-version = "1.0.99"
+name = "toml_write"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "trybuild"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]
@@ -892,15 +873,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -922,25 +903,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.0.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi-util"
@@ -948,152 +913,107 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-sys",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://www.neon-bindings.com"
 repository = "https://github.com/neon-bindings/neon"
 license = "MIT/Apache-2.0"
 exclude = ["neon.jpg", "doc/**/*"]
-edition = "2021"
+edition = "2024"
 
 [dev-dependencies]
 itertools = "0.10.5"
@@ -27,7 +27,7 @@ nodejs-sys = "0.15.0"
 either = "1.13.0"
 getrandom = { version = "0.2.11", optional = true }
 libloading = "0.8.1"
-linkme = "0.3.25"
+linkme = "0.3.32"
 semver = "1.0.20"
 smallvec = "1.11.2"
 once_cell = "1.18.0"

--- a/crates/neon/src/context/internal.rs
+++ b/crates/neon/src/context/internal.rs
@@ -36,12 +36,16 @@ impl Env {
         let result = f();
         let mut local: MaybeUninit<raw::Local> = MaybeUninit::zeroed();
 
-        if sys::error::catch_error(self.to_raw(), local.as_mut_ptr()) {
-            Err(local.assume_init())
-        } else if let Ok(result) = result {
-            Ok(result)
-        } else {
-            panic!("try_catch: unexpected Err(Throw) when VM is not in a throwing state");
+        unsafe {
+            if sys::error::catch_error(self.to_raw(), local.as_mut_ptr()) {
+                Err(local.assume_init())
+            } else {
+                if let Ok(result) = result {
+                    Ok(result)
+                } else {
+                    panic!("try_catch: unexpected Err(Throw) when VM is not in a throwing state");
+                }
+            }
         }
     }
 }
@@ -72,19 +76,21 @@ fn init(cx: ModuleContext) -> NeonResult<()> {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn napi_register_module_v1(env: *mut c_void, m: *mut c_void) -> *mut c_void {
-    let env = env.cast();
+    unsafe {
+        let env = env.cast();
 
-    sys::setup(env);
+        sys::setup(env);
 
-    IS_RUNNING.with(|v| {
-        *v.borrow_mut() = true;
-    });
+        IS_RUNNING.with(|v| {
+            *v.borrow_mut() = true;
+        });
 
-    let env = Env(env);
-    let exports = Handle::new_internal(JsObject::from_local(env, m.cast()));
-    let _ = ModuleContext::with(env, exports, init);
+        let env = Env(env);
+        let exports = Handle::new_internal(JsObject::from_local(env, m.cast()));
+        let _ = ModuleContext::with(env, exports, init);
 
-    m
+        m
+    }
 }

--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -239,9 +239,11 @@ impl<'cx> Cx<'cx> {
     #[cfg(feature = "sys")]
     #[cfg_attr(docsrs, doc(cfg(feature = "sys")))]
     pub unsafe fn from_raw(env: sys::Env) -> Self {
-        Self {
-            env: env.into(),
-            _phantom_inner: PhantomData,
+        unsafe {
+            Self {
+                env: env.into(),
+                _phantom_inner: PhantomData,
+            }
         }
     }
 
@@ -311,7 +313,9 @@ impl CallbackInfo<'_> {
     }
 
     pub fn argv<'b, C: Context<'b>>(&self, cx: &mut C) -> sys::call::Arguments {
-        unsafe { sys::call::argv(cx.env().to_raw(), self.info) }
+        unsafe {
+            sys::call::argv(cx.env().to_raw(), self.info)
+        }
     }
 
     pub fn this<'b, C: Context<'b>>(&self, cx: &mut C) -> raw::Local {
@@ -386,7 +390,9 @@ pub trait Context<'a>: ContextInternal<'a> {
         F: FnOnce(Cx<'b>) -> T,
     {
         let env = self.env();
-        let scope = unsafe { HandleScope::new(env.to_raw()) };
+        let scope = unsafe {
+            HandleScope::new(env.to_raw())
+        };
         let result = f(Cx::new(env));
 
         drop(scope);
@@ -406,14 +412,18 @@ pub trait Context<'a>: ContextInternal<'a> {
         F: FnOnce(Cx<'b>) -> JsResult<'b, V>,
     {
         let env = self.env();
-        let scope = unsafe { EscapableHandleScope::new(env.to_raw()) };
+        let scope = unsafe {
+            EscapableHandleScope::new(env.to_raw())
+        };
         let cx = Cx::new(env);
 
-        let escapee = unsafe { scope.escape(f(cx)?.to_local()) };
+        let escapee = unsafe {
+            scope.escape(f(cx)?.to_local())
+        };
 
-        Ok(Handle::new_internal(unsafe {
-            V::from_local(self.env(), escapee)
-        }))
+        Ok(unsafe {
+            Handle::new_internal(V::from_local(self.env(), escapee))
+        })
     }
 
     fn try_catch<T, F>(&mut self, f: F) -> Result<T, Handle<'a, JsValue>>
@@ -512,6 +522,7 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// Produces a handle to the JavaScript global object.
     fn global_object(&mut self) -> Handle<'a, JsObject> {
         JsObject::build(|out| unsafe {
+            
             sys::scope::get_global(self.env().to_raw(), out);
         })
     }
@@ -799,7 +810,9 @@ impl<'cx> FunctionContext<'cx> {
         };
 
         argv.get(i)
-            .map(|v| Handle::new_internal(unsafe { JsValue::from_local(self.env(), v) }))
+            .map(|v| unsafe {
+                Handle::new_internal(JsValue::from_local(self.env(), v))
+            })
     }
 
     /// Produces the `i`th argument and casts it to the type `V`, or throws an exception if `i` is greater than or equal to `self.len()` or cannot be cast to `V`.

--- a/crates/neon/src/handle/root.rs
+++ b/crates/neon/src/handle/root.rs
@@ -31,7 +31,7 @@ impl NapiRef {
     /// # Safety
     /// Must only be used from the same module context that created the reference
     pub(crate) unsafe fn unref(self, env: raw::Env) {
-        reference::unreference(env, self.0.cast());
+        unsafe { reference::unreference(env, self.0.cast()) }
     }
 }
 

--- a/crates/neon/src/lifecycle.rs
+++ b/crates/neon/src/lifecycle.rs
@@ -108,7 +108,7 @@ impl LocalCell {
     {
         let cell = InstanceData::locals(cx).get(id);
         match cell {
-            LocalCell::Init(ref mut b) => Some(b),
+            LocalCell::Init(b) => Some(b),
             _ => None,
         }
     }

--- a/crates/neon/src/object/mod.rs
+++ b/crates/neon/src/object/mod.rs
@@ -76,7 +76,7 @@ impl PropertyKey for u32 {
         out: &mut raw::Local,
         obj: raw::Local,
     ) -> bool {
-        sys::object::get_index(out, cx.env().to_raw(), obj, self)
+        unsafe { sys::object::get_index(out, cx.env().to_raw(), obj, self) }
     }
 
     unsafe fn set_from<'c, C: Context<'c>>(
@@ -86,7 +86,7 @@ impl PropertyKey for u32 {
         obj: raw::Local,
         val: raw::Local,
     ) -> bool {
-        sys::object::set_index(out, cx.env().to_raw(), obj, self, val)
+        unsafe { sys::object::set_index(out, cx.env().to_raw(), obj, self, val) }
     }
 }
 
@@ -99,7 +99,7 @@ impl<'a, K: Value> PropertyKey for Handle<'a, K> {
     ) -> bool {
         let env = cx.env().to_raw();
 
-        sys::object::get(out, env, obj, self.to_local())
+        unsafe { sys::object::get(out, env, obj, self.to_local()) }
     }
 
     unsafe fn set_from<'c, C: Context<'c>>(
@@ -111,7 +111,7 @@ impl<'a, K: Value> PropertyKey for Handle<'a, K> {
     ) -> bool {
         let env = cx.env().to_raw();
 
-        sys::object::set(out, env, obj, self.to_local(), val)
+        unsafe { sys::object::set(out, env, obj, self.to_local(), val) }
     }
 }
 
@@ -125,7 +125,7 @@ impl<'a> PropertyKey for &'a str {
         let (ptr, len) = Utf8::from(self).into_small_unwrap().lower();
         let env = cx.env().to_raw();
 
-        sys::object::get_string(env, out, obj, ptr, len)
+        unsafe { sys::object::get_string(env, out, obj, ptr, len) }
     }
 
     unsafe fn set_from<'c, C: Context<'c>>(
@@ -138,7 +138,7 @@ impl<'a> PropertyKey for &'a str {
         let (ptr, len) = Utf8::from(self).into_small_unwrap().lower();
         let env = cx.env().to_raw();
 
-        sys::object::set_string(env, out, obj, ptr, len, val)
+        unsafe { sys::object::set_string(env, out, obj, ptr, len, val) }
     }
 }
 

--- a/crates/neon/src/sys/array.rs
+++ b/crates/neon/src/sys/array.rs
@@ -6,7 +6,9 @@ use super::{
 };
 
 pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
-    napi::create_array_with_length(env, length, out as *mut _).unwrap();
+    unsafe {
+        napi::create_array_with_length(env, length, out as *mut _).unwrap();
+    }
 }
 
 /// Gets the length of a `napi_value` containing a JavaScript Array.
@@ -16,6 +18,8 @@ pub unsafe fn new(out: &mut Local, env: Env, length: usize) {
 /// exception.
 pub unsafe fn len(env: Env, array: Local) -> u32 {
     let mut len = 0;
-    napi::get_array_length(env, array, &mut len as *mut _).unwrap();
+    unsafe {
+        napi::get_array_length(env, array, &mut len as *mut _).unwrap();
+    }
     len
 }

--- a/crates/neon/src/sys/arraybuffer.rs
+++ b/crates/neon/src/sys/arraybuffer.rs
@@ -9,14 +9,16 @@ use super::{
 
 pub unsafe fn new(env: Env, len: usize) -> Result<Local, napi::Status> {
     let mut buf = MaybeUninit::uninit();
-    let status = napi::create_arraybuffer(env, len, null_mut(), buf.as_mut_ptr());
+    let status = unsafe {
+        napi::create_arraybuffer(env, len, null_mut(), buf.as_mut_ptr())
+    };
 
     match status {
         Err(err @ napi::Status::PendingException) => return Err(err),
         status => status.unwrap(),
     };
 
-    Ok(buf.assume_init())
+    Ok(unsafe { buf.assume_init() })
 }
 
 #[cfg(feature = "external-buffers")]
@@ -30,22 +32,24 @@ where
     let length = buf.len();
     let mut result = MaybeUninit::uninit();
 
-    napi::create_external_arraybuffer(
-        env,
-        buf.as_mut_ptr() as *mut _,
-        length,
-        Some(drop_external::<T>),
-        Box::into_raw(data) as *mut _,
-        result.as_mut_ptr(),
-    )
-    .unwrap();
+    unsafe {
+        napi::create_external_arraybuffer(
+            env,
+            buf.as_mut_ptr() as *mut _,
+            length,
+            Some(drop_external::<T>),
+            Box::into_raw(data) as *mut _,
+            result.as_mut_ptr(),
+        )
+        .unwrap();
 
-    result.assume_init()
+        result.assume_init()
+    }
 }
 
 #[cfg(feature = "external-buffers")]
 unsafe extern "C" fn drop_external<T>(_env: Env, _data: *mut c_void, hint: *mut c_void) {
-    drop(Box::<T>::from_raw(hint as *mut _));
+    drop(unsafe { Box::<T>::from_raw(hint as *mut _) });
 }
 
 /// # Safety
@@ -55,13 +59,17 @@ pub unsafe fn as_mut_slice<'a>(env: Env, buf: Local) -> &'a mut [u8] {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    unsafe {
+        napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    }
 
     if size == 0 {
         return &mut [];
     }
 
-    slice::from_raw_parts_mut(data.assume_init().cast(), size)
+    unsafe {
+        slice::from_raw_parts_mut(data.assume_init().cast(), size)
+    }
 }
 
 /// # Safety
@@ -70,7 +78,9 @@ pub unsafe fn size(env: Env, buf: Local) -> usize {
     let mut data = MaybeUninit::uninit();
     let mut size = 0usize;
 
-    napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    unsafe {
+        napi::get_arraybuffer_info(env, buf, data.as_mut_ptr(), &mut size as *mut _).unwrap();
+    }
 
     size
 }

--- a/crates/neon/src/sys/async_work.rs
+++ b/crates/neon/src/sys/async_work.rs
@@ -58,24 +58,26 @@ pub unsafe fn schedule<I, O, D>(
     let work = &mut data.work as *mut _;
 
     // Create the `async_work`
-    napi::create_async_work(
-        env,
-        ptr::null_mut(),
-        super::string(env, "neon_async_work"),
-        Some(call_execute::<I, O, D>),
-        Some(call_complete::<I, O, D>),
-        Box::into_raw(data).cast(),
-        work,
-    )
-    .unwrap();
+    unsafe {
+        napi::create_async_work(
+            env,
+            ptr::null_mut(),
+            super::string(env, "neon_async_work"),
+            Some(call_execute::<I, O, D>),
+            Some(call_complete::<I, O, D>),
+            Box::into_raw(data).cast(),
+            work,
+        )
+        .unwrap();
 
-    // Queue the work
-    match napi::queue_async_work(env, *work) {
-        Ok(()) => {}
-        status => {
-            // If queueing failed, delete the work to prevent a leak
-            let _ = napi::delete_async_work(env, *work);
-            status.unwrap()
+        // Queue the work
+        match napi::queue_async_work(env, *work) {
+            Ok(()) => {}
+            status => {
+                // If queueing failed, delete the work to prevent a leak
+                let _ = napi::delete_async_work(env, *work);
+                status.unwrap()
+            }
         }
     }
 }
@@ -123,18 +125,20 @@ impl<I, O> State<I, O> {
 /// * `Env` should not be used because it could attempt to call JavaScript
 /// * `data` is expected to be a pointer to `Data<I, O, D>`
 unsafe extern "C" fn call_execute<I, O, D>(_: Env, data: *mut c_void) {
-    let data = &mut *data.cast::<Data<I, O, D>>();
+    unsafe {
+        let data = &mut *data.cast::<Data<I, O, D>>();
 
-    // This is unwind safe because unwinding will resume on the other side
-    let output = catch_unwind(AssertUnwindSafe(|| {
-        // `unwrap` is ok because `call_execute` should be called exactly once
-        // after initialization
-        let input = data.state.take_execute_input().unwrap();
+        // This is unwind safe because unwinding will resume on the other side
+        let output = catch_unwind(AssertUnwindSafe(|| {
+            // `unwrap` is ok because `call_execute` should be called exactly once
+            // after initialization
+            let input = data.state.take_execute_input().unwrap();
 
-        (data.execute)(input)
-    }));
+            (data.execute)(input)
+        }));
 
-    data.state = State::Output(output);
+        data.state = State::Output(output);
+    }
 }
 
 /// Callback executed on the JavaScript main thread
@@ -142,39 +146,41 @@ unsafe extern "C" fn call_execute<I, O, D>(_: Env, data: *mut c_void) {
 /// # Safety
 /// * `data` is expected to be a pointer to `Data<I, O, D>`
 unsafe extern "C" fn call_complete<I, O, D>(env: Env, status: napi::Status, data: *mut c_void) {
-    let Data {
-        state,
-        complete,
-        data,
-        work,
-        ..
-    } = *Box::<Data<I, O, D>>::from_raw(data.cast());
+    unsafe {
+        let Data {
+            state,
+            complete,
+            data,
+            work,
+            ..
+        } = *Box::<Data<I, O, D>>::from_raw(data.cast());
 
-    debug_assert_eq!(napi::delete_async_work(env, work), Ok(()));
+        debug_assert_eq!(napi::delete_async_work(env, work), Ok(()));
 
-    BOUNDARY.catch_failure(env, None, move |env| {
-        // `unwrap` is okay because `call_complete` should be called exactly once
-        // if and only if `call_execute` has completed successfully
-        let output = state.into_output().unwrap();
+        BOUNDARY.catch_failure(env, None, move |env| {
+            // `unwrap` is okay because `call_complete` should be called exactly once
+            // if and only if `call_execute` has completed successfully
+            let output = state.into_output().unwrap();
 
-        // The event looped has stopped if we do not have an Env
-        let env = if let Some(env) = env {
-            env
-        } else {
-            // Resume panicking if necessary
-            if let Err(panic) = output {
-                resume_unwind(panic);
+            // The event looped has stopped if we do not have an Env
+            let env = if let Some(env) = env {
+                env
+            } else {
+                // Resume panicking if necessary
+                if let Err(panic) = output {
+                    resume_unwind(panic);
+                }
+
+                return ptr::null_mut();
+            };
+
+            match status {
+                napi::Status::Ok => complete(env, output, data.take()),
+                napi::Status::Cancelled => {}
+                _ => assert_eq!(status, napi::Status::Ok),
             }
 
-            return ptr::null_mut();
-        };
-
-        match status {
-            napi::Status::Ok => complete(env, output, data.take()),
-            napi::Status::Cancelled => {}
-            _ => assert_eq!(status, napi::Status::Ok),
-        }
-
-        ptr::null_mut()
-    });
+            ptr::null_mut()
+        })
+    }
 }

--- a/crates/neon/src/sys/call.rs
+++ b/crates/neon/src/sys/call.rs
@@ -33,34 +33,40 @@ impl Arguments {
 pub unsafe fn is_construct(env: Env, info: FunctionCallbackInfo) -> bool {
     let mut target: MaybeUninit<Local> = MaybeUninit::zeroed();
 
-    napi::get_new_target(env, info, target.as_mut_ptr()).unwrap();
+    unsafe {
+        napi::get_new_target(env, info, target.as_mut_ptr()).unwrap();
 
-    // get_new_target is guaranteed to assign to target, so it's initialized.
-    let target: Local = target.assume_init();
+        // get_new_target is guaranteed to assign to target, so it's initialized.
+        let target: Local = target.assume_init();
 
-    // By the get_new_target contract, target will either be NULL if the current
-    // function was called without `new`, or a valid napi_value handle if the current
-    // function was called with `new`.
-    !target.is_null()
+        // By the get_new_target contract, target will either be NULL if the current
+        // function was called without `new`, or a valid napi_value handle if the current
+        // function was called with `new`.
+        !target.is_null()
+    }
 }
 
 pub unsafe fn this(env: Env, info: FunctionCallbackInfo, out: &mut Local) {
-    napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut()).unwrap();
+    unsafe {
+        napi::get_cb_info(env, info, null_mut(), null_mut(), out as *mut _, null_mut()).unwrap();
+    }
 }
 
 /// Gets the number of arguments passed to the function.
 // TODO: Remove this when `FunctionContext` is refactored to get call info upfront.
 pub unsafe fn len(env: Env, info: FunctionCallbackInfo) -> usize {
     let mut argc = 0usize;
-    napi::get_cb_info(
-        env,
-        info,
-        &mut argc as *mut _,
-        null_mut(),
-        null_mut(),
-        null_mut(),
-    )
-    .unwrap();
+    unsafe {
+        napi::get_cb_info(
+            env,
+            info,
+            &mut argc as *mut _,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+        )
+        .unwrap();
+    }
     argc
 }
 
@@ -72,38 +78,44 @@ pub unsafe fn argv(env: Env, info: FunctionCallbackInfo) -> Arguments {
     // Starts as the size allocated; after `get_cb_info` it is the number of arguments
     let mut argc = ARGV_SIZE;
 
-    napi::get_cb_info(
-        env,
-        info,
-        &mut argc as *mut _,
-        argv.as_mut_ptr().cast(),
-        null_mut(),
-        null_mut(),
-    )
-    .unwrap();
+    unsafe {
+        napi::get_cb_info(
+            env,
+            info,
+            &mut argc as *mut _,
+            argv.as_mut_ptr().cast(),
+            null_mut(),
+            null_mut(),
+        )
+        .unwrap();
+    }
 
     // We did not allocate enough space; allocate on the heap and try again
     let argv = if argc > ARGV_SIZE {
         // We know exactly how much space to reserve
         let mut argv = Vec::with_capacity(argc);
 
-        napi::get_cb_info(
-            env,
-            info,
-            &mut argc as *mut _,
-            argv.as_mut_ptr(),
-            null_mut(),
-            null_mut(),
-        )
-        .unwrap();
+        unsafe {
+            napi::get_cb_info(
+                env,
+                info,
+                &mut argc as *mut _,
+                argv.as_mut_ptr(),
+                null_mut(),
+                null_mut(),
+            )
+            .unwrap();
 
-        // Set the size of `argv` to the number of initialized elements
-        argv.set_len(argc);
+            // Set the size of `argv` to the number of initialized elements
+            argv.set_len(argc);
+        }
         SmallVec::from_vec(argv)
 
         // There were `ARGV_SIZE` or fewer arguments, use the stack allocated space
     } else {
-        SmallVec::from_buf_and_len(argv.assume_init(), argc)
+        unsafe {
+            SmallVec::from_buf_and_len(argv.assume_init(), argc)
+        }
     };
 
     Arguments(argv)

--- a/crates/neon/src/sys/convert.rs
+++ b/crates/neon/src/sys/convert.rs
@@ -4,7 +4,9 @@ use super::{
 };
 
 pub unsafe fn to_string(out: &mut Local, env: Env, value: Local) -> bool {
-    let status = napi::coerce_to_string(env, value, out as *mut _);
+    let status = unsafe {
+        napi::coerce_to_string(env, value, out as *mut _)
+    };
 
     status.is_ok()
 }

--- a/crates/neon/src/sys/date.rs
+++ b/crates/neon/src/sys/date.rs
@@ -12,8 +12,10 @@ use super::{
 /// `env` is a raw pointer. Please ensure it points to a napi_env that is valid for the current context.
 pub unsafe fn new_date(env: Env, value: f64) -> Local {
     let mut local = MaybeUninit::zeroed();
-    napi::create_date(env, value, local.as_mut_ptr()).unwrap();
-    local.assume_init()
+    unsafe {
+        napi::create_date(env, value, local.as_mut_ptr()).unwrap();
+        local.assume_init()
+    }
 }
 
 /// Get the value of a date object
@@ -24,6 +26,8 @@ pub unsafe fn new_date(env: Env, value: f64) -> Local {
 /// `Local` must be an NAPI value associated with the given `Env`
 pub unsafe fn value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    napi::get_date_value(env, p, &mut value as *mut _).unwrap();
+    unsafe {
+        napi::get_date_value(env, p, &mut value as *mut _).unwrap();
+    }
     value
 }

--- a/crates/neon/src/sys/error.rs
+++ b/crates/neon/src/sys/error.rs
@@ -8,79 +8,92 @@ use super::{
 pub unsafe fn is_throwing(env: Env) -> bool {
     let mut b: MaybeUninit<bool> = MaybeUninit::zeroed();
 
-    napi::is_exception_pending(env, b.as_mut_ptr()).unwrap();
-
-    b.assume_init()
+    unsafe {
+        napi::is_exception_pending(env, b.as_mut_ptr()).unwrap();
+        b.assume_init()
+    }
 }
 
 pub unsafe fn catch_error(env: Env, error: *mut Local) -> bool {
-    if !is_throwing(env) {
+    if !unsafe { is_throwing(env) } {
         return false;
     }
 
-    napi::get_and_clear_last_exception(env, error).unwrap();
+    unsafe {
+        napi::get_and_clear_last_exception(env, error).unwrap();
+    }
 
     true
 }
 
 pub unsafe fn clear_exception(env: Env) {
     let mut result = MaybeUninit::uninit();
-    napi::is_exception_pending(env, result.as_mut_ptr()).unwrap();
+    unsafe {
+        napi::is_exception_pending(env, result.as_mut_ptr()).unwrap();
 
-    if !result.assume_init() {
-        return;
+        if !result.assume_init() {
+            return;
+        }
+
+        let mut result = MaybeUninit::uninit();
+        napi::get_and_clear_last_exception(env, result.as_mut_ptr()).unwrap();
     }
-
-    let mut result = MaybeUninit::uninit();
-    napi::get_and_clear_last_exception(env, result.as_mut_ptr()).unwrap();
 }
 
 pub unsafe fn throw(env: Env, val: Local) {
-    napi::throw(env, val).unwrap();
+    unsafe {
+        napi::throw(env, val).unwrap();
+    }
 }
 
 pub unsafe fn new_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
-
-    *out = result.assume_init();
+    unsafe {
+        napi::create_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
+        *out = result.assume_init();
+    }
 }
 
 pub unsafe fn new_type_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
-
-    *out = result.assume_init();
+    unsafe {
+        napi::create_type_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
+        *out = result.assume_init();
+    }
 }
 
 pub unsafe fn new_range_error(env: Env, out: &mut Local, msg: Local) {
     let mut result = MaybeUninit::uninit();
-    napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
-
-    *out = result.assume_init();
+    unsafe {
+        napi::create_range_error(env, ptr::null_mut(), msg, result.as_mut_ptr()).unwrap();
+        *out = result.assume_init();
+    }
 }
 
 pub unsafe fn throw_error_from_utf8(env: Env, msg: *const u8, len: i32) {
-    let mut out = MaybeUninit::uninit();
+    unsafe {
+        let mut out = MaybeUninit::uninit();
+        napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr()).unwrap();
 
-    napi::create_string_utf8(env, msg as *const _, len as usize, out.as_mut_ptr()).unwrap();
+        let mut err = MaybeUninit::uninit();
+        napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr()).unwrap();
 
-    let mut err = MaybeUninit::uninit();
-    napi::create_error(env, ptr::null_mut(), out.assume_init(), err.as_mut_ptr()).unwrap();
-
-    throw(env, err.assume_init());
+        throw(env, err.assume_init());
+    }
 }
 
 #[track_caller]
 pub(super) unsafe fn fatal_error(message: &str) -> ! {
     let location = Location::caller().to_string();
 
-    napi::fatal_error(
-        location.as_ptr().cast(),
-        location.len(),
-        message.as_ptr().cast(),
-        message.len(),
-    );
+    unsafe {
+        napi::fatal_error(
+            location.as_ptr().cast(),
+            location.len(),
+            message.as_ptr().cast(),
+            message.len(),
+        );
+    }
 
     unreachable!("Expected napi_fatal_error to exit the process")
 }

--- a/crates/neon/src/sys/fun.rs
+++ b/crates/neon/src/sys/fun.rs
@@ -11,54 +11,58 @@ pub unsafe fn new<F>(env: Env, name: &str, callback: F) -> Result<Local, napi::S
 where
     F: Fn(Env, napi::CallbackInfo) -> Local + 'static,
 {
-    let mut out = MaybeUninit::uninit();
-    let data = Box::into_raw(Box::new(callback));
-    let status = napi::create_function(
-        env,
-        name.as_ptr().cast(),
-        name.len(),
-        Some(call_boxed::<F>),
-        data.cast(),
-        out.as_mut_ptr(),
-    );
-
-    match status {
-        Err(err @ napi::Status::PendingException) => {
-            drop(Box::from_raw(data));
-
-            return Err(err);
-        }
-        status => status.unwrap(),
-    };
-
-    let out = out.assume_init();
-
-    #[cfg(feature = "napi-5")]
-    {
-        unsafe extern "C" fn drop_function<F>(
-            _env: Env,
-            _finalize_data: *mut c_void,
-            finalize_hint: *mut c_void,
-        ) {
-            drop(Box::from_raw(finalize_hint.cast::<F>()));
-        }
-
-        let status = napi::add_finalizer(
+    unsafe {
+        let mut out = MaybeUninit::uninit();
+        let data = Box::into_raw(Box::new(callback));
+        let status = napi::create_function(
             env,
-            out,
-            ptr::null_mut(),
-            Some(drop_function::<F>),
+            name.as_ptr().cast(),
+            name.len(),
+            Some(call_boxed::<F>),
             data.cast(),
-            ptr::null_mut(),
+            out.as_mut_ptr(),
         );
 
-        // If adding the finalizer fails the closure will leak, but it would
-        // be unsafe to drop it because there's no guarantee V8 won't use the
-        // pointer.
-        status.unwrap();
-    }
+        match status {
+            Err(err @ napi::Status::PendingException) => {
+                drop(Box::from_raw(data));
 
-    Ok(out)
+                return Err(err);
+            }
+            status => status.unwrap(),
+        };
+
+        let out = out.assume_init();
+
+        #[cfg(feature = "napi-5")]
+        {
+            unsafe extern "C" fn drop_function<F>(
+                _env: Env,
+                _finalize_data: *mut c_void,
+                finalize_hint: *mut c_void,
+            ) {
+                unsafe {
+                    drop(Box::from_raw(finalize_hint.cast::<F>()));
+                }
+            }
+
+            let status = napi::add_finalizer(
+                env,
+                out,
+                ptr::null_mut(),
+                Some(drop_function::<F>),
+                data.cast(),
+                ptr::null_mut(),
+            );
+
+            // If adding the finalizer fails the closure will leak, but it would
+            // be unsafe to drop it because there's no guarantee V8 won't use the
+            // pointer.
+            status.unwrap();
+        }
+
+        Ok(out)
+    }
 }
 
 // C ABI compatible function for invoking a boxed closure from the data field
@@ -67,20 +71,22 @@ unsafe extern "C" fn call_boxed<F>(env: Env, info: napi::CallbackInfo) -> Local
 where
     F: Fn(Env, napi::CallbackInfo) -> Local + 'static,
 {
-    let mut data = MaybeUninit::uninit();
-    napi::get_cb_info(
-        env,
-        info,
-        ptr::null_mut(),
-        ptr::null_mut(),
-        ptr::null_mut(),
-        data.as_mut_ptr(),
-    )
-    .unwrap();
+    unsafe {
+        let mut data = MaybeUninit::uninit();
+        napi::get_cb_info(
+            env,
+            info,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            data.as_mut_ptr(),
+        )
+        .unwrap();
 
-    let callback = &*data.assume_init().cast::<F>();
+        let callback = &*data.assume_init().cast::<F>();
 
-    callback(env, info)
+        callback(env, info)
+    }
 }
 
 pub unsafe fn construct(
@@ -90,7 +96,9 @@ pub unsafe fn construct(
     argc: usize,
     argv: *const c_void,
 ) -> bool {
-    let status = napi::new_instance(env, fun, argc, argv as *const _, out as *mut _);
+    unsafe {
+        let status = napi::new_instance(env, fun, argc, argv as *const _, out as *mut _);
 
-    status.is_ok()
+        status.is_ok()
+    }
 }

--- a/crates/neon/src/sys/lifecycle.rs
+++ b/crates/neon/src/sys/lifecycle.rs
@@ -17,7 +17,7 @@ use super::{bindings as napi, raw::Env};
 pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T {
     let data = Box::into_raw(Box::new(data));
 
-    napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut()).unwrap();
+    unsafe { napi::set_instance_data(env, data.cast(), Some(drop_box::<T>), ptr::null_mut()).unwrap(); }
 
     data
 }
@@ -30,11 +30,13 @@ pub unsafe fn set_instance_data<T: Send + 'static>(env: Env, data: T) -> *mut T 
 pub unsafe fn get_instance_data<T: Send + 'static>(env: Env) -> *mut T {
     let mut data = MaybeUninit::uninit();
 
-    napi::get_instance_data(env, data.as_mut_ptr()).unwrap();
+    unsafe {
+        napi::get_instance_data(env, data.as_mut_ptr()).unwrap();
 
-    data.assume_init().cast()
+        data.assume_init().cast()
+    }
 }
 
 unsafe extern "C" fn drop_box<T>(_env: Env, data: *mut c_void, _hint: *mut c_void) {
-    drop(Box::<T>::from_raw(data.cast()));
+    unsafe { drop(Box::<T>::from_raw(data.cast())); }
 }

--- a/crates/neon/src/sys/mem.rs
+++ b/crates/neon/src/sys/mem.rs
@@ -5,6 +5,6 @@ use super::{
 
 pub unsafe fn strict_equals(env: Env, lhs: Local, rhs: Local) -> bool {
     let mut result = false;
-    napi::strict_equals(env, lhs, rhs, &mut result as *mut _).unwrap();
+    unsafe { napi::strict_equals(env, lhs, rhs, &mut result as *mut _) }.unwrap();
     result
 }

--- a/crates/neon/src/sys/mod.rs
+++ b/crates/neon/src/sys/mod.rs
@@ -113,15 +113,17 @@ unsafe fn string(env: Env, s: impl AsRef<str>) -> raw::Local {
     let s = s.as_ref();
     let mut result = MaybeUninit::uninit();
 
-    create_string_utf8(
-        env,
-        s.as_bytes().as_ptr() as *const _,
-        s.len(),
-        result.as_mut_ptr(),
-    )
-    .unwrap();
+    unsafe {
+        create_string_utf8(
+            env,
+            s.as_bytes().as_ptr() as *const _,
+            s.len(),
+            result.as_mut_ptr(),
+        )
+        .unwrap();
 
-    result.assume_init()
+        result.assume_init()
+    }
 }
 
 static SETUP: Once = Once::new();
@@ -134,5 +136,5 @@ static SETUP: Once = Once::new();
 /// # Safety
 /// `env` must be a valid `napi_env` for the current thread
 pub unsafe fn setup(env: Env) {
-    SETUP.call_once(|| load(env).expect("Failed to load N-API symbols"));
+    SETUP.call_once(|| unsafe { load(env) }.expect("Failed to load N-API symbols"));
 }

--- a/crates/neon/src/sys/no_panic.rs
+++ b/crates/neon/src/sys/no_panic.rs
@@ -65,9 +65,9 @@ impl FailureBoundary {
         } else {
             // If there was a panic and we don't have an `Env`, crash the process
             if let Err(panic) = panic {
-                let msg = panic_msg(&panic).unwrap_or(UNKNOWN_PANIC_MESSAGE);
+                let msg = unsafe { panic_msg(&panic) }.unwrap_or(UNKNOWN_PANIC_MESSAGE);
 
-                fatal_error(msg);
+                unsafe { fatal_error(msg) };
             }
 
             // If we don't have an `Env`, we can't catch an exception, nothing more to try
@@ -75,7 +75,7 @@ impl FailureBoundary {
         };
 
         // Check and catch a thrown exception
-        let exception = catch_exception(env);
+        let exception = unsafe { catch_exception(env) };
 
         // Create an error message or return if there wasn't a panic or exception
         let msg = match (exception, panic.as_ref()) {
@@ -86,7 +86,7 @@ impl FailureBoundary {
             (Some(err), Ok(_)) => {
                 // Reject the promise without wrapping
                 if let Some(deferred) = deferred {
-                    reject_deferred(env, deferred, err);
+                    unsafe { reject_deferred(env, deferred, err) };
 
                     return;
                 }
@@ -100,7 +100,7 @@ impl FailureBoundary {
             // No errors occurred! We're done!
             (None, Ok(value)) => {
                 if let Some(deferred) = deferred {
-                    resolve_deferred(env, deferred, *value);
+                    unsafe { resolve_deferred(env, deferred, *value) };
                 }
 
                 return;
@@ -109,17 +109,17 @@ impl FailureBoundary {
 
         // Reject the promise
         if let Some(deferred) = deferred {
-            let error = create_error(env, msg, exception, panic.err());
+            let error = unsafe { create_error(env, msg, exception, panic.err()) };
 
-            reject_deferred(env, deferred, error);
+            unsafe { reject_deferred(env, deferred, error) };
 
             return;
         }
 
-        let error = create_error(env, msg, exception, panic.err());
+        let error = unsafe { create_error(env, msg, exception, panic.err()) };
 
         // Trigger a fatal exception
-        fatal_exception(env, error);
+        unsafe { fatal_exception(env, error) };
     }
 }
 
@@ -143,13 +143,15 @@ unsafe fn fatal_exception(env: Env, error: Local) {
     let mut deferred = MaybeUninit::uninit();
     let mut promise = MaybeUninit::uninit();
 
-    let deferred = match napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()) {
-        Ok(()) => deferred.assume_init(),
-        _ => fatal_error("Failed to create a promise"),
-    };
+    unsafe {
+        let deferred = match napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()) {
+            Ok(()) => deferred.assume_init(),
+            _ => fatal_error("Failed to create a promise"),
+        };
 
-    if napi::reject_deferred(env, deferred, error) != Ok(()) {
-        fatal_error("Failed to reject a promise");
+        if napi::reject_deferred(env, deferred, error) != Ok(()) {
+            fatal_error("Failed to reject a promise");
+        }
     }
 }
 
@@ -161,16 +163,16 @@ unsafe fn create_error(
     panic: Option<Panic>,
 ) -> Local {
     // Construct the `uncaughtException` Error object
-    let error = error_from_message(env, msg);
+    let error = unsafe { error_from_message(env, msg) };
 
     // Add the exception to the error
     if let Some(exception) = exception {
-        set_property(env, error, "cause", exception);
+        unsafe { set_property(env, error, "cause", exception) };
     };
 
     // Add the panic to the error
     if let Some(panic) = panic {
-        set_property(env, error, "panic", error_from_panic(env, panic));
+        unsafe { set_property(env, error, "panic", error_from_panic(env, panic)) };
     }
 
     error
@@ -178,65 +180,77 @@ unsafe fn create_error(
 
 #[track_caller]
 unsafe fn resolve_deferred(env: Env, deferred: napi::Deferred, value: Local) {
-    if napi::resolve_deferred(env, deferred, value) != Ok(()) {
-        fatal_error("Failed to resolve promise");
+    unsafe {
+        if napi::resolve_deferred(env, deferred, value) != Ok(()) {
+            fatal_error("Failed to resolve promise");
+        }
     }
 }
 
 #[track_caller]
 unsafe fn reject_deferred(env: Env, deferred: napi::Deferred, value: Local) {
-    if napi::reject_deferred(env, deferred, value) != Ok(()) {
-        fatal_error("Failed to reject promise");
+    unsafe {
+        if napi::reject_deferred(env, deferred, value) != Ok(()) {
+            fatal_error("Failed to reject promise");
+        }
     }
 }
 
 #[track_caller]
 unsafe fn catch_exception(env: Env) -> Option<Local> {
-    if !is_exception_pending(env) {
+    if !unsafe { is_exception_pending(env) } {
         return None;
     }
 
     let mut error = MaybeUninit::uninit();
 
-    if napi::get_and_clear_last_exception(env, error.as_mut_ptr()) != Ok(()) {
-        fatal_error("Failed to get and clear the last exception");
-    }
+    unsafe {
+        if napi::get_and_clear_last_exception(env, error.as_mut_ptr()) != Ok(()) {
+            fatal_error("Failed to get and clear the last exception");
+        }
 
-    Some(error.assume_init())
+        Some(error.assume_init())
+    }
 }
 
 #[track_caller]
 unsafe fn error_from_message(env: Env, msg: &str) -> Local {
-    let msg = create_string(env, msg);
+    let msg = unsafe { create_string(env, msg) };
     let mut err = MaybeUninit::uninit();
 
-    let status = napi::create_error(env, ptr::null_mut(), msg, err.as_mut_ptr());
+    unsafe {
+        let status = napi::create_error(env, ptr::null_mut(), msg, err.as_mut_ptr());
 
-    match status {
-        Ok(()) => err.assume_init(),
-        Err(_) => fatal_error("Failed to create an Error"),
+        match status {
+            Ok(()) => err.assume_init(),
+            Err(_) => fatal_error("Failed to create an Error"),
+        }
     }
 }
 
 #[track_caller]
 unsafe fn error_from_panic(env: Env, panic: Panic) -> Local {
-    if let Some(msg) = panic_msg(&panic) {
-        error_from_message(env, msg)
-    } else {
-        let error = error_from_message(env, UNKNOWN_PANIC_MESSAGE);
-        let panic = external_from_panic(env, panic);
+    unsafe {
+        if let Some(msg) = panic_msg(&panic) {
+            error_from_message(env, msg)
+        } else {
+            let error = error_from_message(env, UNKNOWN_PANIC_MESSAGE);
+            let panic = external_from_panic(env, panic);
 
-        set_property(env, error, "cause", panic);
-        error
+            set_property(env, error, "cause", panic);
+            error
+        }
     }
 }
 
 #[track_caller]
 unsafe fn set_property(env: Env, object: Local, key: &str, value: Local) {
-    let key = create_string(env, key);
+    unsafe {
+        let key = create_string(env, key);
 
-    if napi::set_property(env, object, key, value).is_err() {
-        fatal_error("Failed to set an object property");
+        if napi::set_property(env, object, key, value).is_err() {
+            fatal_error("Failed to set an object property");
+        }
     }
 }
 
@@ -252,25 +266,25 @@ unsafe fn panic_msg(panic: &Panic) -> Option<&str> {
 }
 
 unsafe fn external_from_panic(env: Env, panic: Panic) -> Local {
-    let fail = || fatal_error("Failed to create a neon::types::JsBox from a panic");
+    let fail = || unsafe { fatal_error("Failed to create a neon::types::JsBox from a panic") };
     let mut result = MaybeUninit::uninit();
 
-    if napi::create_external(
+    if unsafe { napi::create_external(
         env,
         Box::into_raw(Box::new(DebugSendWrapper::new(panic))).cast(),
         Some(finalize_panic),
         ptr::null_mut(),
         result.as_mut_ptr(),
-    )
+    ) }
     .is_err()
     {
         fail();
     }
 
-    let external = result.assume_init();
+    let external = unsafe { result.assume_init() };
 
     #[cfg(feature = "napi-8")]
-    if napi::type_tag_object(env, external, &*crate::MODULE_TAG).is_err() {
+    if unsafe { napi::type_tag_object(env, external, &*crate::MODULE_TAG).is_err() } {
         fail();
     }
 
@@ -287,18 +301,22 @@ extern "C" fn finalize_panic(_env: Env, data: *mut c_void, _hint: *mut c_void) {
 unsafe fn create_string(env: Env, msg: &str) -> Local {
     let mut string = MaybeUninit::uninit();
 
-    if napi::create_string_utf8(env, msg.as_ptr().cast(), msg.len(), string.as_mut_ptr()).is_err() {
-        fatal_error("Failed to create a String");
-    }
+    unsafe {
+        if napi::create_string_utf8(env, msg.as_ptr().cast(), msg.len(), string.as_mut_ptr()).is_err() {
+            fatal_error("Failed to create a String");
+        }
 
-    string.assume_init()
+        string.assume_init()
+    }
 }
 
 unsafe fn is_exception_pending(env: Env) -> bool {
     let mut throwing = false;
 
-    if napi::is_exception_pending(env, &mut throwing).is_err() {
-        fatal_error("Failed to check if an exception is pending");
+    unsafe {
+        if napi::is_exception_pending(env, &mut throwing).is_err() {
+            fatal_error("Failed to check if an exception is pending");
+        }
     }
 
     throwing

--- a/crates/neon/src/sys/object.rs
+++ b/crates/neon/src/sys/object.rs
@@ -7,12 +7,12 @@ use super::{
 
 /// Mutates the `out` argument to refer to a `napi_value` containing a newly created JavaScript Object.
 pub unsafe fn new(out: &mut Local, env: Env) {
-    napi::create_object(env, out as *mut _).unwrap();
+    unsafe { napi::create_object(env, out as *mut _) }.unwrap();
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn freeze(env: Env, obj: Local) -> Result<(), napi::Status> {
-    let status = napi::object_freeze(env, obj);
+    let status = unsafe { napi::object_freeze(env, obj) };
     debug_assert!(matches!(
         status,
         Ok(()) | Err(napi::Status::PendingException | napi::Status::GenericFailure)
@@ -22,7 +22,7 @@ pub unsafe fn freeze(env: Env, obj: Local) -> Result<(), napi::Status> {
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn seal(env: Env, obj: Local) -> Result<(), napi::Status> {
-    napi::object_seal(env, obj)
+    unsafe { napi::object_seal(env, obj) }
 }
 
 #[cfg(feature = "napi-6")]
@@ -31,26 +31,28 @@ pub unsafe fn seal(env: Env, obj: Local) -> Result<(), napi::Status> {
 pub unsafe fn get_own_property_names(out: &mut Local, env: Env, object: Local) -> bool {
     let mut property_names = MaybeUninit::uninit();
 
-    match napi::get_all_property_names(
-        env,
-        object,
-        napi::KeyCollectionMode::OwnOnly,
-        napi::KeyFilter::ALL_PROPERTIES | napi::KeyFilter::SKIP_SYMBOLS,
-        napi::KeyConversion::NumbersToStrings,
-        property_names.as_mut_ptr(),
-    ) {
-        Err(napi::Status::PendingException) => return false,
-        status => status.unwrap(),
-    }
+    unsafe {
+        match napi::get_all_property_names(
+            env,
+            object,
+            napi::KeyCollectionMode::OwnOnly,
+            napi::KeyFilter::ALL_PROPERTIES | napi::KeyFilter::SKIP_SYMBOLS,
+            napi::KeyConversion::NumbersToStrings,
+            property_names.as_mut_ptr(),
+        ) {
+            Err(napi::Status::PendingException) => return false,
+            status => status.unwrap(),
+        }
 
-    *out = property_names.assume_init();
+        *out = property_names.assume_init();
+    }
 
     true
 }
 
 /// Mutate the `out` argument to refer to the value at `index` in the given `object`. Returns `false` if the value couldn't be retrieved.
 pub unsafe fn get_index(out: &mut Local, env: Env, object: Local, index: u32) -> bool {
-    let status = napi::get_element(env, object, index, out as *mut _);
+    let status = unsafe { napi::get_element(env, object, index, out as *mut _) };
 
     status.is_ok()
 }
@@ -63,7 +65,7 @@ pub unsafe fn get_index(out: &mut Local, env: Env, object: Local, index: u32) ->
 ///
 /// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
 pub unsafe fn set_index(out: &mut bool, env: Env, object: Local, index: u32, val: Local) -> bool {
-    let status = napi::set_element(env, object, index, val);
+    let status = unsafe { napi::set_element(env, object, index, val) };
     *out = status.is_ok();
 
     *out
@@ -79,17 +81,19 @@ pub unsafe fn get_string(
 ) -> bool {
     let mut key_val = MaybeUninit::uninit();
 
-    // Not using `crate::string::new()` because it requires a _reference_ to a Local,
-    // while we only have uninitialized memory.
-    match napi::create_string_utf8(env, key as *const _, len as usize, key_val.as_mut_ptr()) {
-        Err(napi::Status::PendingException) => return false,
-        status => status.unwrap(),
-    }
+    unsafe {
+        // Not using `crate::string::new()` because it requires a _reference_ to a Local,
+        // while we only have uninitialized memory.
+        match napi::create_string_utf8(env, key as *const _, len as usize, key_val.as_mut_ptr()) {
+            Err(napi::Status::PendingException) => return false,
+            status => status.unwrap(),
+        }
 
-    // Not using napi_get_named_property() because the `key` may not be null terminated.
-    match napi::get_property(env, object, key_val.assume_init(), out as *mut _) {
-        Err(napi::Status::PendingException) => return false,
-        status => status.unwrap(),
+        // Not using napi_get_named_property() because the `key` may not be null terminated.
+        match napi::get_property(env, object, key_val.assume_init(), out as *mut _) {
+            Err(napi::Status::PendingException) => return false,
+            status => status.unwrap(),
+        }
     }
 
     true
@@ -111,22 +115,24 @@ pub unsafe fn set_string(
 ) -> bool {
     let mut key_val = MaybeUninit::uninit();
 
-    *out = true;
+    unsafe {
+        *out = true;
 
-    match napi::create_string_utf8(env, key as *const _, len as usize, key_val.as_mut_ptr()) {
-        Err(napi::Status::PendingException) => {
-            *out = false;
-            return false;
+        match napi::create_string_utf8(env, key as *const _, len as usize, key_val.as_mut_ptr()) {
+            Err(napi::Status::PendingException) => {
+                *out = false;
+                return false;
+            }
+            status => status.unwrap(),
         }
-        status => status.unwrap(),
-    }
 
-    match napi::set_property(env, object, key_val.assume_init(), val) {
-        Err(napi::Status::PendingException) => {
-            *out = false;
-            return false;
+        match napi::set_property(env, object, key_val.assume_init(), val) {
+            Err(napi::Status::PendingException) => {
+                *out = false;
+                return false;
+            }
+            status => status.unwrap(),
         }
-        status => status.unwrap(),
     }
 
     true
@@ -135,7 +141,7 @@ pub unsafe fn set_string(
 /// Mutates `out` to refer to the value of the property of `object` named by the `key` value.
 /// Returns false if the value couldn't be retrieved.
 pub unsafe fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool {
-    let status = napi::get_property(env, object, key, out as *mut _);
+    let status = unsafe { napi::get_property(env, object, key, out as *mut _) };
 
     status.is_ok()
 }
@@ -147,7 +153,7 @@ pub unsafe fn get(out: &mut Local, env: Env, object: Local, key: Local) -> bool 
 ///
 /// [discussion]: https://github.com/neon-bindings/neon/pull/458#discussion_r344827965
 pub unsafe fn set(out: &mut bool, env: Env, object: Local, key: Local, val: Local) -> bool {
-    let status = napi::set_property(env, object, key, val);
+    let status = unsafe { napi::set_property(env, object, key, val) };
     *out = status.is_ok();
 
     *out

--- a/crates/neon/src/sys/primitive.rs
+++ b/crates/neon/src/sys/primitive.rs
@@ -5,17 +5,17 @@ use super::{
 
 /// Mutates the `out` argument provided to refer to the global `undefined` object.
 pub unsafe fn undefined(out: &mut Local, env: Env) {
-    napi::get_undefined(env, out as *mut Local).unwrap();
+    unsafe { napi::get_undefined(env, out as *mut Local).unwrap() };
 }
 
 /// Mutates the `out` argument provided to refer to the global `null` object.
 pub unsafe fn null(out: &mut Local, env: Env) {
-    napi::get_null(env, out as *mut Local).unwrap();
+    unsafe { napi::get_null(env, out as *mut Local).unwrap() };
 }
 
 /// Mutates the `out` argument provided to refer to one of the global `true` or `false` objects.
 pub unsafe fn boolean(out: &mut Local, env: Env, b: bool) {
-    napi::get_boolean(env, b, out as *mut Local).unwrap();
+    unsafe { napi::get_boolean(env, b, out as *mut Local).unwrap() };
 }
 
 /// Get the boolean value out of a `Local` object. If the `Local` object does not contain a
@@ -23,7 +23,7 @@ pub unsafe fn boolean(out: &mut Local, env: Env, b: bool) {
 pub unsafe fn boolean_value(env: Env, p: Local) -> bool {
     let mut value = false;
     assert_eq!(
-        napi::get_value_bool(env, p, &mut value as *mut bool),
+        unsafe { napi::get_value_bool(env, p, &mut value as *mut bool) },
         Ok(())
     );
     value
@@ -32,13 +32,13 @@ pub unsafe fn boolean_value(env: Env, p: Local) -> bool {
 /// Mutates the `out` argument provided to refer to a newly created `Local` containing a
 /// JavaScript number.
 pub unsafe fn number(out: &mut Local, env: Env, v: f64) {
-    napi::create_double(env, v, out as *mut Local).unwrap();
+    unsafe { napi::create_double(env, v, out as *mut Local).unwrap() };
 }
 
 /// Gets the underlying value of an `Local` object containing a JavaScript number. Panics if
 /// the given `Local` is not a number.
 pub unsafe fn number_value(env: Env, p: Local) -> f64 {
     let mut value = 0.0;
-    napi::get_value_double(env, p, &mut value as *mut f64).unwrap();
+    unsafe { napi::get_value_double(env, p, &mut value as *mut f64).unwrap() };
     value
 }

--- a/crates/neon/src/sys/promise.rs
+++ b/crates/neon/src/sys/promise.rs
@@ -15,9 +15,10 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
     let mut deferred = MaybeUninit::uninit();
     let mut promise = MaybeUninit::uninit();
 
-    napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()).unwrap();
-
-    (deferred.assume_init(), promise.assume_init())
+    unsafe {
+        napi::create_promise(env, deferred.as_mut_ptr(), promise.as_mut_ptr()).unwrap();
+        (deferred.assume_init(), promise.assume_init())
+    }
 }
 
 /// Resolve a promise from a `napi::Deferred` handle
@@ -26,7 +27,7 @@ pub unsafe fn create(env: Env) -> (napi::Deferred, napi::Value) {
 /// * `env` is a valid `napi_env` for the current thread
 /// * `resolution` is a valid `napi::Value`
 pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Value) {
-    napi::resolve_deferred(env, deferred, resolution).unwrap();
+    unsafe { napi::resolve_deferred(env, deferred, resolution).unwrap() };
 }
 
 /// Rejects a promise from a `napi::Deferred` handle
@@ -35,7 +36,7 @@ pub unsafe fn resolve(env: Env, deferred: napi::Deferred, resolution: napi::Valu
 /// * `env` is a valid `napi_env` for the current thread
 /// * `rejection` is a valid `napi::Value`
 pub unsafe fn reject(env: Env, deferred: napi::Deferred, rejection: napi::Value) {
-    napi::reject_deferred(env, deferred, rejection).unwrap();
+    unsafe { napi::reject_deferred(env, deferred, rejection).unwrap() };
 }
 
 #[cfg(feature = "napi-6")]
@@ -44,10 +45,11 @@ pub unsafe fn reject(env: Env, deferred: napi::Deferred, rejection: napi::Value)
 /// # Safety
 /// * `env` is a valid `napi_env` for the current thread
 pub unsafe fn reject_err_message(env: Env, deferred: napi::Deferred, msg: impl AsRef<str>) {
-    let msg = super::string(env, msg);
+    let msg = unsafe { super::string(env, msg) };
     let mut err = MaybeUninit::uninit();
 
-    napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()).unwrap();
-
-    reject(env, deferred, err.assume_init());
+    unsafe {
+        napi::create_error(env, std::ptr::null_mut(), msg, err.as_mut_ptr()).unwrap();
+        reject(env, deferred, err.assume_init());
+    }
 }

--- a/crates/neon/src/sys/reference.rs
+++ b/crates/neon/src/sys/reference.rs
@@ -8,9 +8,10 @@ use super::{
 pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
     let mut result = MaybeUninit::uninit();
 
-    napi::create_reference(env, value, 1, result.as_mut_ptr()).unwrap();
-
-    result.assume_init()
+    unsafe {
+        napi::create_reference(env, value, 1, result.as_mut_ptr()).unwrap();
+        result.assume_init()
+    }
 }
 
 /// # Safety
@@ -18,9 +19,10 @@ pub unsafe fn new(env: Env, value: Local) -> napi::Ref {
 pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
     let mut result = MaybeUninit::uninit();
 
-    napi::reference_ref(env, value, result.as_mut_ptr()).unwrap();
-
-    result.assume_init() as usize
+    unsafe {
+        napi::reference_ref(env, value, result.as_mut_ptr()).unwrap();
+        result.assume_init() as usize
+    }
 }
 
 /// # Safety
@@ -28,10 +30,12 @@ pub unsafe fn reference(env: Env, value: napi::Ref) -> usize {
 pub unsafe fn unreference(env: Env, value: napi::Ref) {
     let mut result = MaybeUninit::uninit();
 
-    napi::reference_unref(env, value, result.as_mut_ptr()).unwrap();
+    unsafe {
+        napi::reference_unref(env, value, result.as_mut_ptr()).unwrap();
 
-    if result.assume_init() == 0 {
-        napi::delete_reference(env, value).unwrap();
+        if result.assume_init() == 0 {
+            napi::delete_reference(env, value).unwrap();
+        }
     }
 }
 
@@ -40,7 +44,8 @@ pub unsafe fn unreference(env: Env, value: napi::Ref) {
 pub unsafe fn get(env: Env, value: napi::Ref) -> Local {
     let mut result = MaybeUninit::uninit();
 
-    napi::get_reference_value(env, value, result.as_mut_ptr()).unwrap();
-
-    result.assume_init()
+    unsafe {
+        napi::get_reference_value(env, value, result.as_mut_ptr()).unwrap();
+        result.assume_init()
+    }
 }

--- a/crates/neon/src/sys/scope.rs
+++ b/crates/neon/src/sys/scope.rs
@@ -14,11 +14,13 @@ impl HandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        napi::open_handle_scope(env, scope.as_mut_ptr()).unwrap();
+        unsafe {
+            napi::open_handle_scope(env, scope.as_mut_ptr()).unwrap();
 
-        Self {
-            env,
-            scope: scope.assume_init(),
+            Self {
+                env,
+                scope: scope.assume_init(),
+            }
         }
     }
 }
@@ -42,20 +44,23 @@ impl EscapableHandleScope {
     pub(crate) unsafe fn new(env: Env) -> Self {
         let mut scope = MaybeUninit::uninit();
 
-        napi::open_escapable_handle_scope(env, scope.as_mut_ptr()).unwrap();
+        unsafe {
+            napi::open_escapable_handle_scope(env, scope.as_mut_ptr()).unwrap();
 
-        Self {
-            env,
-            scope: scope.assume_init(),
+            Self {
+                env,
+                scope: scope.assume_init(),
+            }
         }
     }
 
     pub(crate) unsafe fn escape(&self, value: napi::Value) -> napi::Value {
         let mut escapee = MaybeUninit::uninit();
 
-        napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()).unwrap();
-
-        escapee.assume_init()
+        unsafe {
+            napi::escape_handle(self.env, self.scope, value, escapee.as_mut_ptr()).unwrap();
+            escapee.assume_init()
+        }
     }
 }
 
@@ -70,5 +75,5 @@ impl Drop for EscapableHandleScope {
 }
 
 pub unsafe fn get_global(env: Env, out: &mut Local) {
-    super::get_global(env, out as *mut _).unwrap();
+    unsafe { super::get_global(env, out as *mut _) }.unwrap();
 }

--- a/crates/neon/src/sys/string.rs
+++ b/crates/neon/src/sys/string.rs
@@ -6,43 +6,49 @@ use super::{
 };
 
 pub unsafe fn new(out: &mut Local, env: Env, data: *const u8, len: i32) -> bool {
-    let status = napi::create_string_utf8(env, data as *const _, len as usize, out);
+    let status = unsafe { napi::create_string_utf8(env, data as *const _, len as usize, out) };
 
     status.is_ok()
 }
 
 pub unsafe fn utf8_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
-    napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
 
-    len.assume_init()
+    unsafe {
+        napi::get_value_string_utf8(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
+        len.assume_init()
+    }
 }
 
 pub unsafe fn data(env: Env, out: *mut u8, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
 
-    napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr()).unwrap();
-
-    read.assume_init()
+    unsafe {
+        napi::get_value_string_utf8(env, value, out as *mut _, len, read.as_mut_ptr()).unwrap();
+        read.assume_init()
+    }
 }
 
 pub unsafe fn utf16_len(env: Env, value: Local) -> usize {
     let mut len = MaybeUninit::uninit();
 
-    napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
-
-    len.assume_init()
+    unsafe {
+        napi::get_value_string_utf16(env, value, ptr::null_mut(), 0, len.as_mut_ptr()).unwrap();
+        len.assume_init()
+    }
 }
 
 pub unsafe fn data_utf16(env: Env, out: *mut u16, len: usize, value: Local) -> usize {
     let mut read = MaybeUninit::uninit();
-    napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr()).unwrap();
 
-    read.assume_init()
+    unsafe {
+        napi::get_value_string_utf16(env, value, out, len, read.as_mut_ptr()).unwrap();
+        read.assume_init()
+    }
 }
 
 pub unsafe fn run_script(out: &mut Local, env: Env, value: Local) -> bool {
-    let status = napi::run_script(env, value, out as *mut _);
+    let status = unsafe { napi::run_script(env, value, out as *mut _) };
 
     status == Ok(())
 }

--- a/crates/neon/src/sys/tag.rs
+++ b/crates/neon/src/sys/tag.rs
@@ -6,78 +6,78 @@ use super::{
 /// Return true if an `napi_value` `val` has the expected value type.
 unsafe fn is_type(env: Env, val: Local, expect: napi::ValueType) -> bool {
     let mut actual = napi::ValueType::Undefined;
-    napi::typeof_value(env, val, &mut actual as *mut _).unwrap();
+    unsafe { napi::typeof_value(env, val, &mut actual as *mut _) }.unwrap();
     actual == expect
 }
 
 pub unsafe fn is_undefined(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::Undefined)
+    unsafe { is_type(env, val, napi::ValueType::Undefined) }
 }
 
 pub unsafe fn is_null(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::Null)
+    unsafe { is_type(env, val, napi::ValueType::Null) }
 }
 
 /// Is `val` a JavaScript number?
 pub unsafe fn is_number(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::Number)
+    unsafe { is_type(env, val, napi::ValueType::Number) }
 }
 
 /// Is `val` a JavaScript boolean?
 pub unsafe fn is_boolean(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::Boolean)
+    unsafe { is_type(env, val, napi::ValueType::Boolean) }
 }
 
 /// Is `val` a JavaScript string?
 pub unsafe fn is_string(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::String)
+    unsafe { is_type(env, val, napi::ValueType::String) }
 }
 
 pub unsafe fn is_object(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::Object)
+    unsafe { is_type(env, val, napi::ValueType::Object) }
 }
 
 pub unsafe fn is_array(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_array(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_array(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
 pub unsafe fn is_function(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::Function)
+    unsafe { is_type(env, val, napi::ValueType::Function) }
 }
 
 pub unsafe fn is_error(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_error(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_error(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
 /// Is `val` a Node.js Buffer instance?
 pub unsafe fn is_buffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_buffer(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_buffer(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
 /// Is `val` an ArrayBuffer instance?
 pub unsafe fn is_arraybuffer(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_arraybuffer(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_arraybuffer(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
 /// Is `val` a TypedArray instance?
 pub unsafe fn is_typedarray(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_typedarray(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_typedarray(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
 #[cfg(feature = "napi-5")]
 pub unsafe fn is_date(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_date(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_date(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
@@ -87,24 +87,24 @@ pub unsafe fn is_date(env: Env, val: Local) -> bool {
 /// * `env` is a valid `napi_env` for the current thread
 pub unsafe fn is_promise(env: Env, val: Local) -> bool {
     let mut result = false;
-    napi::is_promise(env, val, &mut result as *mut _).unwrap();
+    unsafe { napi::is_promise(env, val, &mut result as *mut _) }.unwrap();
     result
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn type_tag_object(env: Env, object: Local, tag: &super::TypeTag) {
-    napi::type_tag_object(env, object, tag as *const _).unwrap();
+    unsafe { napi::type_tag_object(env, object, tag as *const _) }.unwrap();
 }
 
 #[cfg(feature = "napi-8")]
 pub unsafe fn check_object_type_tag(env: Env, object: Local, tag: &super::TypeTag) -> bool {
     let mut result = false;
 
-    napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _).unwrap();
+    unsafe { napi::check_object_type_tag(env, object, tag as *const _, &mut result as *mut _) }.unwrap();
     result
 }
 
 #[cfg(feature = "napi-6")]
 pub unsafe fn is_bigint(env: Env, val: Local) -> bool {
-    is_type(env, val, napi::ValueType::BigInt)
+    unsafe { is_type(env, val, napi::ValueType::BigInt) }
 }

--- a/crates/neon/src/types_impl/boxed.rs
+++ b/crates/neon/src/types_impl/boxed.rs
@@ -161,7 +161,7 @@ impl<T: 'static> std::fmt::Debug for JsBox<T> {
 // Attempt to use a `napi_value` as a `napi_external` to unwrap a `BoxAny>
 /// Safety: `local` must be a `napi_value` that is valid for the lifetime `'a`.
 unsafe fn maybe_external_deref<'a>(env: Env, local: raw::Local) -> Option<&'a BoxAny> {
-    external::deref::<BoxAny>(env.to_raw(), local).map(|v| &*v)
+    unsafe { external::deref::<BoxAny>(env.to_raw(), local).map(|v| &*v) }
 }
 
 // Custom `Clone` implementation since `T` might not be `Clone`

--- a/crates/neon/src/types_impl/buffer/types.rs
+++ b/crates/neon/src/types_impl/buffer/types.rs
@@ -82,12 +82,12 @@ impl JsBuffer {
 
     /// Constructs a new `Buffer` object with uninitialized memory
     pub unsafe fn uninitialized<'a, C: Context<'a>>(cx: &mut C, len: usize) -> JsResult<'a, Self> {
-        let result = sys::buffer::uninitialized(cx.env().to_raw(), len);
+        let result = unsafe { sys::buffer::uninitialized(cx.env().to_raw(), len) };
 
         if let Ok((buf, _)) = result {
             Ok(Handle::new_internal(Self(buf)))
         } else {
-            Err(Throw::new())
+            Err(unsafe { Throw::new() })
         }
     }
 
@@ -778,7 +778,7 @@ unsafe fn slice_from_info<'a, T>(info: TypedArrayInfo) -> &'a [T] {
     if info.length == 0 {
         &[]
     } else {
-        slice::from_raw_parts(info.data.cast(), info.length)
+        unsafe { slice::from_raw_parts(info.data.cast(), info.length) }
     }
 }
 
@@ -786,7 +786,7 @@ unsafe fn slice_from_info_mut<'a, T>(info: TypedArrayInfo) -> &'a mut [T] {
     if info.length == 0 {
         &mut []
     } else {
-        slice::from_raw_parts_mut(info.data.cast(), info.length)
+        unsafe { slice::from_raw_parts_mut(info.data.cast(), info.length) }
     }
 }
 

--- a/crates/neon/src/types_impl/promise.rs
+++ b/crates/neon/src/types_impl/promise.rs
@@ -394,11 +394,13 @@ unsafe impl Send for NodeApiDeferred {}
 #[cfg(feature = "napi-6")]
 impl NodeApiDeferred {
     pub(crate) unsafe fn leaked(self, env: raw::Env) {
-        sys::promise::reject_err_message(
-            env,
-            self.0,
-            "`neon::types::Deferred` was dropped without being settled",
-        );
+        unsafe {
+            sys::promise::reject_err_message(
+                env,
+                self.0,
+                "`neon::types::Deferred` was dropped without being settled",
+            );
+        }
     }
 }
 


### PR DESCRIPTION
This PR upgrades Neon's two crates (`neon` and `neon-macros`) to Rust 2024 Edition.

Details:
- unsafe functions now mark any unsafe operations explicitly
- upgrade linkme to get fix for 2024 Edition (https://github.com/dtolnay/linkme/issues/101)
- tweak internal generate! macro for a mysterious backwards-incompatibility in macro_rules! expansion behavior
