### PR TITLE
fix(neon): Fix test on Rust nightly

### DIFF
--- a/test/napi/lib/boxed.js
+++ b/test/napi/lib/boxed.js
@@ -55,7 +55,7 @@ describe("boxed", function () {
   });
 
   it("should dynamically check borrowing rules", function () {
-    assert.throws(() => new RefPerson("World").fail(), /BorrowMutError/);
+    assert.throws(() => new RefPerson("World").fail(), /already borrowed/);
   });
 
   it("should type check externals", function () {


### PR DESCRIPTION
The error message in Rust changed from `already borrowed: BorrowMutError` to `RefCell already borrowed`.