### PR TITLE
create-neon uses Neon 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "1.1.0-alpha.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "neon-macros"
-version = "1.1.0-alpha.2"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Once you have the [platform dependencies](https://neon-bindings.com/docs/quick-s
 simple as:
 
 ```
-$ npm init neon my-project
+$ npm init neon@latest my-project
 ```
 
 Then see the [Hello World guide](https://neon-bindings.com/docs/hello-world/) for writing your first Hello World in

--- a/pkgs/create-neon/data/templates/Cargo.toml.hbs
+++ b/pkgs/create-neon/data/templates/Cargo.toml.hbs
@@ -10,7 +10,7 @@ authors = [{{crate.escaped.author}}]
 {{#if crate.license}}
 license = {{crate.escaped.license}}
 {{/if}}
-edition = "2021"
+edition = "2024"
 exclude = ["index.node"]
 
 [lib]

--- a/pkgs/create-neon/data/templates/README.md.hbs
+++ b/pkgs/create-neon/data/templates/README.md.hbs
@@ -27,7 +27,7 @@ After building {{package.name}}, you can explore its exports at the Node console
 $ npm i
 $ npm run build
 $ node
-> require('.').greeting()
+> require('.').greeting('node')
 { message: 'hello node' }
 ```
 {{else}}
@@ -35,7 +35,7 @@ $ node
 $ npm i
 $ npm run build
 $ node
-> require('.').hello()
+> require('.').hello('node')
 'hello node'
 ```
 {{/if}}

--- a/pkgs/create-neon/data/templates/Workspace.toml.hbs
+++ b/pkgs/create-neon/data/templates/Workspace.toml.hbs
@@ -1,3 +1,3 @@
 [workspace]
 members = ["crates/{{crate.name}}"]
-resolver = "2"
+resolver = "3"

--- a/pkgs/create-neon/data/templates/lib.rs.hbs
+++ b/pkgs/create-neon/data/templates/lib.rs.hbs
@@ -1,11 +1,16 @@
-use neon::prelude::*;
+// Use #[neon::export] to export Rust functions as JavaScript functions.
+// See more at: https://docs.rs/neon/latest/neon/attr.export.html
 
-fn hello(mut cx: FunctionContext) -> JsResult<JsString> {
-    Ok(cx.string("hello node"))
+#[neon::export]
+fn hello(name: String) -> String {
+    format!("hello {name}")
 }
 
-#[neon::main]
-fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("hello", hello)?;
-    Ok(())
-}
+// Use #[neon::main] to add additional behavior at module loading time.
+// See more at: https://docs.rs/neon/latest/neon/attr.main.html
+
+// #[neon::main]
+// fn main(_cx: ModuleContext) -> NeonResult<()> {
+//     println!("module is loaded!");
+//     Ok(())
+// }

--- a/pkgs/create-neon/data/templates/ts/index.cts.hbs
+++ b/pkgs/create-neon/data/templates/ts/index.cts.hbs
@@ -6,14 +6,14 @@ import * as addon from './load.cjs';
 // Use this declaration to assign types to the addon's exports,
 // which otherwise by default are `any`.
 declare module "./load.cjs" {
-  function hello(): string;
+  function hello(name: string): string;
 }
 
 export type Greeting = {
   message: string
 };
 
-export function greeting(): Greeting {
-  const message = addon.hello();
+export function greeting(name: string): Greeting {
+  const message = addon.hello(name);
   return { message };
 }

--- a/pkgs/create-neon/data/versions.json
+++ b/pkgs/create-neon/data/versions.json
@@ -1,5 +1,5 @@
 {
-  "neon": "1",
+  "neon": "1.1",
   "neonCLI": "0.1.82",
   "neonLoad": "0.1.82",
   "typescript": "5.3.3",

--- a/pkgs/create-neon/package.json
+++ b/pkgs/create-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-neon",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Create Neon projects with no build configuration.",
   "type": "module",
   "exports": "./dist/src/bin/create-neon.js",

--- a/pkgs/create-neon/package.json
+++ b/pkgs/create-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-neon",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Create Neon projects with no build configuration.",
   "type": "module",
   "exports": "./dist/src/bin/create-neon.js",


### PR DESCRIPTION
This PR updates create-neon to generate projects that use Neon 1.1 and Rust 2024 Edition.