### PR TITLE
feat(neon): Add feature flag for enabling macros

### DIFF
--- a/crates/neon-macros/Cargo.toml
+++ b/crates/neon-macros/Cargo.toml
@@ -14,3 +14,7 @@ proc-macro = true
 proc-macro2 = "1.0.79"
 quote = "1.0.33"
 syn = { version = "2.0.57", features = ["full"] }
+
+[features]
+# Enable `#[neon::export]`
+export = []

--- a/crates/neon-macros/src/lib.rs
+++ b/crates/neon-macros/src/lib.rs
@@ -1,7 +1,9 @@
 //! Procedural macros supporting [Neon](https://docs.rs/neon/latest/neon/)
 
+#[cfg(feature = "export")]
 mod export;
 
+#[cfg(feature = "export")]
 #[proc_macro_attribute]
 pub fn main(
     _attr: proc_macro::TokenStream,
@@ -34,6 +36,41 @@ pub fn main(
     .into()
 }
 
+#[cfg(not(feature = "export"))]
+#[proc_macro_attribute]
+pub fn main(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let block = &input.block;
+    let name = &sig.ident;
+
+    quote::quote!(
+        #(#attrs) *
+        #vis #sig {
+            #[no_mangle]
+            unsafe extern "C" fn napi_register_module_v1(
+                env: *mut std::ffi::c_void,
+                m: *mut std::ffi::c_void,
+            ) -> *mut std::ffi::c_void {
+                unsafe {
+                    neon::macro_internal::initialize_module(env, m, #name);
+                    m
+                }
+            }
+
+            #block
+        }
+    )
+    .into()
+}
+
+#[cfg(feature = "export")]
 #[proc_macro_attribute]
 pub fn export(
     attr: proc_macro::TokenStream,

--- a/crates/neon/Cargo.toml
+++ b/crates/neon/Cargo.toml
@@ -27,7 +27,7 @@ nodejs-sys = "0.15.0"
 either = "1.13.0"
 getrandom = { version = "0.2.11", optional = true }
 libloading = "0.8.1"
-linkme = "0.3.33"
+linkme = { version = "0.3.33", optional = true }
 semver = "1.0.20"
 smallvec = "1.11.2"
 once_cell = "1.18.0"
@@ -46,10 +46,13 @@ features = ["sync"]
 optional = true
 
 [features]
-default = ["napi-8"]
+default = ["export", "napi-8"]
 
 # Enable extracting values by serializing to JSON
 serde = ["dep:serde", "dep:serde_json"]
+
+# Enable `#[neon::export]`
+export = ["dep:linkme", "neon-macros/export"]
 
 # Enable the creation of external binary buffers. This is disabled by default
 # since these APIs fail at runtime in environments that enable the V8 memory

--- a/crates/neon/src/lib.rs
+++ b/crates/neon/src/lib.rs
@@ -195,8 +195,14 @@ impl IntoIterator for Exports {
         for<'cx> fn(&mut ModuleContext<'cx>) -> NeonResult<(&'static str, Handle<'cx, JsValue>)>,
     >;
 
+    #[cfg(feature = "export")]
     fn into_iter(self) -> Self::IntoIter {
         crate::macro_internal::EXPORTS.into_iter()
+    }
+
+    #[cfg(not(feature = "export"))]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIterator::into_iter(&[])
     }
 }
 

