### PR TITLE
internal(neon): ensure test workers terminate

### DIFF
--- a/test/napi/lib/workers.js
+++ b/test/napi/lib/workers.js
@@ -210,7 +210,6 @@ describe("Instance-local storage", () => {
     const worker = new Worker(__filename, {
       workerData: "notify_when_startup_complete",
     });
-    after(() => worker.terminate());
 
     worker.once("message", async () => {
       await worker.terminate();


### PR DESCRIPTION
Adds `after(() => worker.terminate())` whenever a unit test creates a worker, to ensure the test harness eagerly terminates. Supersedes #1124.