### PR TITLE
fix(neon): (soundness) prevent handle leaks from execute_scoped / compute_scoped

### DIFF
--- a/crates/neon/src/context/mod.rs
+++ b/crates/neon/src/context/mod.rs
@@ -204,13 +204,11 @@ use crate::lifecycle::InstanceData;
 /// An execution context of a task completion callback.
 pub type TaskContext<'cx> = Cx<'cx>;
 
-#[doc(hidden)]
 /// An execution context of a scope created by [`Context::execute_scoped()`](Context::execute_scoped).
-pub type ExecuteContext<'cx> = Cx<'cx>;
+pub type ExecuteContext<'outer, 'inner> = ScopedCx<'outer, 'inner>;
 
-#[doc(hidden)]
 /// An execution context of a scope created by [`Context::compute_scoped()`](Context::compute_scoped).
-pub type ComputeContext<'cx> = Cx<'cx>;
+pub type ComputeContext<'outer, 'inner> = ScopedCx<'outer, 'inner>;
 
 #[doc(hidden)]
 /// A view of the JS engine in the context of a finalize method on garbage collection
@@ -283,6 +281,93 @@ impl<'cx> From<ModuleContext<'cx>> for Cx<'cx> {
         cx.cx
     }
 }
+
+/// A temporary execution context created by [`Context::execute_scoped()`] or
+/// [`Context::compute_scoped()`].
+///
+/// `ScopedCx` carries two lifetimes:
+///
+/// * `'outer` &mdash; the lifetime of the surrounding [`Context`] that created the
+///   temporary scope. Handles brought in from the outer scope (e.g. captured by
+///   the closure) carry this lifetime and remain valid for the entire enclosing
+///   computation.
+/// * `'inner` &mdash; the lifetime of this temporary scope. New handles allocated
+///   through this context carry `'inner` and are released as soon as the scope
+///   ends. Because the closure passed to `execute_scoped`/`compute_scoped` is
+///   required to be valid [for every choice][hrtb] of `'inner`, the type system
+///   prevents an inner-scope handle from escaping into outer state through a
+///   captured `&mut`.
+///
+/// The implicit bound `'outer: 'inner` carried by `ScopedCx` allows existing
+/// outer-scope handles to be used freely inside the temporary scope via the
+/// usual covariance of [`Handle`].
+///
+/// [hrtb]: https://doc.rust-lang.org/nomicon/hrtb.html
+pub struct ScopedCx<'outer, 'inner> {
+    cx: Cx<'inner>,
+    // Encodes the implicit bound `'outer: 'inner` without imposing it on the
+    // (universally quantified) HRTB used by the trait methods that introduce
+    // this type.
+    _outer: PhantomData<&'inner &'outer ()>,
+}
+
+impl<'outer, 'inner> ScopedCx<'outer, 'inner> {
+    /// Constructs a `ScopedCx` for an already-open inner handle scope.
+    ///
+    /// # Safety
+    ///
+    /// All of the following must hold when this constructor is called:
+    ///
+    /// * `env` must point to a Node-API environment that is live on the
+    ///   current thread.
+    /// * A Node-API [`HandleScope`] (or [`EscapableHandleScope`]) must be
+    ///   currently open for `env` and must outlive every use of the returned
+    ///   [`ScopedCx`]. In practice this means the constructor must be called
+    ///   immediately after opening such a scope, and the scope must be kept
+    ///   alive across all subsequent uses of the returned value.
+    /// * The caller-chosen lifetime `'inner` must not be longer than the
+    ///   actually-open inner scope; the [`ScopedCx`] (and every [`Handle`]
+    ///   derived from it) must be dropped before the inner scope is closed.
+    /// * The caller-chosen lifetime `'outer` must correspond to an
+    ///   actually-enclosing context's scope, and must satisfy
+    ///   `'outer: 'inner` (this is enforced structurally by the type's
+    ///   phantom data).
+    ///
+    /// Violating any of these invariants permits handles whose backing N-API
+    /// values have been released, which is undefined behavior.
+    unsafe fn new(env: Env) -> Self {
+        Self {
+            cx: Cx::new(env),
+            _outer: PhantomData,
+        }
+    }
+}
+
+impl<'outer, 'inner> Deref for ScopedCx<'outer, 'inner> {
+    type Target = Cx<'inner>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cx
+    }
+}
+
+impl<'outer, 'inner> DerefMut for ScopedCx<'outer, 'inner> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cx
+    }
+}
+
+impl<'outer, 'inner> ContextInternal<'inner> for ScopedCx<'outer, 'inner> {
+    fn cx(&self) -> &Cx<'inner> {
+        &self.cx
+    }
+
+    fn cx_mut(&mut self) -> &mut Cx<'inner> {
+        &mut self.cx
+    }
+}
+
+impl<'outer, 'inner> Context<'inner> for ScopedCx<'outer, 'inner> {}
 
 #[repr(C)]
 pub(crate) struct CallbackInfo<'cx> {