--- a/crates/neon/src/macro_internal/export.rs
+++ b/crates/neon/src/macro_internal/export.rs
@@ -1,0 +1,105 @@
+use std::marker::PhantomData;
+
+pub use linkme;
+
+use crate::{
+    context::{Context, Cx, ModuleContext},
+    handle::Handle,
+    result::{JsResult, NeonResult},
+    types::{extract::TryIntoJs, JsValue},
+};
+
+#[cfg(feature = "serde")]
+use crate::types::extract::Json;
+
+type Export<'cx> = (&'static str, Handle<'cx, JsValue>);
+
+#[linkme::distributed_slice]
+pub static EXPORTS: [for<'cx> fn(&mut ModuleContext<'cx>) -> NeonResult<Export<'cx>>];
+
+#[linkme::distributed_slice]
+pub static MAIN: [for<'cx> fn(ModuleContext<'cx>) -> NeonResult<()>];
+
+// Wrapper for the value type and return type tags
+pub struct NeonMarker<Tag, Return>(PhantomData<Tag>, PhantomData<Return>);
+
+// Markers to determine the type of a value
+#[cfg(feature = "serde")]
+pub struct NeonJsonTag;
+pub struct NeonValueTag;
+pub struct NeonResultTag;
+
+pub trait ToNeonMarker {
+    type Return;
+
+    fn to_neon_marker<Tag>(&self) -> NeonMarker<Tag, Self::Return>;
+}
+
+// Specialized implementation for `Result`
+impl<T, E> ToNeonMarker for Result<T, E> {
+    type Return = NeonResultTag;
+
+    fn to_neon_marker<Tag>(&self) -> NeonMarker<Tag, Self::Return> {
+        NeonMarker(PhantomData, PhantomData)
+    }
+}
+
+// Default implementation that takes lower precedence due to autoref
+impl<T> ToNeonMarker for &T {
+    type Return = NeonValueTag;
+
+    fn to_neon_marker<Tag>(&self) -> NeonMarker<Tag, Self::Return> {
+        NeonMarker(PhantomData, PhantomData)
+    }
+}
+
+impl<Return> NeonMarker<NeonValueTag, Return> {
+    pub fn neon_into_js<'cx, T>(self, cx: &mut Cx<'cx>, v: T) -> JsResult<'cx, JsValue>
+    where
+        T: TryIntoJs<'cx>,
+    {
+        v.try_into_js(cx).map(|v| v.upcast())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl NeonMarker<NeonJsonTag, NeonValueTag> {
+    pub fn neon_into_js<'cx, T>(self, cx: &mut Cx<'cx>, v: T) -> JsResult<'cx, JsValue>
+    where
+        Json<T>: TryIntoJs<'cx>,
+    {
+        Json(v).try_into_js(cx).map(|v| v.upcast())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl NeonMarker<NeonJsonTag, NeonResultTag> {
+    pub fn neon_into_js<'cx, T, E>(
+        self,
+        cx: &mut Cx<'cx>,
+        res: Result<T, E>,
+    ) -> JsResult<'cx, JsValue>
+    where
+        Result<Json<T>, E>: TryIntoJs<'cx>,
+    {
+        res.map(Json).try_into_js(cx).map(|v| v.upcast())
+    }
+}
+
+impl<Tag> NeonMarker<Tag, NeonValueTag> {
+    pub fn into_neon_result<T>(self, _cx: &mut Cx, v: T) -> NeonResult<T> {
+        Ok(v)
+    }
+}
+
+impl<Tag> NeonMarker<Tag, NeonResultTag> {
+    pub fn into_neon_result<'cx, T, E>(self, cx: &mut Cx<'cx>, res: Result<T, E>) -> NeonResult<T>
+    where
+        E: TryIntoJs<'cx>,
+    {
+        match res {
+            Ok(v) => Ok(v),
+            Err(err) => err.try_into_js(cx).and_then(|err| cx.throw(err)),
+        }
+    }
+}

--- a/crates/neon/src/macro_internal/mod.rs
+++ b/crates/neon/src/macro_internal/mod.rs
@@ -1,113 +1,16 @@
 //! Internals needed by macros. These have to be exported for the macros to work
 
-use std::marker::PhantomData;
-
-pub use linkme;
-
-use crate::{
-    context::{Context, Cx, ModuleContext},
-    handle::Handle,
-    result::{JsResult, NeonResult},
-    types::{extract::TryIntoJs, JsValue},
-};
-
-#[cfg(feature = "serde")]
-use crate::types::extract::Json;
+#[cfg(feature = "export")]
+pub use self::export::*;
 
 #[cfg(all(feature = "napi-6", feature = "futures"))]
 pub use self::futures::*;
 
+#[cfg(feature = "export")]
+mod export;
+
 #[cfg(all(feature = "napi-6", feature = "futures"))]
 mod futures;
 
