### PR TITLE
internal(neon): Ensure napi tests exit promptly

### DIFF
--- a/test/napi/package.json
+++ b/test/napi/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "install": "cargo-cp-artifact -nc index.node -- cargo build --message-format=json-render-diagnostics",
     "mocha": "mocha",
-    "test": "mocha --v8-expose-gc --timeout 5000 --recursive lib"
+    "test": "mocha --exit --v8-expose-gc --timeout 5000 --recursive lib"
   },
   "devDependencies": {
     "cargo-cp-artifact": "^0.1.9",


### PR DESCRIPTION
Pass `--exit` to mocha in test/napi to ensure tests exit eagerly after completion.

This probably shaves about 5s off of CI, which isn't that big of a deal, but it was a much more annoying issue in local development.

(Thanks to [this blog post](https://joshtronic.com/2024/01/28/mocha-tests-hang-nodejs/) for discovering this mocha CLI argument.)