@@ -380,14 +465,24 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// Handles created in the new scope are kept alive only for the duration of the computation and cannot escape.
     ///
     /// This method can be useful for limiting the life of temporary values created during long-running computations, to prevent leaks.
-    fn execute_scoped<'b, T, F>(&mut self, f: F) -> T
+    ///
+    /// The closure receives a [`ScopedCx`] whose inner lifetime `'b` is bound
+    /// by a higher-ranked trait bound. This ensures that any handle allocated
+    /// inside the scope is tied to the temporary [`HandleScope`] and cannot
+    /// escape into the surrounding context.
+    fn execute_scoped<T, F>(&mut self, f: F) -> T
     where
-        'a: 'b,
-        F: FnOnce(Cx<'b>) -> T,
+        F: for<'b> FnOnce(ScopedCx<'a, 'b>) -> T,
     {
         let env = self.env();
         let scope = unsafe { HandleScope::new(env.to_raw()) };
-        let result = f(Cx::new(env));
+        // SAFETY: `scope` is an `HandleScope` we just opened for `env` and
+        // hold (via the `drop(scope)` below) across the call to `f`. The
+        // inferred `'b` is bounded by the borrow of `scope` that the
+        // closure transitively performs through the `ScopedCx`, so it
+        // cannot outlive the open scope. `'a` is the enclosing context's
+        // lifetime, which (by `Context<'a>`) outlives `'b`.
+        let result = f(unsafe { ScopedCx::new(env) });
 
         drop(scope);
 
@@ -399,15 +494,27 @@ pub trait Context<'a>: ContextInternal<'a> {
     /// Handles created in the new scope are kept alive only for the duration of the computation and cannot escape, with the exception of the result value, which is rooted in the outer context.
     ///
     /// This method can be useful for limiting the life of temporary values created during long-running computations, to prevent leaks.
-    fn compute_scoped<'b, V, F>(&mut self, f: F) -> JsResult<'a, V>
+    ///
+    /// The closure receives a [`ScopedCx`] whose inner lifetime `'b` is bound
+    /// by a higher-ranked trait bound. Only the returned [`Handle`] escapes
+    /// the temporary scope; it is rooted in the outer context via the
+    /// underlying [`EscapableHandleScope`]. Any other inner-scope handle is
+    /// prevented from leaking into the surrounding context by the type system.
+    fn compute_scoped<V, F>(&mut self, f: F) -> JsResult<'a, V>
     where
-        'a: 'b,
         V: Value,
-        F: FnOnce(Cx<'b>) -> JsResult<'b, V>,
+        F: for<'b> FnOnce(ScopedCx<'a, 'b>) -> JsResult<'b, V>,
     {
         let env = self.env();
         let scope = unsafe { EscapableHandleScope::new(env.to_raw()) };
-        let cx = Cx::new(env);
+        // SAFETY: `scope` is an `EscapableHandleScope` we just opened for
+        // `env` and hold across the call to `f` and the subsequent
+        // `scope.escape(...)`. The inferred `'b` is bounded by the borrow
+        // of `scope` that the closure transitively performs through the
+        // `ScopedCx`, so it cannot outlive the open scope. `'a` is the
+        // enclosing context's lifetime, which (by `Context<'a>`) outlives
+        // `'b`.
+        let cx = unsafe { ScopedCx::new(env) };
 
         let escapee = unsafe { scope.escape(f(cx)?.to_local()) };
 

--- a/test/ui/tests/fail/class-async-context-ref.stderr
+++ b/test/ui/tests/fail/class-async-context-ref.stderr
@@ -27,11 +27,3 @@ note: required by a bound in `neon::macro_internal::spawn`
    |     F: Future + Send + 'static,
    |        ^^^^^^ required by this bound in `spawn`
    = note: this error originates in the attribute macro `neon::class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0282]: type annotations needed
- --> tests/fail/class-async-context-ref.rs:5:1
-  |
-5 | #[neon::class]
-  | ^^^^^^^^^^^^^^ cannot infer type
-  |
-  = note: this error originates in the attribute macro `neon::class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test/ui/tests/fail/compute-scoped-leak.rs
+++ b/test/ui/tests/fail/compute-scoped-leak.rs
@@ -1,0 +1,26 @@
+//! Soundness regression test: `Context::compute_scoped` must not allow
+//! handles created in the inner scope to escape into the outer scope
+//! through closure-captured state. The only sanctioned escape route is
+//! the return value, which is rooted in the parent scope via
+//! `EscapableHandleScope::escape`.
+
+use neon::{
+    context::{Context, FunctionContext},
+    handle::Handle,
+    result::JsResult,
+    types::{JsNumber, JsUndefined},
+};
+
+fn leak(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mut leaked: Option<Handle<JsNumber>> = None;
+
+    let _: Handle<JsNumber> = cx.compute_scoped(|mut inner_cx| {
+        let v = inner_cx.number(42);
+        leaked = Some(v);
+        Ok(inner_cx.number(0))
+    })?;
+
+    Ok(cx.undefined())
+}
+
+fn main() {}

--- a/test/ui/tests/fail/compute-scoped-leak.stderr
+++ b/test/ui/tests/fail/compute-scoped-leak.stderr
@@ -1,0 +1,11 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/fail/compute-scoped-leak.rs:19:9
+   |
+15 |     let mut leaked: Option<Handle<JsNumber>> = None;
+   |         ---------- `leaked` declared here, outside of the closure body
+16 |
+17 |     let _: Handle<JsNumber> = cx.compute_scoped(|mut inner_cx| {
+   |                                                  ------------ `inner_cx` is a reference that is only valid in the closure body
+18 |         let v = inner_cx.number(42);
+19 |         leaked = Some(v);
+   |         ^^^^^^^^^^^^^^^^ `inner_cx` escapes the closure body here

--- a/test/ui/tests/fail/execute-scoped-leak.rs
+++ b/test/ui/tests/fail/execute-scoped-leak.rs
@@ -1,0 +1,26 @@
+//! Soundness regression test: `Context::execute_scoped` must not allow
+//! handles created in the inner scope to escape into the outer scope.
+//!
+//! Before the HRTB fix, the caller could pick `'b = 'a`, allowing the
+//! closure to leak a `Handle<'a, _>` allocated inside the temporary
+//! `HandleScope` into the outer context via a captured `&mut`, producing
+//! a use-after-free once the inner scope was dropped.
+
+use neon::{
+    context::{Context, FunctionContext},
+    handle::Handle,
+    result::JsResult,
+    types::{JsNumber, JsUndefined},
+};
+
+fn leak(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mut leaked: Option<Handle<JsNumber>> = None;
+
+    cx.execute_scoped(|mut inner_cx| {
+        leaked = Some(inner_cx.number(42));
+    });
+
+    Ok(cx.undefined())
+}
+
+fn main() {}

--- a/test/ui/tests/fail/execute-scoped-leak.stderr
+++ b/test/ui/tests/fail/execute-scoped-leak.stderr
@@ -1,0 +1,10 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/fail/execute-scoped-leak.rs:20:9
+   |
+17 |     let mut leaked: Option<Handle<JsNumber>> = None;
+   |         ---------- `leaked` declared here, outside of the closure body
+18 |
+19 |     cx.execute_scoped(|mut inner_cx| {
+   |                        ------------ `inner_cx` is a reference that is only valid in the closure body
+20 |         leaked = Some(inner_cx.number(42));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `inner_cx` escapes the closure body here

--- a/test/ui/tests/fail/scoped-cx-escape.rs
+++ b/test/ui/tests/fail/scoped-cx-escape.rs
@@ -1,0 +1,20 @@
+//! Soundness regression test: a `ScopedCx<'a, 'b>` must not itself be
+//! returnable from the closure passed to `Context::execute_scoped` /
+//! `Context::compute_scoped`. Because the closure's return type is fixed
+//! outside the HRTB binder on `'b`, there is no way to coerce
+//! `ScopedCx<'a, 'b>` (which is parameterized by `'b`) into a `'b`-free
+//! return type.
+
+use neon::{
+    context::{Context, FunctionContext, ScopedCx},
+    result::JsResult,
+    types::JsUndefined,
+};
+
+fn return_scoped_cx(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let _escaped: ScopedCx<'_, '_> = cx.execute_scoped(|inner| inner);
+
+    Ok(cx.undefined())
+}
+
+fn main() {}

--- a/test/ui/tests/fail/scoped-cx-escape.stderr
+++ b/test/ui/tests/fail/scoped-cx-escape.stderr
@@ -1,0 +1,8 @@
+error: lifetime may not live long enough
+  --> tests/fail/scoped-cx-escape.rs:15:64
+   |
+15 |     let _escaped: ScopedCx<'_, '_> = cx.execute_scoped(|inner| inner);
+   |                                                         ------ ^^^^^ returning this value requires that `'1` must outlive `'2`
+   |                                                         |    |
+   |                                                         |    return type of closure is ScopedCx<'_, '2>
+   |                                                         has type `ScopedCx<'_, '1>`

--- a/test/ui/tests/pass/scoped-cx.rs
+++ b/test/ui/tests/pass/scoped-cx.rs
@@ -1,0 +1,47 @@
+//! Pass test for `Context::execute_scoped` and `Context::compute_scoped`:
+//! the legitimate patterns (using outer-scope handles inside the closure,
+//! and re-escaping an outer-scope handle from `compute_scoped`) must still
+//! compile under the higher-ranked `ScopedCx<'a, 'b>` signatures.
+
+use neon::{
+    context::{Context, FunctionContext},
+    handle::Handle,
+    object::Object,
+    result::JsResult,
+    types::{JsNumber, JsObject, JsValue},
+};
+
+/// `execute_scoped` closure may freely use captured outer-scope handles
+/// alongside inner-scope handles, as long as nothing inner-scope escapes.
+fn use_outer_in_execute_scoped(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let outer: Handle<JsObject> = cx.argument(0)?;
+
+    for i in 0..3u32 {
+        cx.execute_scoped(|mut inner_cx| -> Result<(), neon::result::Throw> {
+            let n = inner_cx.number(i);
+            outer.set(&mut inner_cx, i, n)?;
+            Ok(())
+        })?;
+    }
+
+    Ok(outer.upcast())
+}
+
+/// `compute_scoped` can pass an outer-scope handle through unchanged: the
+/// implicit `'a: 'b` bound carried by `ScopedCx<'a, 'b>` lets `Handle<'a, V>`
+/// be coerced to `Handle<'b, V>`, and the escape mechanism then re-roots it
+/// in the parent scope.
+fn pass_through_compute_scoped(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let value: Handle<JsValue> = cx.argument(0)?;
+
+    cx.compute_scoped(move |_| Ok(value))
+}
+
+/// `compute_scoped` can also allocate a fresh handle inside the scope and
+/// return it; the value is escaped via `EscapableHandleScope` into the
+/// parent scope.
+fn allocate_in_compute_scoped(mut cx: FunctionContext) -> JsResult<JsNumber> {
+    cx.compute_scoped(|mut inner_cx| Ok(inner_cx.number(42)))
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary

`execute_scoped` / `compute_scoped` let the caller pick the inner lifetime
`'b`, including `'b = 'a`, so a closure could `leaked = Some(inner.number(42))`
into outer state and dereference it after the scope dropped. UB.

Fix: HRTB on the closure plus a new `ScopedCx<'outer, 'inner>` whose
`PhantomData<&'inner &'outer ()>` carries the implied `'outer: 'inner`
bound. HRTB universalizes `'b` so nothing parameterized by it escapes;
the phantom bound keeps `recompute_scoped`-style pass-through compiling
via `Handle` covariance.

`ScopedCx::new` is `unsafe fn` with a documented contract — `Cx::new` is
deliberately untouched.

## Breaking

Closure parameter is now `ScopedCx<'a, 'b>`, not `Cx<'b>`. `ExecuteContext`
/ `ComputeContext` aliases gain a second lifetime. Most callers compile
unchanged via `Deref<Target = Cx<'inner>>`.

## Tests

- `fail/execute-scoped-leak.rs`, `fail/compute-scoped-leak.rs` — leaks via
  captured `&mut` no longer compile (E0521).
- `fail/scoped-cx-escape.rs` — `ScopedCx` itself can't be returned.
- `pass/scoped-cx.rs` — outer-handle pass-through, fresh-handle escape,
  and using outer handles inside the scope all still compile.
- `napi-tests` builds, exercising `recompute_scoped` at runtime.