-type Export<'cx> = (&'static str, Handle<'cx, JsValue>);
-
-#[linkme::distributed_slice]
-pub static EXPORTS: [for<'cx> fn(&mut ModuleContext<'cx>) -> NeonResult<Export<'cx>>];
-
-#[linkme::distributed_slice]
-pub static MAIN: [for<'cx> fn(ModuleContext<'cx>) -> NeonResult<()>];
-
-// Wrapper for the value type and return type tags
-pub struct NeonMarker<Tag, Return>(PhantomData<Tag>, PhantomData<Return>);
-
-// Markers to determine the type of a value
-#[cfg(feature = "serde")]
-pub struct NeonJsonTag;
-pub struct NeonValueTag;
-pub struct NeonResultTag;
-
-pub trait ToNeonMarker {
-    type Return;
-
-    fn to_neon_marker<Tag>(&self) -> NeonMarker<Tag, Self::Return>;
-}
-
-// Specialized implementation for `Result`
-impl<T, E> ToNeonMarker for Result<T, E> {
-    type Return = NeonResultTag;
-
-    fn to_neon_marker<Tag>(&self) -> NeonMarker<Tag, Self::Return> {
-        NeonMarker(PhantomData, PhantomData)
-    }
-}
-
-// Default implementation that takes lower precedence due to autoref
-impl<T> ToNeonMarker for &T {
-    type Return = NeonValueTag;
-
-    fn to_neon_marker<Tag>(&self) -> NeonMarker<Tag, Self::Return> {
-        NeonMarker(PhantomData, PhantomData)
-    }
-}
-
-impl<Return> NeonMarker<NeonValueTag, Return> {
-    pub fn neon_into_js<'cx, T>(self, cx: &mut Cx<'cx>, v: T) -> JsResult<'cx, JsValue>
-    where
-        T: TryIntoJs<'cx>,
-    {
-        v.try_into_js(cx).map(|v| v.upcast())
-    }
-}
-
-#[cfg(feature = "serde")]
-impl NeonMarker<NeonJsonTag, NeonValueTag> {
-    pub fn neon_into_js<'cx, T>(self, cx: &mut Cx<'cx>, v: T) -> JsResult<'cx, JsValue>
-    where
-        Json<T>: TryIntoJs<'cx>,
-    {
-        Json(v).try_into_js(cx).map(|v| v.upcast())
-    }
-}
-
-#[cfg(feature = "serde")]
-impl NeonMarker<NeonJsonTag, NeonResultTag> {
-    pub fn neon_into_js<'cx, T, E>(
-        self,
-        cx: &mut Cx<'cx>,
-        res: Result<T, E>,
-    ) -> JsResult<'cx, JsValue>
-    where
-        Result<Json<T>, E>: TryIntoJs<'cx>,
-    {
-        res.map(Json).try_into_js(cx).map(|v| v.upcast())
-    }
-}
-
-impl<Tag> NeonMarker<Tag, NeonValueTag> {
-    pub fn into_neon_result<T>(self, _cx: &mut Cx, v: T) -> NeonResult<T> {
-        Ok(v)
-    }
-}
-
-impl<Tag> NeonMarker<Tag, NeonResultTag> {
-    pub fn into_neon_result<'cx, T, E>(self, cx: &mut Cx<'cx>, res: Result<T, E>) -> NeonResult<T>
-    where
-        E: TryIntoJs<'cx>,
-    {
-        match res {
-            Ok(v) => Ok(v),
-            Err(err) => err.try_into_js(cx).and_then(|err| cx.throw(err)),
-        }
-    }
-}
+#[cfg(not(feature = "export"))]
+pub use crate::context::internal::initialize_module;

--- a/crates/neon/src/macros.rs
+++ b/crates/neon/src/macros.rs
@@ -28,6 +28,8 @@
 /// ```
 pub use neon_macros::main;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "export")))]
+#[cfg(feature = "export")]
 /// Register an item to be exported by the Neon addon
 ///
 /// ## Exporting constants and statics


### PR DESCRIPTION
This allows making the `linkme` dependency optional which may be problematic on some platforms.

We may want to wait for reported problems before we add this complexity. While adding a default feature flag is not considered a breaking change, it _can_ break builds for anyone using `default-features = false`.