### PR TITLE
fix(neon): Allow extracting Json<Option<T>> when value is `undefined`

### DIFF
--- a/test/napi/lib/extract.js
+++ b/test/napi/lib/extract.js
@@ -73,6 +73,9 @@ describe("Extractors", () => {
   it("JSON", () => {
     assert.strictEqual(addon.extract_json_sum([1, 2, 3, 4]), 10);
     assert.strictEqual(addon.extract_json_sum([8, 16, 18]), 42);
+    assert.strictEqual(addon.extractJsonOption(42), 42);
+    assert.strictEqual(addon.extractJsonOption(null), null);
+    assert.strictEqual(addon.extractJsonOption(), null);
   });
 
   it("Either", () => {

--- a/test/napi/src/js/extract.rs
+++ b/test/napi/src/js/extract.rs
@@ -138,6 +138,11 @@ pub fn extract_single_add_one(mut cx: FunctionContext) -> JsResult<JsNumber> {
     Ok(cx.number(n + 1.0))
 }
 
+#[neon::export(json)]
+pub fn extract_json_option(maybe_x: Option<f64>) -> Option<f64> {
+    maybe_x
+}
+
 #[neon::export]
 pub fn extract_either(either: Either<String, f64>) -> String {
     match either {


### PR DESCRIPTION
In JavaScript, it's very common to have optional arguments, especially with options object. Consider the following:

```ts
function createClient(opts?: Partial<ClientOptions>);
```

In this case, a user can call `createClient()` without any options or they can call it with any subset of the keys from `ClientOptions`. If we want to model this in Neon, we can use the `Json` extractor.

```rust
#[dervie(Default, Deserialize)]
struct ClientOptions {
    host: Option<String>,
    /* ... */
}

#[neon::export]
fn create_client(Json(opts): Json<ClientOptions>) {}
```

This already works well, except for case where `opts` isn't provided at all. For that, we want to `Option<T>` wrap the options.

```rust
fn create_client(Json(opts): Json<Option<ClientOptions>>) {
    let opts = opts.unwrap_or_default();
}
```

This works if the user explicitly passes `null` for opts (since it is serialized as `"null"`), but fails if it's `undefined` (not passed at all) because of the behavior of `JSON.stringify`. This PR fixes it to match expectations.