### PR TITLE
fix(neon): class methods have proper `.name` property

### DIFF
--- a/crates/neon-macros/src/class/mod.rs
+++ b/crates/neon-macros/src/class/mod.rs
@@ -74,7 +74,7 @@ fn generate_method_wrapper(
     let internal_name = &sig.ident;
     let external_name_string = match &meta.name {
         Some(name) => name.value(),
-        None => internal_name.to_string(),
+        None => crate::name::to_camel_case(&internal_name.to_string()),
     };
     let external_name_str = &external_name_string[..];
     let is_mut = is_receiver_mutable(sig);

--- a/test/napi/lib/class.js
+++ b/test/napi/lib/class.js
@@ -56,12 +56,14 @@ describe("classes", function () {
     assert.strictEqual(message.concat.name, "concat");
     assert.strictEqual(buffer.includes.name, "includes");
     assert.strictEqual(buffer.trimStart.name, "trimStart");
+    assert.strictEqual(buffer.trimEnd.name, "trimEnd");
 
     assert.strictEqual(util.inspect(message.read), "[Function: read]");
     assert.strictEqual(util.inspect(message.append), "[Function: append]");
     assert.strictEqual(util.inspect(message.concat), "[Function: concat]");
     assert.strictEqual(util.inspect(buffer.includes), "[Function: includes]");
     assert.strictEqual(util.inspect(buffer.trimStart), "[Function: trimStart]");
+    assert.strictEqual(util.inspect(buffer.trimEnd), "[Function: trimEnd]");
 
     assert.strictEqual(
       message.read.toString(),
@@ -96,6 +98,10 @@ describe("classes", function () {
     assert.strictEqual(
       buffer.trimStart.toString(),
       "function trimStart() { [native code] }"
+    );
+    assert.strictEqual(
+      buffer.trimEnd.toString(),
+      "function trimEnd() { [native code] }"
     );
   });
 


### PR DESCRIPTION
Build class prototype methods with `JsFunction::with_name()` so that they display more idiomatically with JavaScript reflection operations like `.name` and `util.inspect()`.